### PR TITLE
chore(release): prepare v3.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,8 @@ jobs:
             ${{ runner.temp }}/Sky-Auto-Player-v${{ steps.stage.outputs.version }}.zip
             ${{ runner.temp }}/Sky-Auto-Player-v${{ steps.stage.outputs.version }}.zip.sha256
             ${{ runner.temp }}/MANIFEST.json
-          generate_release_notes: true
+          body_path: docs/releases/v${{ steps.stage.outputs.version }}-release-notes.md
+          generate_release_notes: false
           draft: false
           prerelease: ${{ steps.verlock.outputs.is_prerelease == 'true' }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Sky Auto Player are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-08-08
+
+### Added
+
+- Frame-based note-hold controls for clearer FPS-aware playback tuning.
+
+### Changed
+
+- Improved latency calibration and consistent use of calibrated timing margins across playback flows.
+- Improved native scheduling for chords and timestamp-aligned input transitions.
+- Reduced real-time dispatch overhead for steadier playback, especially during longer sessions.
+
+### Fixed
+
+- Hardened focus handling, input-state recovery, and cleanup around interrupted or failed input delivery.
+- Improved playback HUD consistency and calibration guidance.
+
 ## [3.0.0] - 2026-08-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sends standard keystrokes through the public Windows `SendInput` API — the sam
 keyboard macro uses — and never reads game memory, injects code, hooks the process, attaches a
 debugger, or touches game files.
 
-**Current source release:** `v3.0.0`.
+**Current source release:** `v3.1.0`.
 
 ## Why it sounds right
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -20,7 +20,7 @@ These files represent the current system state and contracts:
 * [architecture.md](architecture.md) — Explains the 4-layer DDD codebase and the Python application / Rust native dispatch boundary.
 * [hold-frame-model.md](hold-frame-model.md) — Explicit hold-frame choices, FPS selection, and materialization formulas.
 * [perf-baselines/2026-06-baseline.md](perf-baselines/2026-06-baseline.md) — Pipeline CPU baselines and post-optimization gate numbers.
-* [distribution-and-update.md](distribution-and-update.md) — Distribution model, update architecture, and release contracts for Sky Auto Player (tracks the `pyproject.toml` `[project].version`, currently 3.0.0).
+* [distribution-and-update.md](distribution-and-update.md) — Distribution model, update architecture, and release contracts for Sky Auto Player (tracks the `pyproject.toml` `[project].version`, currently 3.1.0).
 * [releases/v3.0.0-acceptance.md](releases/v3.0.0-acceptance.md) — Exact-SHA acceptance evidence for the v3.0.0 release candidate.
 
 ---

--- a/docs/distribution-and-update.md
+++ b/docs/distribution-and-update.md
@@ -1,8 +1,8 @@
 # Distribution and Update Model
 
-This document explains the distribution model, update architecture, and lifecycle rules for Sky Auto Player. It tracks the `pyproject.toml` `[project].version` (currently 3.0.0) and is the reference for contributors handling packaging or update logic. Update this header whenever the release version bumps — the rules below apply to every shipped release, not a specific point release.
+This document explains the distribution model, update architecture, and lifecycle rules for Sky Auto Player. It tracks the `pyproject.toml` `[project].version` (currently 3.1.0) and is the reference for contributors handling packaging or update logic. Update this header whenever the release version bumps — the rules below apply to every shipped release, not a specific point release.
 
-For the v3.0.0 release candidate, native sender-side acceptance runs before frozen packaging. The release evidence boundary remains sender completion; the updater and release artifact contract are unchanged.
+For the v3.1.0 release candidate, native correctness and no-allocation tests run before frozen packaging. The release evidence boundary remains sender completion; the updater and release artifact contract are unchanged.
 
 ## 1. Model Overview
 

--- a/docs/releases/v3.1.0-acceptance.md
+++ b/docs/releases/v3.1.0-acceptance.md
@@ -1,0 +1,31 @@
+# Sky Auto Player v3.1.0 Acceptance
+
+Release: v3.1.0  
+Candidate SHA: pending release-preparation commit  
+Release date: 2026-08-08  
+Windows runner/runtime: pending final runner evidence  
+Python version: pending final runner evidence  
+Rust version: pending final runner evidence  
+Native wheel status: PENDING  
+Application build status: PENDING  
+Release asset verification: PENDING
+
+| Gate | Status |
+|---|---|
+| ruff | PENDING |
+| pyright | PENDING |
+| security audit | PENDING |
+| cargo fmt | PENDING |
+| cargo check | PENDING |
+| cargo clippy -D warnings | PENDING |
+| cargo test | PENDING |
+| rt_dispatch_no_alloc | PENDING |
+| native wheel build | PENDING |
+| Python tests | PENDING |
+| updater PS5.1 gate | PENDING |
+| Pester | PENDING |
+| frozen application build | PENDING |
+| packaged self-tests | PENDING |
+
+Native A/B: not a release gate  
+Real SendInput CI matrix: not a release gate

--- a/docs/releases/v3.1.0-acceptance.md
+++ b/docs/releases/v3.1.0-acceptance.md
@@ -1,31 +1,33 @@
 # Sky Auto Player v3.1.0 Acceptance
 
-Release: v3.1.0  
-Candidate SHA: pending release-preparation commit  
-Release date: 2026-08-08  
-Windows runner/runtime: pending final runner evidence  
-Python version: pending final runner evidence  
-Rust version: pending final runner evidence  
-Native wheel status: PENDING  
-Application build status: PENDING  
-Release asset verification: PENDING
+Release: v3.1.0
+Candidate SHA: 24a3c52ae8c9c2cdd39e8fef47422b95f79fdb14
+Release date: 2026-08-08
+Windows runner/runtime: Windows 11 10.0.26200 (SP0)
+Python version: CPython 3.14.3 free-threaded (GIL disabled)
+Rust version: rustc 1.97.1 (8bab26f4f 2026-07-14)
+Native wheel status: PASS — cp314t-win_amd64; native build commit matches candidate
+Application build status: PASS — frozen v3.1.0 build with manifest and smoke tests
+Release asset verification: PENDING — performed after tag publication
+
+Known playback-correctness blocker: CLOSED — post-send clock-failure uncertainty is preserved for cleanup; the dedicated regression test passed.
 
 | Gate | Status |
 |---|---|
-| ruff | PENDING |
-| pyright | PENDING |
-| security audit | PENDING |
-| cargo fmt | PENDING |
-| cargo check | PENDING |
-| cargo clippy -D warnings | PENDING |
-| cargo test | PENDING |
-| rt_dispatch_no_alloc | PENDING |
-| native wheel build | PENDING |
-| Python tests | PENDING |
-| updater PS5.1 gate | PENDING |
-| Pester | PENDING |
-| frozen application build | PENDING |
-| packaged self-tests | PENDING |
+| ruff | PASS |
+| pyright | PASS |
+| security audit | PASS |
+| cargo fmt | PASS |
+| cargo check | PASS |
+| cargo clippy -D warnings | PASS |
+| cargo test | PASS |
+| rt_dispatch_no_alloc | PASS |
+| native wheel build | PASS |
+| Python tests | PASS — 724 passed, 7 skipped, 1 xpassed |
+| updater PS5.1 gate | PASS |
+| Pester | PASS — 61/61 |
+| frozen application build | PASS |
+| packaged self-tests | PASS |
 
 Native A/B: not a release gate  
 Real SendInput CI matrix: not a release gate

--- a/docs/releases/v3.1.0-release-notes.md
+++ b/docs/releases/v3.1.0-release-notes.md
@@ -1,0 +1,12 @@
+# Sky Auto Player v3.1.0
+
+A focused update for smoother, more reliable playback and clearer timing controls.
+
+## Highlights
+
+* Added frame-based note-hold controls for FPS-aware playback tuning.
+* Improved latency calibration and consistent calibrated timing across playback modes.
+* Improved native scheduling for chords and timestamp-aligned input transitions.
+* Reduced real-time dispatch overhead for steadier long-session playback.
+* Hardened focus handling, key-state recovery, and cleanup after interrupted or failed input delivery.
+* Improved playback HUD consistency and calibration guidance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sky-auto-player"
-version = "3.0.0"
+version = "3.1.0"
 description = "Sky Auto Player - Auto Music Sheet Player"
 readme = "README.md"
 # The dispatch loop tight-spins on `time.perf_counter_ns` for up to ~800 us per action, and a

--- a/site/src/content/guides/en/en-how-it-works.md
+++ b/site/src/content/guides/en/en-how-it-works.md
@@ -14,7 +14,7 @@ category: getting-started
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 showDiagram: true
 related:

--- a/site/src/content/guides/en/en-security-boundaries.md
+++ b/site/src/content/guides/en/en-security-boundaries.md
@@ -14,7 +14,7 @@ category: technical-safety
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - how-it-works
@@ -98,7 +98,7 @@ Every release produces three files:
 Verify the archive before extracting:
 
 ```powershell
-(Get-FileHash "Sky-Auto-Player-v3.0.0.zip" -Algorithm SHA256).Hash
+(Get-FileHash "Sky-Auto-Player-v3.1.0.zip" -Algorithm SHA256).Hash
 # Compare with the content of the .sha256 file
 ```
 

--- a/site/src/content/guides/en/en-sheet-formats.md
+++ b/site/src/content/guides/en/en-sheet-formats.md
@@ -13,7 +13,7 @@ category: getting-started
 order: 2
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - windows-setup

--- a/site/src/content/guides/en/en-timing-engine.md
+++ b/site/src/content/guides/en/en-timing-engine.md
@@ -15,7 +15,7 @@ category: playback-timing
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - how-it-works

--- a/site/src/content/guides/en/en-troubleshooting.md
+++ b/site/src/content/guides/en/en-troubleshooting.md
@@ -14,7 +14,7 @@ category: support
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - windows-setup

--- a/site/src/content/guides/en/en-windows-setup.md
+++ b/site/src/content/guides/en/en-windows-setup.md
@@ -13,7 +13,7 @@ category: getting-started
 order: 3
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - sheet-formats
@@ -44,7 +44,7 @@ evidence:
 
    ```powershell
    # In PowerShell, in the folder where you downloaded the zip:
-   (Get-FileHash "Sky-Auto-Player-v3.0.0.zip" -Algorithm SHA256).Hash
+   (Get-FileHash "Sky-Auto-Player-v3.1.0.zip" -Algorithm SHA256).Hash
    # Compare the output with the contents of the .sha256 file
    ```
 

--- a/site/src/content/guides/vi/vi-how-it-works.md
+++ b/site/src/content/guides/vi/vi-how-it-works.md
@@ -14,7 +14,7 @@ category: getting-started
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 showDiagram: true
 related:

--- a/site/src/content/guides/vi/vi-security-boundaries.md
+++ b/site/src/content/guides/vi/vi-security-boundaries.md
@@ -14,7 +14,7 @@ category: technical-safety
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - how-it-works
@@ -97,7 +97,7 @@ Mỗi bản phát hành tạo ra ba file:
 Xác minh archive trước khi giải nén:
 
 ```powershell
-(Get-FileHash "Sky-Auto-Player-v3.0.0.zip" -Algorithm SHA256).Hash
+(Get-FileHash "Sky-Auto-Player-v3.1.0.zip" -Algorithm SHA256).Hash
 # So sánh với nội dung file .sha256
 ```
 

--- a/site/src/content/guides/vi/vi-sheet-formats.md
+++ b/site/src/content/guides/vi/vi-sheet-formats.md
@@ -13,7 +13,7 @@ category: getting-started
 order: 2
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - windows-setup

--- a/site/src/content/guides/vi/vi-timing-engine.md
+++ b/site/src/content/guides/vi/vi-timing-engine.md
@@ -14,7 +14,7 @@ category: playback-timing
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - how-it-works

--- a/site/src/content/guides/vi/vi-troubleshooting.md
+++ b/site/src/content/guides/vi/vi-troubleshooting.md
@@ -13,7 +13,7 @@ category: support
 order: 1
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - windows-setup

--- a/site/src/content/guides/vi/vi-windows-setup.md
+++ b/site/src/content/guides/vi/vi-windows-setup.md
@@ -13,7 +13,7 @@ category: getting-started
 order: 3
 published: '2026-08-08'
 updated: '2026-08-08'
-lastReviewedVersion: '3.0.0'
+lastReviewedVersion: '3.1.0'
 draft: false
 related:
   - sheet-formats
@@ -43,7 +43,7 @@ evidence:
 
    ```powershell
    # Trong PowerShell, ở thư mục chứa file zip:
-   (Get-FileHash "Sky-Auto-Player-v3.0.0.zip" -Algorithm SHA256).Hash
+   (Get-FileHash "Sky-Auto-Player-v3.1.0.zip" -Algorithm SHA256).Hash
    # So sánh kết quả với nội dung file .sha256
    ```
 

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "sky-auto-player"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary

- Prepare Sky Auto Player v3.1.0 with the curated changelog and release notes.
- Synchronize live version metadata and `uv.lock` to 3.1.0.
- Make the tag release body deterministic via the curated notes file.
- Record acceptance evidence for the native correctness, installer, Python, and frozen-build gates.

## Release policy

- Native A/B benchmarking is not a release gate.
- The real SendInput CI qualification matrix is not a release gate.
- The post-send clock-failure cleanup uncertainty fix is covered by a dedicated Rust regression test.

## Validation

- Ruff, Pyright, security audit: PASS
- Cargo fmt, check, clippy -D warnings, workspace tests: PASS
- `rt_dispatch_no_alloc`: PASS
- Native free-threaded wheel build and verification: PASS
- Python tests: 724 passed, 7 skipped, 1 xpassed
- Updater PowerShell 5.1 gate: PASS
- Pester: 61/61 passed
- Frozen v3.1.0 build, manifest, and packaged self-tests: PASS