### PR TITLE
fix(ui): update progress renderer for missed notes

### DIFF
--- a/src/sky_music/ui/hud.py
+++ b/src/sky_music/ui/hud.py
@@ -172,6 +172,10 @@ class ProgressRenderer:
         song_name: str,
         status: str = "playing",
         pre_roll_remaining_us: int = 0,
+        missed_down_boundaries: int = 0,
+        missed_down_keys: int = 0,
+        missed_hard_late_boundaries: int = 0,
+        late_authorized_boundaries: int = 0,
         force: bool = False,
         input_path_degraded: bool = False,
         sendinput_path_degraded: bool = False,
@@ -189,6 +193,7 @@ class ProgressRenderer:
 
         self.last_render_at = now
         self.input_path_degraded = bool(input_path_degraded)
+        self.missed_down_keys = int(missed_down_keys)
 
         if not self.run_id:
             self.run_id = time.strftime("%Y%m%d-%H%M%S")
@@ -354,6 +359,9 @@ class ProgressRenderer:
                 "  >5ms:", str(self.late_5ms),
                 "  >10ms:", str(self.late_10ms),
                 "  ·  active keys: ", str(active_keys),
+                "  ·  missed:", str(missed_down_boundaries),
+                " · hard:", str(missed_hard_late_boundaries),
+                " · late-ok:", str(late_authorized_boundaries),
                 *dropped_parts,
             )
         else:
@@ -393,6 +401,13 @@ class ProgressRenderer:
             )
             for notice in notice_state.notices
         )
+        if not self.verbose and missed_down_boundaries > 0:
+            panel_content.append(
+                Text(
+                    f"missed notes: {missed_down_boundaries}",
+                    style=styles["warning"],
+                )
+            )
 
         # Timing info (verbose)
         if self.verbose and self.active_policy is not None:

--- a/tests/test_hud_ui.py
+++ b/tests/test_hud_ui.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import inspect
+from io import StringIO
+
+from rich.console import Console
 
 from sky_music.domain.scheduler_types import FrameTimingPolicy
 from sky_music.infrastructure.hotkeys import HotkeyBinding, PlaybackControls
@@ -88,3 +91,57 @@ def test_hud_retains_schedule_warning_state_for_live_renderer() -> None:
     assert [notice.message for notice in state.persistent_notices] == [
         "schedule repeat warning"
     ]
+
+
+def test_progress_renderer_surfaces_missed_note_counters(monkeypatch) -> None:
+    import sky_music.ui.hud as hud_module
+
+    class FakeLive:
+        def __init__(self, renderable, **_kwargs) -> None:
+            self.renderable = renderable
+
+        def start(self) -> None:
+            return None
+
+        def update(self, renderable) -> None:
+            self.renderable = renderable
+
+        def stop(self) -> None:
+            return None
+
+    monkeypatch.setattr(hud_module, "Live", FakeLive)
+
+    normal = ProgressRenderer()
+    normal.render(
+        0.0,
+        1.0,
+        "Test Song",
+        force=True,
+        missed_down_boundaries=3,
+        missed_down_keys=3,
+        missed_hard_late_boundaries=2,
+        late_authorized_boundaries=4,
+    )
+    normal_output = StringIO()
+    assert normal._live is not None
+    Console(file=normal_output, width=120).print(normal._live.renderable)
+    assert "missed notes: 3" in normal_output.getvalue()
+    normal.finish()
+
+    verbose = ProgressRenderer(verbose=True)
+    verbose.render(
+        0.0,
+        1.0,
+        "Test Song",
+        force=True,
+        missed_down_boundaries=3,
+        missed_hard_late_boundaries=2,
+        late_authorized_boundaries=4,
+    )
+    verbose_output = StringIO()
+    assert verbose._live is not None
+    Console(file=verbose_output, width=120).print(verbose._live.renderable)
+    assert "missed:3" in verbose_output.getvalue()
+    assert "hard:2" in verbose_output.getvalue()
+    assert "late-ok:4" in verbose_output.getvalue()
+    verbose.finish()


### PR DESCRIPTION
## What changed

Update the Rich/console `ProgressRenderer` to accept the native missed-note counters forwarded by `RustDispatchRuntime`.

- Add the four counter arguments with default `0`.
- Show `missed notes: N` in normal mode.
- Show `missed:N · hard:M · late-ok:L` in verbose mode.
- Add a direct Rich renderer regression test covering the interface and both HUD modes.

## Why

The console fallback renderer did not accept the new keyword arguments, causing a `TypeError` on the first live render when Textual was unavailable.

## Validation

- Full pytest: 786 passed, 6 skipped, 1 expected xfail.
- Native wheel build/import/GIL verification passed.
- Changed-file Ruff and Pyright passed.
- Security audit passed.
- `cargo fmt --all -- --check` and `cargo check --workspace` passed.

The repository-wide Ruff/Pyright baselines still report unrelated diagnostics in unchanged benchmark bridge files. The exact parallel `cargo test --workspace` run remains timing-sensitive in existing harness tests; no Rust files were changed in this patch.