### PR TITLE
fix(rust): satisfy strict Clippy release gate

### DIFF
--- a/rust/crates/sky_player_rs/src/engine/worker/dispatch/authored.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/dispatch/authored.rs
@@ -347,9 +347,9 @@ fn admit_authored_down(
             .checked_duration_since(view.authored_batch_scheduled_ticks)
             .is_ok_and(|late| late > timing.down_late_grace_ticks)
     {
-        return Err(DispatchStep::Terminate(format!(
-            "authored Down exceeded the session down late-grace window",
-        )));
+        return Err(DispatchStep::Terminate(
+            "authored Down exceeded the session down late-grace window".to_string(),
+        ));
     }
     if has_conflicts {
         local_metrics.authored_conflict_events =


### PR DESCRIPTION
## Summary
- replace one static `format!` with `.to_string()` in authored dispatch termination
- no runtime behavior change

## Validation
- `cargo fmt --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

All passed on Windows.