### PR TITLE
fix(dispatch): close target-attribution acceptance blocker

### DIFF
--- a/.config/rust_architecture_allowlist.json
+++ b/.config/rust_architecture_allowlist.json
@@ -1,7 +1,5 @@
 {
   "entries": [
-    {"path":"rust/crates/sky_dispatch_core/src/coordinator.rs","rule":"regular_module_lines","reason":"pre-existing coordinator consolidation; split by invariant owner in Phase 6","expires_phase":"Phase 6"},
-    {"path":"rust/crates/sky_dispatch_core/src/estimator.rs","rule":"regular_module_lines","reason":"pre-existing estimator implementation; split only with timing proof in Phase 6","expires_phase":"Phase 6"},
     {"path":"rust/crates/sky_dispatch_win32/src/calibration.rs","rule":"regular_module_lines","reason":"pre-existing calibration tool outside dispatch hot path","expires_phase":"Phase 12"},
     {"path":"rust/crates/sky_dispatch_win32/src/input.rs","rule":"facade_lines","reason":"isolate raw sender and transactions in Phase 7","expires_phase":"Phase 7"},
     {"path":"rust/crates/sky_dispatch_win32/src/wait.rs","rule":"facade_lines","reason":"isolate wait responsibilities in Phase 7","expires_phase":"Phase 7"},

--- a/docs/rt-dispatch-architecture.md
+++ b/docs/rt-dispatch-architecture.md
@@ -125,9 +125,9 @@ zero. It has no trace, hash maps, generation ledger, estimator internals, or
 build provenance. Latency degradation is reported as an input-path health
 signal; the typed snapshot separates `sendinput_path_degraded`,
 `core_post_send_degraded`, `observer_degraded`, and `wait_path_degraded`.
-`input_path_degraded` is the OR of SendInput and core post-send health only;
-observer slowdown is an independent domain. SendInput warning thresholds use a
-fixed sender-side floor plus a fixed margin; core post-send, observer, and wait
+`input_path_degraded` is the OR of SendInput, core post-send, and wait-path
+health; observer slowdown is an independent domain. SendInput warning
+thresholds use the fixed sender-side floor; core post-send, observer, and wait
 thresholds remain independent. Each path also publishes its degraded-sample
 count and active threshold. UI text must not infer an OS hook, Filter Keys, or
 game-side cause from any of these sender-side signals.
@@ -137,7 +137,7 @@ dispatch; the rolling health windows retain only that boolean classification,
 not raw durations. SendInput, post-send occupancy, and scheduler wake latency
 have independent fixed-capacity hysteresis windows. The adaptive dispatch-cost
 estimator is separate from health: it records clean sender completion cost in
-fixed path/polyphony buckets and never drives the health budget. A single spike
+fixed path/event-count buckets and never drives the health budget. A single spike
 therefore cannot latch degradation for a session, and a later threshold change
 cannot reclassify history. Backend rejection, partial packets, clock failures,
 and uncertain key state remain immediate session-latched correctness failures.
@@ -164,8 +164,8 @@ The native lifecycle/status domain is separate from UI presentation status:
 is accepted before live-status validation; Python then joins once, materializes
 `session_report`, parses telemetry and estimator state, and only then surfaces a
 terminal error. Normal completion never invokes panic cleanup.
-`input_path_degraded` remains the aggregate of SendInput and core post-send
-health; observer and wait-path degradation remain separate signals.
+`input_path_degraded` remains the aggregate of SendInput, core post-send, and
+wait-path health; observer degradation remains a separate signal.
 
 ## Invariants
 

--- a/docs/timing-principles.md
+++ b/docs/timing-principles.md
@@ -136,7 +136,7 @@ and release-recovery changes still invalidate it. The planner does not mutate
 the coordinator, sample QPC itself, allocate, or format strings on success.
 Pending releases use a bounded cohort fixed point: the Up lead is selected from the releases that
 share the next effective deadline, rather than from all currently pending keys. The resulting
-deadline/lead/polyphony plan is reused for waiting and popping. The native accuracy-first path
+deadline/lead/event-count-cohort plan is reused for waiting and popping. The native accuracy-first path
 also requires `chord_stagger_us == 0`; staggered chords remain an explicit Python diagnostic path.
 A future physical anchor is created before the worker loop; the first authored action is gated at
 `startup_anchor + scheduled_us - lead_us`, including the negative offset for a note at `t=0`.
@@ -148,9 +148,13 @@ The worker records a separate Up completion residual only from clean, non-deferr
 release cohorts.
 Normal estimator operation uses the clamped rolling p95; native strict timing
 uses the clamped rolling maximum so an observed upper-tail sample remains
-visible. Sparse buckets fall back to their path's lower-cardinality evidence and
-then the path prior; there is no cross-path contamination. Repeated positive
-residual at the lead cap is a controlled timing error rather than an unreported
+visible. Sparse buckets fall back to the nearest seeded lower-cardinality bucket,
+then the nearest seeded higher-cardinality bucket, then zero; there is no
+cross-path contamination or path prior. The separate lead-saturation diagnostic
+arrays use exact event-count indices 1..14 and an explicit `15_plus` bucket at
+index 15; this diagnostic compression does not change the estimator's exact
+1..30 event-count buckets. Repeated positive residual at the lead cap is a
+controlled timing error rather than an unreported
 tail.
 For release observations, `lead_up_saturated` records the lead applied by the physical plan;
 `saturated_positive` is derived separately from the effective SendInput completion error, not

--- a/rust/crates/sky_player_rs/src/engine/telemetry/metrics.rs
+++ b/rust/crates/sky_player_rs/src/engine/telemetry/metrics.rs
@@ -61,6 +61,8 @@ pub struct WorkerMetricsLocal {
     pub keys_inserted_before_failure: u64,
     pub keys_rolled_back: u64,
     pub rollback_residue_keys: u64,
+    /// Saturation diagnostics indexed by physical event count. Index 0 is
+    /// unused; index 15 is the explicit `15_plus` overflow bucket.
     pub lead_saturation_count_down: [u64; 16],
     pub lead_saturation_count_up: [u64; 16],
     pub positive_residual_at_cap: u64,

--- a/rust/crates/sky_player_rs/src/engine/test_support/dispatch_harness.rs
+++ b/rust/crates/sky_player_rs/src/engine/test_support/dispatch_harness.rs
@@ -682,14 +682,7 @@ impl ProductionDispatchTestHarness {
             plan,
             effective_now_ticks,
             now_ticks,
-            plan.deadline_ticks.map(|deadline| {
-                self.resources
-                    .playback
-                    .epoch
-                    .checked_add_duration(DurationTicks::from_raw(deadline.as_u64()))
-                    .expect("physical target QPC")
-                    .min(now_ticks)
-            }),
+            self.resources.playback.epoch,
             false,
             &self.config,
             &mut self.resources,
@@ -755,7 +748,9 @@ impl ProductionDispatchTestHarness {
             effective_now_ticks: self.effective_now_ticks,
             now_ticks,
             physical_target_qpc: plan
-                .deadline_ticks
+                .authored
+                .as_ref()
+                .map(|authored| authored.deadline_ticks)
                 .map(|deadline| {
                     self.resources
                         .playback

--- a/rust/crates/sky_player_rs/src/engine/worker/dispatch/timing.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/dispatch/timing.rs
@@ -26,13 +26,16 @@ use sky_dispatch_win32::input::{PacketRetryReason, PhysicalPacket, SendTransacti
 /// Snapshot of the next authored packet's dispatch path and lead.
 ///
 /// Built once per worker loop epoch and reused for both
-/// `prepare_next_due_authored` and `next_deadline_ticks`.
+/// `prepare_next_due_authored` and wait-boundary planning.  The deadline is
+/// the physical target for this authored work; `NextDispatchPlan::deadline_ticks`
+/// may be earlier when a pending release is also present.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct AuthoredDispatchPlan {
     pub(crate) path: DispatchPath,
     pub(crate) lead_us: u64,
     pub(crate) lead_ticks: DurationTicks,
     pub(crate) lead_saturated: bool,
+    pub(crate) deadline_ticks: TimelineTicks,
 }
 
 /// Resolve the path-aware lead for one authored packet without reading QPC.

--- a/rust/crates/sky_player_rs/src/engine/worker/dispatch_loop.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/dispatch_loop.rs
@@ -16,14 +16,30 @@ use std::any::Any;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU64, Ordering};
 
-fn planned_target_qpc(
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PhysicalWork {
+    Pending,
+    Authored,
+}
+
+fn physical_target_qpc_for_work(
     plan: &super::planning::NextDispatchPlan,
     epoch: sky_dispatch_win32::clock::QpcTicks,
+    now: sky_dispatch_win32::clock::QpcTicks,
+    work: PhysicalWork,
 ) -> Result<Option<sky_dispatch_win32::clock::QpcTicks>, String> {
-    plan.deadline_ticks
+    let deadline = match work {
+        PhysicalWork::Pending => plan.pending.as_ref().map(|pending| pending.deadline_ticks),
+        PhysicalWork::Authored => plan
+            .authored
+            .as_ref()
+            .map(|authored| authored.deadline_ticks),
+    };
+    deadline
         .map(|deadline| {
             epoch
                 .checked_add_duration(DurationTicks::from_raw(deadline.as_u64()))
+                .map(|target| target.min(now))
                 .map_err(|error| format!("physical target arithmetic failure: {error}"))
         })
         .transpose()
@@ -37,7 +53,7 @@ pub(crate) fn dispatch_due_from_plan(
     plan: &super::planning::NextDispatchPlan,
     effective_now_ticks: TimelineTicks,
     now_ticks: sky_dispatch_win32::clock::QpcTicks,
-    physical_target_qpc: Option<sky_dispatch_win32::clock::QpcTicks>,
+    epoch_qpc: sky_dispatch_win32::clock::QpcTicks,
     focus_loss_fault: bool,
     config: &super::WorkerConfig,
     resources: &mut super::WorkerResources,
@@ -82,11 +98,16 @@ pub(crate) fn dispatch_due_from_plan(
         None => SmallVec::new(),
     };
     if !due_pending.is_empty() {
-        let Some(physical_target_qpc) = physical_target_qpc else {
-            return super::DispatchStep::Terminate(
-                "pending dispatch has no physical target boundary".to_string(),
-            );
-        };
+        let physical_target_qpc =
+            match physical_target_qpc_for_work(plan, epoch_qpc, now_ticks, PhysicalWork::Pending) {
+                Ok(Some(target)) => target,
+                Ok(None) => {
+                    return super::DispatchStep::Terminate(
+                        "pending dispatch has no physical target boundary".to_string(),
+                    );
+                }
+                Err(error) => return super::DispatchStep::Terminate(error),
+            };
         let Some(frozen_budget) = plan.pending_budget.as_ref() else {
             return super::DispatchStep::Terminate(
                 "pending dispatch plan has no health budget".to_string(),
@@ -133,11 +154,16 @@ pub(crate) fn dispatch_due_from_plan(
             "authored dispatch plan has no health budget".to_string(),
         );
     }
-    let Some(physical_target_qpc) = physical_target_qpc else {
-        return super::DispatchStep::Terminate(
-            "authored dispatch has no physical target boundary".to_string(),
-        );
-    };
+    let physical_target_qpc =
+        match physical_target_qpc_for_work(plan, epoch_qpc, now_ticks, PhysicalWork::Authored) {
+            Ok(Some(target)) => target,
+            Ok(None) => {
+                return super::DispatchStep::Terminate(
+                    "authored dispatch has no physical target boundary".to_string(),
+                );
+            }
+            Err(error) => return super::DispatchStep::Terminate(error),
+        };
 
     super::dispatch_authored_packet(
         super::AuthoredPacketContext {
@@ -750,20 +776,11 @@ pub(super) fn dispatch(
                     };
                 }
             }
-            let physical_target_qpc =
-                match planned_target_qpc(&dispatch_plan, resources.playback.epoch) {
-                    Ok(target) => target,
-                    Err(error) => {
-                        core.runtime.force_full_cleanup = true;
-                        core.runtime.terminal_error = Some(error);
-                        break;
-                    }
-                };
             let authored_step = dispatch_due_from_plan(
                 &dispatch_plan,
                 effective_now_ticks,
                 now_ticks,
-                physical_target_qpc,
+                resources.playback.epoch,
                 focus_loss_fault,
                 config,
                 resources,
@@ -825,6 +842,9 @@ pub(super) fn dispatch(
                     wait_result,
                     target_qpc,
                 } => {
+                    // This is the global wait boundary only. Physical target
+                    // attribution is resolved from the selected work below.
+                    let _wait_boundary_target_qpc = target_qpc;
                     let Some(wait_deadline_ticks) = deadline_ticks else {
                         core.runtime.force_full_cleanup = true;
                         core.runtime.terminal_error =
@@ -871,7 +891,7 @@ pub(super) fn dispatch(
                         &dispatch_plan,
                         dispatch_effective_now,
                         dispatch_now_ticks,
-                        Some(target_qpc),
+                        resources.playback.epoch,
                         focus_loss_fault,
                         config,
                         resources,
@@ -981,12 +1001,107 @@ fn observer_drain_requires_replan(result: Option<u64>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::observer_drain_requires_replan;
+    use super::{PhysicalWork, observer_drain_requires_replan, physical_target_qpc_for_work};
+    use crate::engine::worker::dispatch::timing::AuthoredDispatchPlan;
+    use crate::engine::worker::health::DispatchPath;
+    use crate::engine::worker::planning::NextDispatchPlan;
+    use sky_dispatch_core::coordinator::PendingDispatchPlan;
+    use sky_dispatch_core::time::{DurationTicks, QpcTicks, TimelineTicks};
 
     #[test]
     fn zero_microsecond_observer_drain_still_invalidates_the_plan() {
         assert!(observer_drain_requires_replan(Some(0)));
         assert!(observer_drain_requires_replan(Some(7)));
         assert!(!observer_drain_requires_replan(None));
+    }
+
+    fn plan_with_deadlines(authored: u64, pending: u64) -> NextDispatchPlan {
+        NextDispatchPlan {
+            authored: Some(AuthoredDispatchPlan {
+                path: DispatchPath::DownOnly { down_count: 1 },
+                lead_us: 0,
+                lead_ticks: DurationTicks::ZERO,
+                lead_saturated: false,
+                deadline_ticks: TimelineTicks::from_raw(authored),
+            }),
+            authored_budget: None,
+            pending: Some(PendingDispatchPlan {
+                deadline_ticks: TimelineTicks::from_raw(pending),
+                lead_ticks: DurationTicks::ZERO,
+                polyphony: 1,
+                lead_saturated: false,
+            }),
+            pending_budget: None,
+            deadline_ticks: Some(TimelineTicks::from_raw(authored.min(pending))),
+        }
+    }
+
+    #[test]
+    fn pending_overdue_work_uses_its_own_physical_target() {
+        let plan = plan_with_deadlines(1_000, 1_100);
+        let epoch = QpcTicks::ZERO;
+
+        assert_eq!(
+            physical_target_qpc_for_work(
+                &plan,
+                epoch,
+                QpcTicks::from_raw(1_200),
+                PhysicalWork::Pending
+            )
+            .expect("pending target")
+            .expect("pending deadline"),
+            QpcTicks::from_raw(1_100)
+        );
+        assert_eq!(
+            physical_target_qpc_for_work(
+                &plan,
+                epoch,
+                QpcTicks::from_raw(1_200),
+                PhysicalWork::Authored
+            )
+            .expect("authored target")
+            .expect("authored deadline"),
+            QpcTicks::from_raw(1_000)
+        );
+    }
+
+    #[test]
+    fn pending_target_remains_earlier_when_authored_is_later() {
+        let plan = plan_with_deadlines(1_100, 1_000);
+        let target = physical_target_qpc_for_work(
+            &plan,
+            QpcTicks::ZERO,
+            QpcTicks::from_raw(1_200),
+            PhysicalWork::Pending,
+        )
+        .expect("pending target")
+        .expect("pending deadline");
+
+        assert_eq!(target, QpcTicks::from_raw(1_000));
+    }
+
+    #[test]
+    fn equal_authored_and_pending_deadlines_share_the_same_target() {
+        let plan = plan_with_deadlines(1_000, 1_000);
+        let epoch = QpcTicks::from_raw(500);
+        let pending = physical_target_qpc_for_work(
+            &plan,
+            epoch,
+            QpcTicks::from_raw(1_500),
+            PhysicalWork::Pending,
+        )
+        .expect("pending target")
+        .expect("pending deadline");
+        let authored = physical_target_qpc_for_work(
+            &plan,
+            epoch,
+            QpcTicks::from_raw(1_500),
+            PhysicalWork::Authored,
+        )
+        .expect("authored target")
+        .expect("authored deadline");
+
+        assert_eq!(pending, QpcTicks::from_raw(1_500));
+        assert_eq!(authored, pending);
     }
 }

--- a/rust/crates/sky_player_rs/src/engine/worker/estimator.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/estimator.rs
@@ -17,13 +17,18 @@ pub(crate) fn update_estimator_after_send_observation(
     estimator.update(path, event_count, dispatch_cost_us)
 }
 
+/// Record a saturated lead by physical event count.
+///
+/// The fixed diagnostic arrays use indices 1..=14 for exact counts; index 15
+/// is an explicit `15_plus` overflow bucket. This is separate from the
+/// estimator, which retains exact event counts through 30.
 pub(crate) fn record_lead_saturation(
     counters: &mut [u64; 16],
     positive_residual_at_cap: &mut u64,
-    polyphony: usize,
+    event_count: usize,
     completion_error_us: i64,
 ) {
-    let bucket = polyphony.clamp(1, 15);
+    let bucket = event_count.clamp(1, 15);
     counters[bucket] = counters[bucket].saturating_add(1);
     if completion_error_us > 0 {
         *positive_residual_at_cap = positive_residual_at_cap.saturating_add(1);

--- a/rust/crates/sky_player_rs/src/engine/worker/planning.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/planning.rs
@@ -13,7 +13,7 @@ use super::health::{
 };
 use crate::engine::config::TimingOptions;
 use sky_dispatch_core::coordinator::{
-    CoordinatorError, PendingDispatchPlan, RuntimeDispatchCoordinator,
+    CoordinatorError, CoordinatorInvariantError, PendingDispatchPlan, RuntimeDispatchCoordinator,
 };
 use sky_dispatch_core::estimator::DispatchCostEstimator;
 use sky_dispatch_core::time::{DurationTicks, TimelineTicks};
@@ -153,11 +153,21 @@ fn plan_next_dispatch_inner(
             let lead_ticks = qpc_clock
                 .duration_from_us(lead.applied_us)
                 .map_err(|error| PlanningError::TimeConversion(format!("{error:?}")))?;
+            let deadline_ticks = coordinator
+                .next_authored_ticks(lead_ticks)?
+                .ok_or_else(|| {
+                    PlanningError::Coordinator(CoordinatorError::Invariant(
+                        CoordinatorInvariantError::Accounting(
+                            "authored path exists but no authored deadline exists".to_string(),
+                        ),
+                    ))
+                })?;
             Some(AuthoredDispatchPlan {
                 path,
                 lead_us: lead.applied_us,
                 lead_ticks,
                 lead_saturated: lead.saturated,
+                deadline_ticks,
             })
         }
         None => None,

--- a/rust/crates/sky_player_rs/tests/rt_dispatch_no_alloc.rs
+++ b/rust/crates/sky_player_rs/tests/rt_dispatch_no_alloc.rs
@@ -2,8 +2,9 @@
 //!
 //! Verifies that the allocation-free segment of the authored dispatch path
 //! (from plan build through `dispatch_ready` — i.e. coordinator commit and
-//! observer enqueue) makes zero heap allocations.  Observer drain (estimator,
-//! health, publish) is explicitly excluded from the counter window per §8.11.
+//! observer enqueue) makes zero heap allocations.  Observer drain (health,
+//! publish) is explicitly excluded from the counter window per §8.11; direct
+//! estimator query/update allocation proofs are covered below.
 //!
 //! Uses a counting `GlobalAlloc` wrapper that increments an atomic counter on
 //! every `alloc` call.  The counter is *only* read inside the assertion window;
@@ -13,6 +14,7 @@
 //!   cargo test --manifest-path rust/Cargo.toml -p sky_player_rs \
 //!       --features test-support --test rt_dispatch_no_alloc
 
+use sky_dispatch_core::estimator::{DispatchCostEstimator, SendPath};
 use sky_dispatch_core::time::{DurationTicks, QpcTicks, TimelineTicks};
 use sky_dispatch_win32::input::{PacketRetryReason, PhysicalPacket, SendTransactionStatus};
 use sky_player_rs::engine::dispatch_primitives::{
@@ -206,6 +208,43 @@ fn clean_estimator_evidence(requested_count: usize) -> EstimatorObservationEvide
         recovery_used: false,
         chord_integrity_lost: false,
     }
+}
+
+#[test]
+fn estimator_query_no_alloc() {
+    let _lock = TEST_LOCK.lock();
+    let mut estimator = DispatchCostEstimator::try_new(2_000, 30).expect("estimator");
+    for _ in 0..5 {
+        estimator
+            .update(SendPath::UpOnly, 2, 700)
+            .expect("seed sample");
+    }
+
+    enable_counting();
+    let estimate = estimator.estimate_lead(SendPath::UpOnly, 2, false);
+    let allocs = disable_counting();
+
+    assert_eq!(estimate.applied_us, 700);
+    assert_eq!(allocs, 0, "estimator query made {allocs} allocation(s)");
+}
+
+#[test]
+fn estimator_update_no_alloc() {
+    let _lock = TEST_LOCK.lock();
+    let mut estimator = DispatchCostEstimator::try_new(2_000, 30).expect("estimator");
+    for _ in 0..5 {
+        estimator
+            .update(SendPath::Mixed, 3, 900)
+            .expect("seed sample");
+    }
+
+    enable_counting();
+    estimator
+        .update(SendPath::Mixed, 3, 950)
+        .expect("update sample");
+    let allocs = disable_counting();
+
+    assert_eq!(allocs, 0, "estimator update made {allocs} allocation(s)");
 }
 
 #[test]

--- a/scripts/check_rust_architecture.py
+++ b/scripts/check_rust_architecture.py
@@ -87,6 +87,9 @@ def _load_allowlist(repository_root: Path) -> dict[tuple[str, str], dict[str, st
         if missing:
             raise ValueError(f"allowlist entry missing {sorted(missing)}: {entry!r}")
         key = (str(entry["path"]), str(entry["rule"]))
+        entry_path = repository_root / key[0]
+        if not entry_path.is_file():
+            raise ValueError(f"allowlist path does not exist: {key[0]}")
         result[key] = {name: str(entry[name]) for name in required}
     return result
 

--- a/tests/test_estimator_cache.py
+++ b/tests/test_estimator_cache.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from sky_music.orchestration.estimator_cache import (
     load_estimator_state,
     save_estimator_state,
@@ -36,3 +38,62 @@ def test_estimator_cache_rejects_corrupt_or_mismatched_state(tmp_path) -> None:
 
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert set(payload) == {"schema_version", "native_abi", "estimator_state_json"}
+
+
+def test_estimator_cache_rejects_abi_mismatch_and_schema_v1(tmp_path) -> None:
+    path = tmp_path / "state.json"
+    save_estimator_state('{"version":8}', native_abi="abi-1", path=path)
+
+    assert load_estimator_state(native_abi="abi-2", path=path) is None
+
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "native_abi": "abi-1",
+                "estimator_state_json": '{"version":8}',
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert load_estimator_state(native_abi="abi-1", path=path) is None
+
+
+@pytest.mark.parametrize("state_json", ["[]", "not-json"])
+def test_estimator_cache_rejects_non_object_inner_state(tmp_path, state_json: str) -> None:
+    path = tmp_path / "state.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "native_abi": "abi-1",
+                "estimator_state_json": state_json,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert load_estimator_state(native_abi="abi-1", path=path) is None
+
+
+def test_estimator_cache_identity_ignores_build_commit_and_fps(tmp_path) -> None:
+    path = tmp_path / "state.json"
+    save_estimator_state('{"version":8}', native_abi="abi-1", path=path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["unrelated_build_commit"] = "different-build"
+    payload["fps"] = 144
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert load_estimator_state(native_abi="abi-1", path=path) == '{"version":8}'
+
+
+def test_estimator_cache_save_failure_is_non_fatal(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "state.json"
+
+    def fail_replace(*args, **kwargs):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr("sky_music.orchestration.estimator_cache.os.replace", fail_replace)
+    save_estimator_state('{"version":8}', native_abi="abi-1", path=path)
+
+    assert not path.exists()

--- a/tests/test_rust_architecture.py
+++ b/tests/test_rust_architecture.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def _checker():
     path = Path(__file__).parents[1] / "scripts" / "check_rust_architecture.py"
@@ -104,6 +106,22 @@ def test_checker_accepts_explicit_temporary_allowlist(tmp_path):
 
     assert not report.errors
     assert any("temporary allowlist" in item.message for item in report.warnings)
+
+
+def test_checker_rejects_stale_allowlist_path(tmp_path):
+    source = tmp_path / "rust" / "crates" / "sky_dispatch_core" / "src"
+    config = tmp_path / ".config"
+    source.mkdir(parents=True)
+    config.mkdir()
+    (config / "rust_architecture_allowlist.json").write_text(
+        '{"entries":[{"path":"rust/crates/sky_dispatch_core/src/removed.rs",'
+        '"rule":"regular_module_lines","reason":"stale",'
+        '"expires_phase":"Phase 2"}]}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="allowlist path does not exist"):
+        _checker().check_repository(tmp_path)
 
 
 def test_checker_treats_python_root_as_ffi_boundary(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the P0 multi-due dispatch attribution bug. The global earliest deadline remains a wait boundary only; each physical send now derives its QPC target from the selected authored or pending work.

Also closes the acceptance proof gaps:

- Removes stale coordinator/estimator architecture allowlist entries and makes stale paths fail the checker.
- Adds direct CountingAllocator proofs for estimator query/update.
- Completes cache v2 ABI/schema/inner-state/identity/save-failure tests.
- Aligns normative timing/health docs with current code.
- Documents saturation diagnostics as exact event counts 1..14 plus an explicit 15_plus bucket.

## Root cause

When authored work and pending Up work were both overdue, the coordinator dispatched pending first but passed the global earliest deadline as the pending physical target. This could train the Up estimator with an inflated completion cost.

## Validation

- Rust fmt/check/clippy: PASS
- Rust workspace all-features tests: PASS
- sky_player_rs no-allocation suite: PASS, including direct estimator query/update tests
- Ruff: PASS
- Pyright: PASS
- Python tests: 776 passed, 1 xfailed
- P0 security audit: PASS
- Architecture checker and stale-allowlist regression: PASS
- Free-threaded wheel audit: PASS
- Clean-provenance mock acceptance smoke: PASS (1/1 run, correctness failures 0)

Real SendInput A/B/Raw Input qualification was intentionally not run; it requires a separate controlled foreground/input authorization and remains an acceptance evidence gap.