### PR TITLE
Agent/host input delivery calibration

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,12 +152,22 @@ process tags every packet with direction and sequence, records Raw Input at
 the `WM_INPUT` handler entry, and pairs receipts by scan code. For each key it
 computes the signed hold shrink `D - U`; only clean pairs enter the signed
 quantiles. At least 100 clean pairs are required in every production bucket.
-The cache is version 2 (native schema 9, measurement protocol 4), and cache
-version 1 is rejected rather than reinterpreted. The selected margin is:
+The cache is version 3 (native schema 9, measurement protocol 4); version 2
+is integrity-checked and migrated, while version 1 is rejected rather than
+reinterpreted. Qualification is:
 
 ```text
-max(300, min(2_000, max(0, required_bucket_p99_shrink) + 100))
+candidate = max(0, required_bucket_p99_shrink) + 100
+candidate <= 2_000 -> VALID, applied margin = max(300, candidate)
+candidate > 2_000  -> OUT_OF_ENVELOPE, applied margin = None
 ```
+
+Completed out-of-envelope evidence overwrites the cache with its unhealthy
+v3 status and playback falls back to a clearly-sourced 500 µs hold margin.
+Measurement or integrity failure preserves the previous cache. The hold
+margin never changes Note-On timestamps, `physical_target`, dispatch lead, or
+the independent fixed `down_late_grace_us` policy, which is `500 µs` in
+production.
 
 Invalid provenance, incomplete buckets, anomalies, cleanup failure, or a
 failed startup Down/Up correlation self-test fail closed and preserve the

--- a/docs/hold-frame-model.md
+++ b/docs/hold-frame-model.md
@@ -12,19 +12,23 @@ requested_min_hold_us = round(hold_frames * frame_us) + margin_us
 effective_min_hold_us = requested_min_hold_us
 ```
 
-The default margin is `500 µs`; calibration may provide a validated margin.
+The default hold margin is `500 µs`; calibration may provide a validated
+margin.
 The validated host-delivery calibration uses only paired Down/Up evidence from
 the six required `1/5/15 × hot/cold` buckets, with at least 100 clean pairs in
-each bucket. Its recommended margin is the global positive p99 hold shrink plus
-`100 µs`, clamped to `300–2,000 µs`; cache v1 or incomplete/dirty evidence
-falls back to the unchanged `500 µs` default.
+each bucket. Its candidate is the global positive p99 hold shrink plus
+`100 µs`. A candidate at or below `2,000 µs` is valid and applies
+`max(300 µs, candidate)`; a candidate above `2,000 µs` is out of the trusted
+correction envelope and applies no calibrated margin. Cache v1 or
+incomplete/dirty evidence falls back to the unchanged `500 µs` default, while
+completed out-of-envelope evidence is retained as unhealthy cache v3.
 The native worker receives only the materialized `effective_min_hold_us` and
 uses it as a fixed duration. PyO3 does not add another frame-relative floor;
 Rust only range-checks and validates this value in QPC ticks. It does not learn
-or subtract SendInput cost. The same session-fixed `min_hold_margin_us` is
-forwarded as `down_late_grace_us` and converted once to QPC ticks. It bounds
-authorized Down lateness at the final sender cutoff; it is never added to an
-authored target or adapted during playback. Equality at the cutoff is allowed;
+or subtract SendInput cost. The independent fixed `down_late_grace_us` sender
+policy is `500 µs` and is converted once to QPC ticks. It bounds authorized
+Down lateness at the final sender cutoff; it is never derived from calibration,
+added to an authored target, or adapted during playback. Equality at the cutoff is allowed;
 the first QPC tick beyond it is a missed Down. Up-only releases remain exempt.
 
 At 60 FPS with the default margin:

--- a/docs/rt-dispatch-architecture.md
+++ b/docs/rt-dispatch-architecture.md
@@ -185,11 +185,12 @@ deadline/overdue policy handles a late boundary; recovery-only pending
 releases are stored in a fixed `[Option; 15]` per-key table with mask and
 generation ownership. There is no transport retry state.
 
-The session-fixed `down_late_grace_us` is the already-materialized
-`min_hold_margin_us`, converted once to QPC ticks at admission. It bounds
-authorized Down lateness only; it is never dispatch lead and never changes an
-authored target. The trusted sender repeats the same cutoff check immediately
-before `SendInput`, while Up-only safety releases remain exempt.
+The session-fixed `down_late_grace_us` is an independent sender correctness
+policy, currently `500 µs`, converted once to QPC ticks at admission. It bounds
+authorized Down lateness only; it is never derived from the hold margin,
+calibration, or dispatch lead, and never changes an authored target. The
+trusted sender repeats the same cutoff check immediately before `SendInput`,
+while Up-only safety releases remain exempt.
 
 ## 5. Wait and interrupt ordering
 

--- a/docs/timing-principles.md
+++ b/docs/timing-principles.md
@@ -21,7 +21,7 @@ microsecond conversions.
 | `sendinput_completion_qpc` | QPC sample returned after the prepared SendInput call. |
 | `pre_call_to_completion` | The interval from `pre_call_qpc` to `sendinput_completion_qpc`; compatibility field `send_duration_us` retains this value. |
 | `effective_min_hold` | Fixed materialized hold floor passed into the native worker. |
-| `down_late_grace` | The session-fixed hold margin reused as the maximum authorized Down lateness. |
+| `down_late_grace` | Independent fixed sender correctness grace for authorized Down admission; production is `500 µs`. |
 | `authored_hold_valid` | Pre-start proof that authored Down→Up spacing meets the materialized hold. |
 
 The worker never applies a learned dispatch-cost lead to `scheduled` or
@@ -51,14 +51,10 @@ the same QPC tick domain used by dispatch. If the interval is invalid, native
 admission fails before any musical packet can be sent; the worker never
 reschedules the Up target.
 
-`min_hold_margin_us` serves two related purposes:
-
-1. it is already included once in the authored effective minimum hold;
-2. the same fixed session value bounds how late an authorized Down may enter
-   `SendInput` without being classified as a missed boundary.
-
-It is never added to the authored target, never used as dispatch lead, and
-never adapted during playback. The native worker materializes it once as
+`min_hold_margin_us` affects only the authored effective minimum hold. It is
+never added to the authored target, never used as dispatch lead, and never
+adapted during playback. Independently, production uses the fixed
+`down_late_grace_us = 500` sender policy, materialized once as
 `down_late_grace_ticks` at admission. For the tightest valid authored hold:
 
 ```text
@@ -70,9 +66,9 @@ authored_up - actual_down_pre_call
     >= effective_min_hold - down_late_grace
 ```
 
-Production supplies `down_late_grace_us` from `min_hold_margin_us`. Equality
-at the cutoff is permitted; a pre-call QPC one tick beyond it makes zero Down
-`SendInput` syscalls and follows the existing missed-Down recovery path.
+Equality at the cutoff is permitted; a pre-call QPC one tick beyond it makes
+zero Down `SendInput` syscalls and follows the existing missed-Down recovery
+path. Calibration never changes this grace.
 
 Before a native session starts, the boundary validator rejects every authored
 same-key Down→Up interval below `effective_min_hold_us`, including intervals
@@ -107,10 +103,22 @@ shrink = D - U
 ```
 
 The publishable matrix has six buckets (`1/5/15 × hot/cold`) with at least
-100 clean pairs in each. The selected static margin is the positive global
-bucket p99 plus a 100 µs guard, clamped to 300–2,000 µs. This margin is
-applied only to the hold floor; it never leads the playback target or claims
-game-observed timing. Full-calibration checkpoints use plain-text SHA256
+100 clean pairs in each. Qualification uses:
+
+```text
+candidate = positive global p99 + 100 µs
+
+candidate <= 2,000 µs
+    => calibrated, applied margin = max(300 µs, candidate)
+candidate > 2,000 µs
+    => out of the trusted correction envelope, no calibrated correction
+```
+
+An out-of-envelope measurement is complete evidence, is written as unhealthy
+cache v3, and playback falls back to the explicit 500 µs hold margin. A
+measurement/integrity failure preserves the previous cache. The correction is
+applied only to the hold floor; it never leads the playback target, changes
+`down_late_grace`, or claims game-observed timing. Full-calibration checkpoints use plain-text SHA256
 sidecars and a stable common provenance manifest. Resume and finalization
 reject any bucket whose source/build identity, native source fingerprint,
 Rust version, QPC frequency, or Windows build differs from the other five;

--- a/src/sky_music/cli/console_playback.py
+++ b/src/sky_music/cli/console_playback.py
@@ -619,6 +619,7 @@ def play_selected_song(
         min_hold_us=int(active_policy.min_hold_us),
         min_hold_margin_us=int(active_policy.min_hold_margin_us),
         min_hold_margin_source=active_policy.min_hold_margin_source,
+        down_late_grace_us=int(active_policy.down_late_grace_us),
         target_hwnd=(
             int(_window_target.cached_target_hwnd())
             if not is_dry_run

--- a/src/sky_music/cli/doctor_command.py
+++ b/src/sky_music/cli/doctor_command.py
@@ -31,7 +31,7 @@ def run_doctor_command(
         print("=" * 60)
     elif calibrate:
         print("=" * 60)
-        print("    SKY MUSIC PLAYER — INPUT DELIVERY LATENCY CALIBRATION")
+        print("    SKY MUSIC PLAYER — HOST INPUT DELIVERY CALIBRATION")
         print("=" * 60)
         from sky_music.platform.win32 import window_target
         if window_target.get_sky_window() is not None:
@@ -44,19 +44,33 @@ def run_doctor_command(
         print("Injecting balanced Down/Up pairs and measuring host-side Raw Input delivery...")
         print("This is a SendInput -> app-owned WM_INPUT delivery proxy, not game/audio onset truth.")
         try:
+            from sky_music.infrastructure.calibration_loader import CalibrationStatus
             from sky_music.platform.win32.native_calibration import (
                 run_published_native_calibration,
             )
 
             res = run_published_native_calibration()
-            print("Calibration complete successfully!")
             print(
-                "Host hold-shrink p99 (us): "
+                "Host delivery hold-shrink p99 (us): "
                 f"{res.global_shrink_p99_us} (worst bucket: {res.worst_bucket})"
             )
-            print(f"Recommended margin (us): {res.margin_us}")
+            print(f"Candidate hold correction (us): {res.candidate_margin_us}")
+            print(f"Trusted correction ceiling (us): {res.ceiling_us}")
+            if res.status is CalibrationStatus.VALID:
+                assert res.margin_us is not None
+                print("Host Input Delivery Calibration: VALID")
+                print(f"Applied hold margin (us): {res.margin_us}")
+                print(f"Materialized authored hold (us): {res.effective_min_hold_us}")
+            else:
+                print("Host Input Delivery Calibration: OUT OF ENVELOPE")
+                print("Applied calibrated margin: NONE")
+                print("Playback hold fallback: 500 us (not calibrated)")
+                print("Calibration measurement completed, but host qualification failed.")
             print(f"Clean pairs per bucket: {res.sample_count}")
             print("Calibration saved to .cache/input_latency.json")
+            print("Note-On timestamps: unchanged")
+            print("=" * 60)
+            return 0 if res.status is CalibrationStatus.VALID else 1
         except Exception as exc:
             print(f"Calibration failed: {exc}")
             print("=" * 60)

--- a/src/sky_music/cli/doctor_command.py
+++ b/src/sky_music/cli/doctor_command.py
@@ -55,7 +55,10 @@ def run_doctor_command(
                 f"{res.global_shrink_p99_us} (worst bucket: {res.worst_bucket})"
             )
             print(f"Candidate hold correction (us): {res.candidate_margin_us}")
+            print(f"Policy guard (us): {res.guard_us}")
             print(f"Trusted correction ceiling (us): {res.ceiling_us}")
+            print(f"Evidence: {res.evidence_kind}")
+            print(f"Cache: {res.cache_path.as_posix()}")
             if res.status is CalibrationStatus.VALID:
                 assert res.margin_us is not None
                 print("Host Input Delivery Calibration: VALID")
@@ -67,7 +70,6 @@ def run_doctor_command(
                 print("Playback hold fallback: 500 us (not calibrated)")
                 print("Calibration measurement completed, but host qualification failed.")
             print(f"Clean pairs per bucket: {res.sample_count}")
-            print("Calibration saved to .cache/input_latency.json")
             print("Note-On timestamps: unchanged")
             print("=" * 60)
             return 0 if res.status is CalibrationStatus.VALID else 1

--- a/src/sky_music/domain/scheduler_types.py
+++ b/src/sky_music/domain/scheduler_types.py
@@ -14,6 +14,7 @@ from sky_music.domain.hold_timing import (
 
 DEFAULT_FOCUS_RESTORE_GRACE_US = 100_000
 DEFAULT_SAME_KEY_CONFLICT_POLICY = "drop_chord"
+DEFAULT_DOWN_LATE_GRACE_US = 500
 
 
 class ActionKind(StrEnum):
@@ -39,11 +40,18 @@ class TimingPolicy:
     same_key_conflict_policy: ConflictPolicy = DEFAULT_SAME_KEY_CONFLICT_POLICY
     min_hold_margin_us: Microseconds = Microseconds(500)
     min_hold_margin_source: str = "default_500"
+    down_late_grace_us: Microseconds = Microseconds(DEFAULT_DOWN_LATE_GRACE_US)
 
     def __post_init__(self) -> None:
         validate_hold_frames(self.hold_frames)
         if self.focus_restore_grace_us < 0:
             raise ValueError("focus_restore_grace_us must be non-negative")
+        if (
+            not isinstance(self.down_late_grace_us, int)
+            or isinstance(self.down_late_grace_us, bool)
+            or self.down_late_grace_us < 0
+        ):
+            raise ValueError("down_late_grace_us must be a non-negative integer")
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,6 +65,7 @@ class FrameTimingPolicy:
     same_key_conflict_policy: ConflictPolicy = DEFAULT_SAME_KEY_CONFLICT_POLICY
     min_hold_margin_us: Microseconds = Microseconds(500)
     min_hold_margin_source: str = "default_500"
+    down_late_grace_us: Microseconds = Microseconds(DEFAULT_DOWN_LATE_GRACE_US)
 
     @classmethod
     def from_timing_policy(
@@ -81,6 +90,7 @@ class FrameTimingPolicy:
             same_key_conflict_policy=conflict,
             min_hold_margin_us=Microseconds(max(0, int(policy.min_hold_margin_us))),
             min_hold_margin_source=policy.min_hold_margin_source,
+            down_late_grace_us=Microseconds(policy.down_late_grace_us),
         )
 
     @classmethod
@@ -91,6 +101,7 @@ class FrameTimingPolicy:
         *,
         margin_us: int = 500,
         margin_source: str = "default_500",
+        down_late_grace_us: int = DEFAULT_DOWN_LATE_GRACE_US,
         focus_restore_grace_us: int = DEFAULT_FOCUS_RESTORE_GRACE_US,
         same_key_conflict_policy: ConflictPolicy = DEFAULT_SAME_KEY_CONFLICT_POLICY,
     ) -> FrameTimingPolicy:
@@ -101,6 +112,7 @@ class FrameTimingPolicy:
                 same_key_conflict_policy=same_key_conflict_policy,
                 min_hold_margin_us=Microseconds(margin_us),
                 min_hold_margin_source=margin_source,
+                down_late_grace_us=Microseconds(down_late_grace_us),
             ),
             fps,
         )

--- a/src/sky_music/domain/session_context.py
+++ b/src/sky_music/domain/session_context.py
@@ -14,6 +14,7 @@ from sky_music.domain.hold_timing import (
     validate_hold_frames,
 )
 from sky_music.domain.scheduler_types import (
+    DEFAULT_DOWN_LATE_GRACE_US,
     DEFAULT_FOCUS_RESTORE_GRACE_US,
     FrameTimingPolicy,
     TimingPolicy,
@@ -101,16 +102,19 @@ class PlaybackSessionContext:
         self,
         cfg: AppConfig | None = None,
         *,
-        calibrated_margin_us: int | None = None,
-        calibrated_margin_source: str = "default_500",
+        hold_margin_us: int = 500,
+        hold_margin_source: str = "default_500",
     ) -> FrameTimingPolicy:
         del cfg
+        if type(hold_margin_us) is not int or hold_margin_us < 0:
+            raise ValueError("hold_margin_us must be a non-negative integer")
         policy = TimingPolicy(
             hold_frames=self.hold_frames,
             focus_restore_grace_us=Microseconds(self.focus_restore_grace_us),
             same_key_conflict_policy=self.same_key_conflict_policy,
-            min_hold_margin_us=Microseconds(max(0, calibrated_margin_us if calibrated_margin_us is not None else 500)),
-            min_hold_margin_source=calibrated_margin_source if calibrated_margin_us is not None else "default_500",
+            min_hold_margin_us=Microseconds(hold_margin_us),
+            min_hold_margin_source=hold_margin_source,
+            down_late_grace_us=Microseconds(DEFAULT_DOWN_LATE_GRACE_US),
         )
         return FrameTimingPolicy.from_timing_policy(policy, fps=self.fps)
 

--- a/src/sky_music/infrastructure/calibration_loader.py
+++ b/src/sky_music/infrastructure/calibration_loader.py
@@ -10,19 +10,25 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 DEFAULT_CACHE_FILENAME: str = ".cache/input_latency.json"
 SOURCE_DEVICE_CACHE: str = "device_cache"
 SOURCE_DEFAULT_500: str = "default_500"
-SUPPORTED_CACHE_VERSION: int = 2
+SOURCE_OUT_OF_ENVELOPE_DEFAULT_500: str = "out_of_envelope_default_500"
+SOURCE_INVALID_CACHE_DEFAULT_500: str = "invalid_cache_default_500"
+SUPPORTED_CACHE_VERSION: int = 3
+LEGACY_CACHE_VERSION: int = 2
 SUPPORTED_NATIVE_CALIBRATION_VERSION: int = 9
 SUPPORTED_MEASUREMENT_PROTOCOL_VERSION: int = 4
-SOURCE_FORMULA_VERSION: int = 2
+SOURCE_FORMULA_VERSION: int = 3
+LEGACY_SOURCE_FORMULA_VERSION: int = 2
 MIN_CALIBRATION_SAMPLE_COUNT: int = 100
 MAX_SHRINK_US: int = 100_000
 MARGIN_GUARD_US: int = 100
 MARGIN_FLOOR_US: int = 300
+# This is a qualification ceiling, not a saturation/clamp target.
 MARGIN_CEILING_US: int = 2_000
 REQUIRED_BUCKETS: tuple[str, ...] = (
     "1/hot",
@@ -32,6 +38,44 @@ REQUIRED_BUCKETS: tuple[str, ...] = (
     "15/hot",
     "15/cold",
 )
+
+
+class CalibrationStatus(StrEnum):
+    VALID = "valid"
+    OUT_OF_ENVELOPE = "out_of_envelope"
+    UNCALIBRATED = "uncalibrated"
+    INVALID_CACHE = "invalid_cache"
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationQualification:
+    status: CalibrationStatus
+    candidate_margin_us: int
+    applied_margin_us: int | None
+
+
+def qualify_calibration_margin(
+    global_shrink_p99_us: int,
+) -> CalibrationQualification:
+    """Apply the one authoritative host-delivery qualification formula."""
+
+    if not isinstance(global_shrink_p99_us, int) or isinstance(
+        global_shrink_p99_us, bool
+    ):
+        raise TypeError("global_shrink_p99_us must be an integer")
+    positive_p99 = max(0, global_shrink_p99_us)
+    candidate = positive_p99 + MARGIN_GUARD_US
+    if candidate > MARGIN_CEILING_US:
+        return CalibrationQualification(
+            status=CalibrationStatus.OUT_OF_ENVELOPE,
+            candidate_margin_us=candidate,
+            applied_margin_us=None,
+        )
+    return CalibrationQualification(
+        status=CalibrationStatus.VALID,
+        candidate_margin_us=candidate,
+        applied_margin_us=max(MARGIN_FLOOR_US, candidate),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,7 +108,8 @@ class PairBucketSummary:
 
 @dataclass(frozen=True, slots=True)
 class CalibrationCacheSummary:
-    margin_us: int
+    status: CalibrationStatus
+    margin_us: int | None
     source: str
     sample_count: int
     pair_buckets: dict[str, PairBucketSummary]
@@ -73,8 +118,17 @@ class CalibrationCacheSummary:
     guard_us: int
     floor_us: int
     ceiling_us: int
+    candidate_margin_us: int
     down_us: CalibrationQuantiles | None = None
     up_us: CalibrationQuantiles | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationLoadResult:
+    status: CalibrationStatus
+    resolved_margin_us: int
+    margin_source: str
+    summary: CalibrationCacheSummary | None
 
 
 def _int(value: object, name: str, *, minimum: int | None = None) -> int:
@@ -100,42 +154,27 @@ def _quantiles(value: object, name: str) -> SignedQuantiles:
     return SignedQuantiles(**values)
 
 
-def _selected_margin(global_shrink_p99_us: int) -> int:
+def _legacy_v2_selected_margin(global_p99: int) -> int:
+    """Validate only the selected value serialized by a legacy v2 cache."""
+
     return max(
         MARGIN_FLOOR_US,
-        min(MARGIN_CEILING_US, global_shrink_p99_us + MARGIN_GUARD_US),
+        min(MARGIN_CEILING_US, global_p99 + MARGIN_GUARD_US),
     )
 
 
-def parse_calibration_cache_summary(data: object) -> CalibrationCacheSummary:
-    """Strictly parse cache-v2 paired evidence.
-
-    This function deliberately does not accept cache-v1.  The old marginal
-    formula cannot be converted into per-pair ``D-U`` evidence safely.
-    """
-
-    if not isinstance(data, dict):
-        raise TypeError("calibration cache payload must be a dict")
-    if data.get("version") != SUPPORTED_CACHE_VERSION:
-        raise ValueError(f"unsupported calibration cache version: {data.get('version')}")
-    if data.get("evidence_kind") != "injected_raw_input_delivery_proxy":
-        raise ValueError("invalid calibration evidence kind")
-    if data.get("source_formula_version") != SOURCE_FORMULA_VERSION:
-        raise ValueError("unsupported calibration source formula")
-    if data.get("native_calibration_version") != SUPPORTED_NATIVE_CALIBRATION_VERSION:
-        raise ValueError("unsupported native calibration schema")
-    if data.get("measurement_protocol_version") != SUPPORTED_MEASUREMENT_PROTOCOL_VERSION:
-        raise ValueError("unsupported measurement protocol")
-    if data.get("source") != SOURCE_DEVICE_CACHE:
-        raise ValueError("invalid calibration source")
-    if data.get("dirty_worktree") is not False:
-        raise ValueError("calibration provenance is dirty")
-    for field in ("source_git_sha", "native_build_id"):
+def _validate_provenance(data: dict[str, object], *, require_extended: bool) -> None:
+    fields = ["source_git_sha", "native_build_id"]
+    if require_extended:
+        fields.extend(("native_source_fingerprint", "rustc_version"))
+    for field in fields:
         value = data.get(field)
         if not isinstance(value, str) or not value.strip() or value == "unknown":
             raise ValueError(f"invalid calibration provenance field: {field}")
     if data["source_git_sha"] != data["native_build_id"]:
         raise ValueError("calibration source/build provenance mismatch")
+    if data.get("dirty_worktree") is not False:
+        raise ValueError("calibration provenance is dirty")
     host = data.get("host_fingerprint")
     if not isinstance(host, dict):
         raise TypeError("host_fingerprint must be an object")
@@ -143,6 +182,8 @@ def parse_calibration_cache_summary(data: object) -> CalibrationCacheSummary:
     if not isinstance(host.get("win32_build"), str) or not host["win32_build"].strip():
         raise ValueError("host_fingerprint.win32_build is required")
 
+
+def _parse_pair_buckets(data: dict[str, object]) -> dict[str, PairBucketSummary]:
     required = data.get("required_buckets")
     if not isinstance(required, list) or tuple(required) != REQUIRED_BUCKETS:
         raise ValueError("calibration required bucket matrix is incomplete")
@@ -156,9 +197,7 @@ def parse_calibration_cache_summary(data: object) -> CalibrationCacheSummary:
         if not isinstance(bucket, dict):
             raise TypeError(f"pair bucket {key} must be an object")
         attempted = _int(bucket.get("attempted"), f"{key}.attempted", minimum=0)
-        clean = _int(
-            bucket.get("clean_pair_count"), f"{key}.clean_pair_count", minimum=0
-        )
+        clean = _int(bucket.get("clean_pair_count"), f"{key}.clean_pair_count", minimum=0)
         rejected = _int(bucket.get("rejected"), f"{key}.rejected", minimum=0)
         if clean < MIN_CALIBRATION_SAMPLE_COUNT:
             raise ValueError(
@@ -175,37 +214,54 @@ def parse_calibration_cache_summary(data: object) -> CalibrationCacheSummary:
                 bucket.get("pair_worst_shrink_us"), f"{key}.pair_worst_shrink_us"
             ),
         )
+    return pair_buckets
 
-    selected = data.get("selected_margin")
-    if not isinstance(selected, dict):
-        raise TypeError("selected_margin must be an object")
+
+def _recompute_qualification(
+    pair_buckets: dict[str, PairBucketSummary],
+) -> tuple[int, str, CalibrationQualification]:
     p99_values = {
         key: max(0, bucket.pair_worst_shrink_us.p99)
         for key, bucket in pair_buckets.items()
     }
-    global_p99 = max(p99_values.values())
-    worst_bucket = max(REQUIRED_BUCKETS, key=lambda key: (p99_values[key], -REQUIRED_BUCKETS.index(key)))
-    if selected.get("basis") != "max_required_bucket_p99_positive_pair_hold_shrink":
-        raise ValueError("selected margin basis is missing or invalid")
-    if selected.get("worst_bucket") != worst_bucket:
-        raise ValueError("selected margin worst bucket is inconsistent")
-    if selected.get("global_shrink_p99_us") != global_p99:
-        raise ValueError("selected margin p99 is inconsistent")
-    guard = _int(selected.get("guard_us"), "selected_margin.guard_us", minimum=0)
-    floor = _int(selected.get("floor_us"), "selected_margin.floor_us", minimum=0)
-    ceiling = _int(selected.get("ceiling_us"), "selected_margin.ceiling_us", minimum=floor)
+    global_p99 = max(0, *(p99_values[key] for key in REQUIRED_BUCKETS))
+    worst_bucket = max(
+        REQUIRED_BUCKETS,
+        key=lambda key: (p99_values[key], -REQUIRED_BUCKETS.index(key)),
+    )
+    return global_p99, worst_bucket, qualify_calibration_margin(global_p99)
+
+
+def _validate_policy_constants(
+    payload: dict[str, object], *, name: str
+) -> tuple[int, int, int]:
+    guard = _int(payload.get("guard_us"), f"{name}.guard_us", minimum=0)
+    floor = _int(payload.get("floor_us"), f"{name}.floor_us", minimum=0)
+    ceiling = _int(payload.get("ceiling_us"), f"{name}.ceiling_us", minimum=floor)
     if (guard, floor, ceiling) != (
         MARGIN_GUARD_US,
         MARGIN_FLOOR_US,
         MARGIN_CEILING_US,
     ):
         raise ValueError("calibration policy constants do not match the correction contract")
-    margin = _int(selected.get("recommended_margin_us"), "selected_margin.recommended_margin_us", minimum=0)
-    if margin != _selected_margin(global_p99):
-        raise ValueError("selected margin is inconsistent with paired p99 evidence")
+    return guard, floor, ceiling
 
+
+def _summary(
+    *,
+    status: CalibrationStatus,
+    margin_us: int | None,
+    pair_buckets: dict[str, PairBucketSummary],
+    worst_bucket: str,
+    global_p99: int,
+    candidate_margin_us: int,
+    guard: int,
+    floor: int,
+    ceiling: int,
+) -> CalibrationCacheSummary:
     return CalibrationCacheSummary(
-        margin_us=margin,
+        status=status,
+        margin_us=margin_us,
         source=SOURCE_DEVICE_CACHE,
         sample_count=min(bucket.clean_pair_count for bucket in pair_buckets.values()),
         pair_buckets=pair_buckets,
@@ -214,31 +270,192 @@ def parse_calibration_cache_summary(data: object) -> CalibrationCacheSummary:
         guard_us=guard,
         floor_us=floor,
         ceiling_us=ceiling,
+        candidate_margin_us=candidate_margin_us,
+    )
+
+
+def _parse_v3(data: dict[str, object]) -> CalibrationCacheSummary:
+    if data.get("source_formula_version") != SOURCE_FORMULA_VERSION:
+        raise ValueError("unsupported calibration source formula")
+    _validate_provenance(data, require_extended=True)
+    pair_buckets = _parse_pair_buckets(data)
+    global_p99, worst_bucket, qualification = _recompute_qualification(pair_buckets)
+
+    raw = data.get("qualification")
+    if not isinstance(raw, dict):
+        raise TypeError("qualification must be an object")
+    if raw.get("basis") != "max_required_bucket_p99_positive_pair_hold_shrink":
+        raise ValueError("qualification basis is missing or invalid")
+    if raw.get("worst_bucket") != worst_bucket:
+        raise ValueError("qualification worst bucket is inconsistent")
+    if raw.get("global_shrink_p99_us") != global_p99:
+        raise ValueError("qualification p99 is inconsistent")
+    guard, floor, ceiling = _validate_policy_constants(raw, name="qualification")
+    candidate = _int(raw.get("candidate_margin_us"), "qualification.candidate_margin_us", minimum=0)
+    if candidate != qualification.candidate_margin_us:
+        raise ValueError("qualification candidate is inconsistent")
+    serialized_status = raw.get("status", data.get("status"))
+    if serialized_status != data.get("status"):
+        raise ValueError("cache status and qualification status disagree")
+    try:
+        status = CalibrationStatus(serialized_status)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid calibration cache status") from exc
+    if status not in (CalibrationStatus.VALID, CalibrationStatus.OUT_OF_ENVELOPE):
+        raise ValueError("v3 cache has a non-publishable status")
+    if status is not qualification.status:
+        raise ValueError("qualification status is inconsistent")
+
+    applied_value = raw.get("applied_margin_us")
+    if applied_value is None:
+        applied = None
+    else:
+        applied = _int(applied_value, "qualification.applied_margin_us", minimum=0)
+    if applied != qualification.applied_margin_us:
+        raise ValueError("qualification applied margin is inconsistent")
+
+    return _summary(
+        status=status,
+        margin_us=applied,
+        pair_buckets=pair_buckets,
+        worst_bucket=worst_bucket,
+        global_p99=global_p99,
+        candidate_margin_us=candidate,
+        guard=guard,
+        floor=floor,
+        ceiling=ceiling,
+    )
+
+
+def _parse_v2(data: dict[str, object]) -> CalibrationCacheSummary:
+    if data.get("source_formula_version") != LEGACY_SOURCE_FORMULA_VERSION:
+        raise ValueError("unsupported legacy calibration source formula")
+    _validate_provenance(data, require_extended=False)
+    pair_buckets = _parse_pair_buckets(data)
+    global_p99, worst_bucket, qualification = _recompute_qualification(pair_buckets)
+
+    raw = data.get("selected_margin")
+    if not isinstance(raw, dict):
+        raise TypeError("selected_margin must be an object")
+    if raw.get("basis") != "max_required_bucket_p99_positive_pair_hold_shrink":
+        raise ValueError("selected margin basis is missing or invalid")
+    if raw.get("worst_bucket") != worst_bucket:
+        raise ValueError("selected margin worst bucket is inconsistent")
+    if raw.get("global_shrink_p99_us") != global_p99:
+        raise ValueError("selected margin p99 is inconsistent")
+    guard, floor, ceiling = _validate_policy_constants(raw, name="selected_margin")
+    legacy_margin = _int(
+        raw.get("recommended_margin_us"),
+        "selected_margin.recommended_margin_us",
+        minimum=0,
+    )
+    if legacy_margin != _legacy_v2_selected_margin(global_p99):
+        raise ValueError("legacy selected margin is inconsistent with paired p99 evidence")
+
+    # The legacy value is integrity evidence only.  Runtime resolution always
+    # uses the v3 qualification result, including its out-of-envelope state.
+    return _summary(
+        status=qualification.status,
+        margin_us=qualification.applied_margin_us,
+        pair_buckets=pair_buckets,
+        worst_bucket=worst_bucket,
+        global_p99=global_p99,
+        candidate_margin_us=qualification.candidate_margin_us,
+        guard=guard,
+        floor=floor,
+        ceiling=ceiling,
+    )
+
+
+def parse_calibration_cache_summary(data: object) -> CalibrationCacheSummary:
+    """Strictly parse canonical v3 evidence or migrate an integrity-checked v2 cache."""
+
+    if not isinstance(data, dict):
+        raise TypeError("calibration cache payload must be a dict")
+    version = data.get("version")
+    if version not in (SUPPORTED_CACHE_VERSION, LEGACY_CACHE_VERSION):
+        raise ValueError(f"unsupported calibration cache version: {version}")
+    if data.get("evidence_kind") != "injected_raw_input_delivery_proxy":
+        raise ValueError("invalid calibration evidence kind")
+    if data.get("native_calibration_version") != SUPPORTED_NATIVE_CALIBRATION_VERSION:
+        raise ValueError("unsupported native calibration schema")
+    if data.get("measurement_protocol_version") != SUPPORTED_MEASUREMENT_PROTOCOL_VERSION:
+        raise ValueError("unsupported measurement protocol")
+    if data.get("source") != SOURCE_DEVICE_CACHE:
+        raise ValueError("invalid calibration source")
+    if version == SUPPORTED_CACHE_VERSION:
+        return _parse_v3(data)
+    return _parse_v2(data)
+
+
+def load_calibration_resolution(
+    *, cache_path: Path | None = None, data: dict | None = None
+) -> CalibrationLoadResult:
+    """Resolve the playback hold margin and preserve cache health semantics."""
+
+    if data is None:
+        path = Path(cache_path) if cache_path is not None else Path(DEFAULT_CACHE_FILENAME)
+        if not path.exists():
+            return CalibrationLoadResult(
+                status=CalibrationStatus.UNCALIBRATED,
+                resolved_margin_us=500,
+                margin_source=SOURCE_DEFAULT_500,
+                summary=None,
+            )
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return CalibrationLoadResult(
+                status=CalibrationStatus.INVALID_CACHE,
+                resolved_margin_us=500,
+                margin_source=SOURCE_INVALID_CACHE_DEFAULT_500,
+                summary=None,
+            )
+    try:
+        summary = parse_calibration_cache_summary(data)
+    except (TypeError, ValueError, KeyError):
+        return CalibrationLoadResult(
+            status=CalibrationStatus.INVALID_CACHE,
+            resolved_margin_us=500,
+            margin_source=SOURCE_INVALID_CACHE_DEFAULT_500,
+            summary=None,
+        )
+    if summary.status is CalibrationStatus.OUT_OF_ENVELOPE:
+        return CalibrationLoadResult(
+            status=summary.status,
+            resolved_margin_us=500,
+            margin_source=SOURCE_OUT_OF_ENVELOPE_DEFAULT_500,
+            summary=summary,
+        )
+    if summary.margin_us is None:
+        raise ValueError("valid calibration summary has no applied margin")
+    return CalibrationLoadResult(
+        status=CalibrationStatus.VALID,
+        resolved_margin_us=summary.margin_us,
+        margin_source=SOURCE_DEVICE_CACHE,
+        summary=summary,
     )
 
 
 def load_calibrated_margin_recommendation(
     *, cache_path: Path | None = None, data: dict | None = None
 ) -> tuple[int | None, str]:
-    """Return a validated static margin or the unchanged 500 µs fallback."""
+    """Compatibility wrapper; production policy resolution uses the typed result."""
 
-    if data is None:
-        path = Path(cache_path) if cache_path is not None else Path(DEFAULT_CACHE_FILENAME)
-        if not path.exists():
-            return None, SOURCE_DEFAULT_500
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            return None, SOURCE_DEFAULT_500
-    try:
-        summary = parse_calibration_cache_summary(data)
-    except (TypeError, ValueError, KeyError):
-        return None, SOURCE_DEFAULT_500
-    return summary.margin_us, SOURCE_DEVICE_CACHE
+    resolution = load_calibration_resolution(cache_path=cache_path, data=data)
+    if resolution.status is CalibrationStatus.VALID:
+        return resolution.resolved_margin_us, SOURCE_DEVICE_CACHE
+    if resolution.status is CalibrationStatus.OUT_OF_ENVELOPE:
+        return None, SOURCE_OUT_OF_ENVELOPE_DEFAULT_500
+    if resolution.status is CalibrationStatus.INVALID_CACHE:
+        return None, SOURCE_INVALID_CACHE_DEFAULT_500
+    return None, SOURCE_DEFAULT_500
 
 
 __all__ = [
     "DEFAULT_CACHE_FILENAME",
+    "LEGACY_CACHE_VERSION",
+    "LEGACY_SOURCE_FORMULA_VERSION",
     "MARGIN_CEILING_US",
     "MARGIN_FLOOR_US",
     "MAX_SHRINK_US",
@@ -246,12 +463,20 @@ __all__ = [
     "REQUIRED_BUCKETS",
     "SOURCE_DEFAULT_500",
     "SOURCE_DEVICE_CACHE",
+    "SOURCE_FORMULA_VERSION",
+    "SOURCE_INVALID_CACHE_DEFAULT_500",
+    "SOURCE_OUT_OF_ENVELOPE_DEFAULT_500",
     "SUPPORTED_CACHE_VERSION",
     "SUPPORTED_MEASUREMENT_PROTOCOL_VERSION",
     "SUPPORTED_NATIVE_CALIBRATION_VERSION",
     "CalibrationCacheSummary",
+    "CalibrationLoadResult",
+    "CalibrationQualification",
     "CalibrationQuantiles",
+    "CalibrationStatus",
     "PairBucketSummary",
     "load_calibrated_margin_recommendation",
+    "load_calibration_resolution",
     "parse_calibration_cache_summary",
+    "qualify_calibration_margin",
 ]

--- a/src/sky_music/infrastructure/doctor.py
+++ b/src/sky_music/infrastructure/doctor.py
@@ -96,7 +96,7 @@ def check_physical_keys_held() -> dict:
     return status
 
 def check_calibration_cache() -> dict:
-    """Checks whether the input-latency calibration cache exists."""
+    """Checks whether the host input-delivery calibration cache exists."""
     from pathlib import Path
     path = Path(".cache/input_latency.json")
     status = {"ok": True, "msg": "", "path": str(path)}
@@ -104,7 +104,7 @@ def check_calibration_cache() -> dict:
         status["msg"] = f"Calibration cache found at {path}."
     else:
         status["ok"] = False
-        status["msg"] = "Calibration cache not found. Run `--doctor-calibrate` to measure input latency for tighter margins."
+        status["msg"] = "Calibration cache not found. Run `--doctor-calibrate` to measure host input delivery for tighter hold margins."
     return status
 
 
@@ -262,7 +262,7 @@ def run_all_doctor_checks() -> bool:
     print_fps_advisory()
     print("-" * 60)
 
-    # 8. Input Latency Calibration Cache (redundant path hint)
+    # 8. Host Input Delivery Calibration Cache (redundant path hint)
     print("[8/8] Preflight Summary:")
     print("      Run `--doctor-calibrate` if calibration cache is missing (see check 3/8).")
     print("=" * 60)

--- a/src/sky_music/orchestration/calibrated_policy.py
+++ b/src/sky_music/orchestration/calibrated_policy.py
@@ -6,7 +6,7 @@ calling ``session.resolve_effective_policy(cfg)`` directly.  This guarantees tha
 
 1. The loader is called exactly once per resolution.
 2. The ``min_hold_margin_source`` in the returned policy reflects the actual
-   cache state (``"device_cache"`` or ``"default_500"``).
+   cache state, including unhealthy fallback states.
 3. Console, Textual, and picker-metadata paths all behave identically.
 
 Layer contract (AGENTS.md Architecture Invariants):
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from sky_music.infrastructure.calibration_loader import (
-    load_calibrated_margin_recommendation,
+    load_calibration_resolution,
 )
 
 if TYPE_CHECKING:
@@ -43,10 +43,9 @@ def resolve_calibrated_policy(
     This is the **production entry point** for any code that needs a
     playback policy.  It:
 
-    1. Calls :func:`~sky_music.infrastructure.calibration_loader.load_calibrated_margin_recommendation`
-       to read ``.cache/input_latency.json`` (or fall back to the 500 µs
-       constant if the cache is absent or invalid).
-    2. Forwards ``calibrated_margin_us`` and ``calibrated_margin_source`` into
+    1. Calls :func:`~sky_music.infrastructure.calibration_loader.load_calibration_resolution`
+       to read ``.cache/input_latency.json`` and classify its health.
+    2. Forwards ``hold_margin_us`` and ``hold_margin_source`` into
        :meth:`~sky_music.domain.session_context.PlaybackSessionContext.resolve_effective_policy`
        so the returned policy carries the correct ``min_hold_margin_source``.
 
@@ -60,15 +59,14 @@ def resolve_calibrated_policy(
     Returns
     -------
     FrameTimingPolicy
-        A fully-resolved timing policy whose ``min_hold_margin_us`` reflects
-        the device cache (``device_cache``) or the static fallback
-        (``default_500``).
+        A fully-resolved timing policy whose hold margin reflects the device
+        cache or the explicit fallback source for its health state.
     """
-    margin_us, source = load_calibrated_margin_recommendation()
+    resolution = load_calibration_resolution()
     return session.resolve_effective_policy(
         cfg,
-        calibrated_margin_us=margin_us,
-        calibrated_margin_source=source,
+        hold_margin_us=resolution.resolved_margin_us,
+        hold_margin_source=resolution.margin_source,
     )
 
 

--- a/src/sky_music/orchestration/engine.py
+++ b/src/sky_music/orchestration/engine.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sky_music.domain.domain import Song
 from sky_music.domain.scheduler_types import (
+    DEFAULT_DOWN_LATE_GRACE_US,
     DEFAULT_FOCUS_RESTORE_GRACE_US,
     KeyAction,
 )
@@ -62,6 +63,7 @@ class PlaybackEngine:
         min_hold_us: int = 0,
         min_hold_margin_us: int = 500,
         min_hold_margin_source: str = "default_500",
+        down_late_grace_us: int = DEFAULT_DOWN_LATE_GRACE_US,
         dry_run: bool = False,
         pre_roll_us: int = 0,
         target_hwnd: int | None = None,
@@ -83,6 +85,9 @@ class PlaybackEngine:
             raise ValueError("game_fps must be in 15..=240")
         self.min_hold_us = max(0, int(min_hold_us))
         self.min_hold_margin_us = min_hold_margin_us
+        if type(down_late_grace_us) is not int or down_late_grace_us < 0:
+            raise ValueError("down_late_grace_us must be a non-negative integer")
+        self.down_late_grace_us = int(down_late_grace_us)
         self.hold_label = hold_label
         self.hold_frames = hold_frames
         self.tempo_scale = tempo_scale
@@ -111,6 +116,7 @@ class PlaybackEngine:
                 "rust_dispatch_schema_version": RUST_DISPATCH_SCHEMA_VERSION,
                 "dry_run": self.dry_run,
                 "min_hold_us": self.min_hold_us,
+                "down_late_grace_us": self.down_late_grace_us,
                 "focus_required": self.require_focus,
             }
         )
@@ -129,7 +135,7 @@ class PlaybackEngine:
             song_name=self.song.name,
             game_fps=self.game_fps,
             min_hold_us=self.min_hold_us,
-            down_late_grace_us=self.min_hold_margin_us,
+            down_late_grace_us=self.down_late_grace_us,
             require_focus=self.require_focus,
             focus_restore_grace_us=self.focus_restore_grace_us,
             pre_roll_us=self.pre_roll_us,
@@ -228,6 +234,10 @@ class PlaybackEngine:
                 "rt_priority_acquired": snapshot.get("rt_priority_acquired"),
                 "wait_strategy_acquired": snapshot.get("wait_strategy_acquired"),
                 "input_path_degraded": snapshot.get("input_path_degraded", False),
+                "min_hold_us": self.min_hold_us,
+                "min_hold_margin_us": self.min_hold_margin_us,
+                "min_hold_margin_source": self.telemetry.min_hold_margin_source,
+                "down_late_grace_us": self.down_late_grace_us,
             }
         )
         self.telemetry.record_backend_health(

--- a/src/sky_music/orchestration/runtime_session.py
+++ b/src/sky_music/orchestration/runtime_session.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from sky_music.config import AppConfig
 from sky_music.domain.session_context import PlaybackSessionContext
+from sky_music.orchestration.calibrated_policy import resolve_calibrated_policy
 from sky_music.orchestration.native_admission import RustBuildInfo
 
 
@@ -34,21 +35,7 @@ class RuntimeSessionState:
 
     def apply_session(self, session: PlaybackSessionContext, cfg: AppConfig) -> None:
         self.session = session
-        # Resolve the device-calibrated margin once at session build time
-        # and inject the primitives into the domain session. The
-        # calibration loader lives in ``infrastructure/`` so the domain
-        # session stays filesystem-free (AGENTS.md Architecture Invariants).
-        from sky_music.infrastructure.calibration_loader import (
-            load_calibrated_margin_recommendation,
-        )
-        calibrated_margin_us, calibrated_margin_source = (
-            load_calibrated_margin_recommendation()
-        )
-        self.timing_policy = session.resolve_effective_policy(
-            cfg,
-            calibrated_margin_us=calibrated_margin_us,
-            calibrated_margin_source=calibrated_margin_source,
-        )
+        self.timing_policy = resolve_calibrated_policy(session, cfg)
         self.scan_code_mode = session.scan_code_mode
         self.tempo_scale = session.tempo_scale
         self.hold_frames = session.hold_frames

--- a/src/sky_music/platform/win32/native_calibration.py
+++ b/src/sky_music/platform/win32/native_calibration.py
@@ -2,7 +2,7 @@
 
 The native process owns the Raw Input window and emits signed paired evidence.
 This adapter validates the complete result before writing an artifact or the
-version-2 production cache. Diagnostic runs may be saved as reports, never as
+version-3 production cache. Diagnostic runs may be saved as reports, never as
 production cache.
 """
 
@@ -33,10 +33,10 @@ from sky_music.infrastructure.calibration_loader import (
     MIN_CALIBRATION_SAMPLE_COUNT,
     REQUIRED_BUCKETS,
     CalibrationCacheSummary,
-    CalibrationQuantiles,
+    CalibrationStatus,
     PairBucketSummary,
-    _selected_margin,
     parse_calibration_cache_summary,
+    qualify_calibration_margin,
 )
 
 SUPPORTED_NATIVE_CALIBRATION_VERSION = 9
@@ -69,7 +69,9 @@ NATIVE_RECEIPT_TIMEOUT_MS = 200
 
 @dataclass(frozen=True, slots=True)
 class PublishedCalibrationResult:
-    margin_us: int
+    status: CalibrationStatus
+    margin_us: int | None
+    candidate_margin_us: int
     source: str
     sample_count: int
     cache_path: Path
@@ -80,10 +82,8 @@ class PublishedCalibrationResult:
     worst_bucket: str = ""
     global_shrink_p99_us: int = 0
     guard_us: int = MARGIN_GUARD_US
+    ceiling_us: int = MARGIN_CEILING_US
     effective_min_hold_us: int | None = None
-    # Compatibility diagnostics. They are never used as the margin formula.
-    down_us: CalibrationQuantiles | None = None
-    up_us: CalibrationQuantiles | None = None
 
 
 class NativeCalibrationError(RuntimeError):
@@ -464,7 +464,7 @@ def _bucket_key(polyphony: int, class_name: str) -> str:
     return f"{polyphony}/{class_name}"
 
 
-def _cache_v2(result: dict[str, Any]) -> dict[str, Any]:
+def _cache_v3(result: dict[str, Any]) -> dict[str, Any]:
     raw_buckets = _require_mapping(result.get("pair_buckets"), "pair_buckets")
     flattened: dict[str, dict[str, Any]] = {}
     for polyphony, class_name in calibration_bucket_keys():
@@ -482,20 +482,23 @@ def _cache_v2(result: dict[str, Any]) -> dict[str, Any]:
     }
     global_p99 = max(p99_values.values())
     worst_bucket = max(REQUIRED_BUCKETS, key=lambda key: (p99_values[key], -REQUIRED_BUCKETS.index(key)))
-    selected = {
+    qualification_result = qualify_calibration_margin(global_p99)
+    qualification = {
         "basis": "max_required_bucket_p99_positive_pair_hold_shrink",
         "worst_bucket": worst_bucket,
         "global_shrink_p99_us": global_p99,
         "guard_us": MARGIN_GUARD_US,
         "floor_us": MARGIN_FLOOR_US,
         "ceiling_us": MARGIN_CEILING_US,
-        "recommended_margin_us": _selected_margin(global_p99),
+        "candidate_margin_us": qualification_result.candidate_margin_us,
+        "applied_margin_us": qualification_result.applied_margin_us,
     }
     return {
-        "version": 2,
+        "version": 3,
         "source": "device_cache",
+        "status": qualification_result.status.value,
         "evidence_kind": result["evidence_kind"],
-        "source_formula_version": 2,
+        "source_formula_version": 3,
         "native_calibration_version": result["version"],
         "measurement_protocol_version": result["measurement_protocol_version"],
         "source_git_sha": result.get("source_git_sha"),
@@ -506,7 +509,7 @@ def _cache_v2(result: dict[str, Any]) -> dict[str, Any]:
         "host_fingerprint": result.get("host_fingerprint"),
         "required_buckets": list(REQUIRED_BUCKETS),
         "pair_buckets": flattened,
-        "selected_margin": selected,
+        "qualification": qualification,
     }
 
 
@@ -989,7 +992,7 @@ def finalize_native_calibration(
     final = _finalize_artifacts(
         artifacts, orchestration=orchestration, expected_provenance=stable_provenance
     )
-    cache = _cache_v2(final)
+    cache = _cache_v3(final)
     parse_calibration_cache_summary(cache)
     _write_json_atomically(Path(output_path), final)
     _write_json_atomically(Path(cache_path), cache)
@@ -1035,7 +1038,7 @@ def run_native_calibration(
     budget = min(MAX_CALIBRATION_BUDGET_SECONDS, max(6, math.floor(timeout)))
     result = _run_process(_find_binary(), budget_seconds=budget, timeout_seconds=timeout, samples=FULL_SAMPLE_COUNT)
     raw_output = Path(output_path) if output_path is not None else Path(".cache/calibration-native.json")
-    cache = _cache_v2(result)
+    cache = _cache_v3(result)
     # Validation happens before either write; an invalid run leaves an old
     # cache untouched.
     parse_calibration_cache_summary(cache)
@@ -1055,9 +1058,11 @@ def run_published_native_calibration(
     result = run_native_calibration(
         mode="quick", output_path=output_path, cache_path=cache_path, timeout_seconds=timeout_seconds
     )
-    summary: CalibrationCacheSummary = parse_calibration_cache_summary(_cache_v2(result))
+    summary: CalibrationCacheSummary = parse_calibration_cache_summary(_cache_v3(result))
     return PublishedCalibrationResult(
+        status=summary.status,
         margin_us=summary.margin_us,
+        candidate_margin_us=summary.candidate_margin_us,
         source=summary.source,
         sample_count=summary.sample_count,
         cache_path=Path(cache_path),
@@ -1068,7 +1073,12 @@ def run_published_native_calibration(
         worst_bucket=summary.worst_bucket,
         global_shrink_p99_us=summary.global_shrink_p99_us,
         guard_us=summary.guard_us,
-        effective_min_hold_us=materialize_hold_us(hold_frames, fps, summary.margin_us),
+        ceiling_us=summary.ceiling_us,
+        effective_min_hold_us=(
+            materialize_hold_us(hold_frames, fps, summary.margin_us)
+            if summary.status is CalibrationStatus.VALID and summary.margin_us is not None
+            else None
+        ),
     )
 
 
@@ -1076,7 +1086,6 @@ __all__ = [
     "CALIBRATION_ARTIFACT_SCHEMA_VERSION",
     "FULL_POLYPHONIES",
     "FULL_SAMPLE_COUNT",
-    "CalibrationQuantiles",
     "NativeCalibrationError",
     "PublishedCalibrationResult",
     "calibration_bucket_keys",

--- a/src/sky_music/ui/picker_metadata.py
+++ b/src/sky_music/ui/picker_metadata.py
@@ -85,6 +85,7 @@ _PERSISTENT_POLICY_ATTRS: tuple[str, ...] = (
     "min_hold_us",
     "min_hold_margin_us",
     "min_hold_margin_source",
+    "down_late_grace_us",
     "focus_restore_grace_us",
     "same_key_conflict_policy",
     "frame_us",
@@ -939,7 +940,9 @@ def get_song_ui_metadata(
         resolver = None
 
         song = _song_repository.load(song_path)
-        policy = session.resolve_effective_policy(cfg)
+        from sky_music.orchestration.calibrated_policy import resolve_calibrated_policy
+
+        policy = resolve_calibrated_policy(session, cfg if cfg is not None else AppConfig())
         sched = build_key_actions(
             song,
             policy=policy,
@@ -1292,7 +1295,7 @@ def clear_metadata_cache(*, clear_persistent: bool = False) -> None:
 def invalidate_policy_metadata() -> None:
     """Clear only the session/policy-dependent in-memory caches.
 
-    Call this after a successful native input-latency calibration so that
+    Call this after a completed native host input-delivery calibration so that
     subsequent picker renders recompute risk and recommended-hold data
     against the new device margin.  Raw song parse results and the
     policy-independent ``_raw_cache`` are intentionally preserved.

--- a/src/sky_music/ui/textual_app/app.py
+++ b/src/sky_music/ui/textual_app/app.py
@@ -775,6 +775,7 @@ class SkyPickerApp(App[SongPickerResult | None]):
             min_hold_us=int(plan.active_policy.min_hold_us),
             min_hold_margin_us=int(plan.active_policy.min_hold_margin_us),
             min_hold_margin_source=plan.active_policy.min_hold_margin_source,
+            down_late_grace_us=int(plan.active_policy.down_late_grace_us),
             pre_roll_us=max(0, int(self.countdown_seconds)) * 1_000_000,
         )
         engine.telemetry.record_schedule_metadata(plan.sched_meta)

--- a/src/sky_music/ui/textual_app/keymap.py
+++ b/src/sky_music/ui/textual_app/keymap.py
@@ -46,7 +46,7 @@ COMMANDS: list[CommandSpec] = [
     CommandSpec("fps", "f", "FPS Sync", "Synchronize with game frame rate", "Playback"),
     CommandSpec("calibration", "", "Telemetry Playback Recommendation", "Analyze the latest playback telemetry and suggest hold/tempo changes", "Playback"),
     CommandSpec("dry_run", "d", "Toggle Dry-run", "Simulate without sending keys", "Playback"),
-    CommandSpec("calibrate_latency", "c", "Input Latency Calibration", "Measure host-side injected input delivery latency", "Playback"),
+    CommandSpec("calibrate_latency", "c", "Host Input Delivery Calibration", "Measure host-side injected Raw Input delivery", "Playback"),
     CommandSpec("hud", "h", "Toggle HUD", "Show/hide TUI HUD and Debug panel", "Interface"),
     CommandSpec("telemetry", "F3", "Toggle Telemetry", "Enable/disable CSV logging", "Interface"),
     CommandSpec("reload", "Ctrl+R", "Reload Songs", "Refresh songs directory", "Library"),

--- a/src/sky_music/ui/textual_app/modals.py
+++ b/src/sky_music/ui/textual_app/modals.py
@@ -164,21 +164,21 @@ class OptionModal(PickerModal[object | None]):
 
 
 class CalibrationProgressModal(PickerModal[None]):
-    """Modal displayed while input latency calibration is actively running."""
+    """Modal displayed while host input delivery calibration is running."""
 
     BINDINGS: list[tuple[str, str, str]] = []
 
     def __init__(self, *, theme_name: str = "aurora") -> None:
         PickerModal.__init__(
             self,
-            "Input Latency Calibration",
+            "Host Input Delivery Calibration",
             [],
             theme_name=theme_name,
         )
 
     def compose_modal_content(self) -> ComposeResult:
         text = (
-            "Input latency calibration is running.\n\n"
+            "Host input delivery calibration is running.\n\n"
             "Keep the separate calibration window focused.\n"
             "Keyboard commands are temporarily disabled."
         )

--- a/src/sky_music/ui/textual_app/screens/picker.py
+++ b/src/sky_music/ui/textual_app/screens/picker.py
@@ -1326,7 +1326,7 @@ class PickerScreen(Screen[SongPickerResult]):
 
         self.app.push_screen(
             OptionModal(
-                "Input Latency Calibration",
+                "Host Input Delivery Calibration",
                 options,
                 info_text=text,
                 theme_name=self.active_theme,
@@ -1338,6 +1338,7 @@ class PickerScreen(Screen[SongPickerResult]):
         import asyncio
         from functools import partial
 
+        from sky_music.infrastructure.calibration_loader import CalibrationStatus
         from sky_music.platform.win32.native_calibration import (
             run_published_native_calibration,
         )
@@ -1390,25 +1391,52 @@ class PickerScreen(Screen[SongPickerResult]):
 
         assert published is not None
 
-        # Invalidate session/policy-dependent picker metadata so the next render
-        # uses the new device_cache margin.
+        # The completed measurement always published a new v3 cache, including
+        # an unhealthy out-of-envelope result.  Invalidate metadata so the next
+        # render resolves the new policy source.
         invalidate_policy_metadata()
         self._replace_metadata_coordinator()
 
-        self.app.push_screen(
-                InfoModal(
-                    "Input Latency Calibration Complete",
-                    f"Host delivery hold-shrink p99: {published.global_shrink_p99_us} \u00b5s\n"
-                    f"Worst measured bucket: {published.worst_bucket}\n"
-                    f"Calibrated device margin: {published.margin_us} \u00b5s\n"
-                    f"Policy guard: {published.guard_us} \u00b5s\n"
-                    f"Materialized authored hold: {published.effective_min_hold_us} \u00b5s (selected frame hold + calibrated margin)\n"
-                    f"Clean pairs per required bucket: {published.sample_count}\n"
-                    f"Evidence: {published.evidence_kind}\n"
-                    f"Cache: {published.cache_path}",
-                    theme_name=self.active_theme,
-                )
-        )
+        if published.status is CalibrationStatus.OUT_OF_ENVELOPE:
+            message = (
+                "Host Input Delivery Calibration: OUT OF ENVELOPE\n\n"
+                f"Host delivery hold-shrink p99 : {published.global_shrink_p99_us} \u00b5s\n"
+                f"Worst measured bucket          : {published.worst_bucket}\n"
+                f"Policy guard                   : {published.guard_us} \u00b5s\n"
+                f"Required hold correction       : {published.candidate_margin_us} \u00b5s\n"
+                f"Trusted correction ceiling    : {published.ceiling_us} \u00b5s\n\n"
+                "Applied calibrated margin      : NONE\n"
+                "Playback hold fallback         : 500 \u00b5s (not calibrated)\n"
+                f"Clean pairs / required bucket  : {published.sample_count}\n"
+                f"Evidence                       : {published.evidence_kind}\n"
+                f"Cache                          : {published.cache_path}\n\n"
+                "Note-On timestamps: unchanged\n\n"
+                "Reason:\n"
+                "Measured host delivery behavior is outside the trusted\n"
+                "calibration correction envelope."
+            )
+            title = "Host Input Delivery Calibration: OUT OF ENVELOPE"
+        else:
+            assert published.status is CalibrationStatus.VALID
+            assert published.margin_us is not None
+            assert published.effective_min_hold_us is not None
+            message = (
+                "Host Input Delivery Calibration: VALID\n\n"
+                f"Host delivery hold-shrink p99 : {published.global_shrink_p99_us} \u00b5s\n"
+                f"Worst measured bucket          : {published.worst_bucket}\n"
+                f"Policy guard                   : {published.guard_us} \u00b5s\n"
+                f"Candidate hold correction      : {published.candidate_margin_us} \u00b5s\n"
+                f"Applied hold margin            : {published.margin_us} \u00b5s\n"
+                f"Trusted correction ceiling     : {published.ceiling_us} \u00b5s\n"
+                f"Materialized authored hold     : {published.effective_min_hold_us} \u00b5s\n"
+                f"Clean pairs / required bucket  : {published.sample_count}\n"
+                f"Evidence                       : {published.evidence_kind}\n"
+                f"Cache                          : {published.cache_path}\n\n"
+                "Note-On timestamps: unchanged"
+            )
+            title = "Host Input Delivery Calibration: VALID"
+
+        self.app.push_screen(InfoModal(title, message, theme_name=self.active_theme))
 
 
     def action_open_calibration(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,9 @@ def isolate_input_latency_cache(request, monkeypatch):
     """Isolate every test from a real ``.cache/input_latency.json`` so a
     cached run cannot pollute a test that does not opt in.
 
-    We patch ``sky_music.infrastructure.calibration_loader.load_calibration_resolution``
-    (the source module) so every production consumer sees the mock.
+    We patch both the source module and the binding captured by
+    ``calibrated_policy`` so every production consumer sees the mock even when
+    that module was imported during pytest collection.
     """
     nodeid = request.node.nodeid
     if (
@@ -40,13 +41,23 @@ def isolate_input_latency_cache(request, monkeypatch):
     ):
         return
     import sky_music.infrastructure.calibration_loader as loader_module
+    import sky_music.orchestration.calibrated_policy as calibrated_policy_module
+
+    def _default_resolution(*_args: object, **_kwargs: object):
+        return loader_module.CalibrationLoadResult(
+            status=loader_module.CalibrationStatus.UNCALIBRATED,
+            resolved_margin_us=500,
+            margin_source=loader_module.SOURCE_DEFAULT_500,
+            summary=None,
+        )
+
     monkeypatch.setattr(
         loader_module,
         "load_calibration_resolution",
-        lambda: loader_module.CalibrationLoadResult(
-            status=loader_module.CalibrationStatus.UNCALIBRATED,
-            resolved_margin_us=500,
-            margin_source="default_500",
-            summary=None,
-        ),
+        _default_resolution,
+    )
+    monkeypatch.setattr(
+        calibrated_policy_module,
+        "load_calibration_resolution",
+        _default_resolution,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,9 @@
 Ensures that ``src/`` is on ``sys.path`` for every test session so individual
 test files do not need to call ``sys.path.insert`` themselves.
 
-Also autouse-mocks the calibration loader so non-calibration tests are
+Also autouse-mocks the calibration resolver so non-calibration tests are
 isolated from a real ``.cache/input_latency.json`` artefact in the working
-tree. The three calibration-focused tests opt out via the nodeid check
-below so they can exercise the real loader.
+tree. Calibration-focused tests opt out via the nodeid check below.
 """
 from __future__ import annotations
 
@@ -28,11 +27,8 @@ def isolate_input_latency_cache(request, monkeypatch):
     """Isolate every test from a real ``.cache/input_latency.json`` so a
     cached run cannot pollute a test that does not opt in.
 
-    We patch ``sky_music.infrastructure.calibration_loader.load_calibrated_margin_recommendation``
-    (the source module) so every consumer -- the orchestration
-    ``RuntimeSessionState.apply_session`` and any test that imports the
-    loader directly -- sees the mock. Tests whose nodeid contains one of
-    the three calibration-loader opt-out markers run unmocked.
+    We patch ``sky_music.infrastructure.calibration_loader.load_calibration_resolution``
+    (the source module) so every production consumer sees the mock.
     """
     nodeid = request.node.nodeid
     if (
@@ -40,13 +36,17 @@ def isolate_input_latency_cache(request, monkeypatch):
         or "test_calibrated_margin_recommendation_poison_cases" in nodeid
         or "test_calibrated_margin_rejects_low_sample_count" in nodeid
         or "test_calibration_regression" in nodeid
+        or "test_load_calibration_resolution_states" in nodeid
     ):
         return
     import sky_music.infrastructure.calibration_loader as loader_module
     monkeypatch.setattr(
         loader_module,
-        "load_calibrated_margin_recommendation",
-        lambda: (None, "default_500"),
+        "load_calibration_resolution",
+        lambda: loader_module.CalibrationLoadResult(
+            status=loader_module.CalibrationStatus.UNCALIBRATED,
+            resolved_margin_us=500,
+            margin_source="default_500",
+            summary=None,
+        ),
     )
-
-

--- a/tests/test_calibration_regression_fix.py
+++ b/tests/test_calibration_regression_fix.py
@@ -346,6 +346,7 @@ class TestPickerMetadataSignatureIncludesCalibration:
             "min_hold_margin_source must be part of the persistent cache key signature"
         )
         assert "min_hold_margin_us" in sig
+        assert sig["down_late_grace_us"] == 500
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_calibration_regression_fix.py
+++ b/tests/test_calibration_regression_fix.py
@@ -21,11 +21,13 @@ from sky_music.domain.session_context import PlaybackSessionContext
 from sky_music.infrastructure.calibration_loader import (
     SOURCE_DEFAULT_500,
     SOURCE_DEVICE_CACHE,
-    load_calibrated_margin_recommendation,
+    CalibrationLoadResult,
+    CalibrationStatus,
+    load_calibration_resolution,
 )
 
 # ---------------------------------------------------------------------------
-# Helper – minimal valid cache-v2 payload
+# Helper – minimal valid cache-v3 payload
 # ---------------------------------------------------------------------------
 
 def _signed_stats(p99: int = 6) -> dict[str, int]:
@@ -36,10 +38,13 @@ def _signed_stats(p99: int = 6) -> dict[str, int]:
 
 _REQUIRED_BUCKETS = ("1/hot", "1/cold", "5/hot", "5/cold", "15/hot", "15/cold")
 _INTEGRATION_CACHE: dict = {
-    "version": 2,
+    "version": 3,
+    "status": "valid",
     "source": "device_cache",
     "evidence_kind": "injected_raw_input_delivery_proxy",
-    "source_formula_version": 2,
+    "source_formula_version": 3,
+    "native_source_fingerprint": "test-fingerprint",
+    "rustc_version": "rustc test",
     "native_calibration_version": 9,
     "measurement_protocol_version": 4,
     "source_git_sha": "test-sha",
@@ -56,21 +61,35 @@ _INTEGRATION_CACHE: dict = {
         }
         for key in _REQUIRED_BUCKETS
     },
-    "selected_margin": {
+    "qualification": {
         "basis": "max_required_bucket_p99_positive_pair_hold_shrink",
         "worst_bucket": "15/cold",
         "global_shrink_p99_us": 700,
         "guard_us": 100,
         "floor_us": 300,
         "ceiling_us": 2000,
-        "recommended_margin_us": 800,
+        "candidate_margin_us": 800,
+        "applied_margin_us": 800,
     },
 }
 
 _EXPECTED_MARGIN_US = 800
 
-# Correct patch target: the function as imported into calibrated_policy's namespace
-_LOADER_PATCH = "sky_music.orchestration.calibrated_policy.load_calibrated_margin_recommendation"
+def _resolution(
+    margin_us: int,
+    source: str,
+    status: CalibrationStatus = CalibrationStatus.VALID,
+) -> CalibrationLoadResult:
+    return CalibrationLoadResult(
+        status=status,
+        resolved_margin_us=margin_us,
+        margin_source=source,
+        summary=None,
+    )
+
+
+# Correct patch target: the typed resolver imported by calibrated_policy.
+_LOADER_PATCH = "sky_music.orchestration.calibrated_policy.load_calibration_resolution"
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +106,7 @@ class TestResolveCalibratedPolicy:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(_LOADER_PATCH, return_value=(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
+        with patch(_LOADER_PATCH, return_value=_resolution(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
             policy = resolve_calibrated_policy(session, cfg)
 
         assert int(policy.min_hold_margin_us) == _EXPECTED_MARGIN_US
@@ -100,7 +119,10 @@ class TestResolveCalibratedPolicy:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(_LOADER_PATCH, return_value=(None, SOURCE_DEFAULT_500)):
+        with patch(
+            _LOADER_PATCH,
+            return_value=_resolution(500, SOURCE_DEFAULT_500, CalibrationStatus.UNCALIBRATED),
+        ):
             policy = resolve_calibrated_policy(session, cfg)
 
         assert policy.min_hold_margin_source == SOURCE_DEFAULT_500
@@ -114,7 +136,10 @@ class TestResolveCalibratedPolicy:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(_LOADER_PATCH, return_value=(None, SOURCE_DEFAULT_500)):
+        with patch(
+            _LOADER_PATCH,
+            return_value=_resolution(500, SOURCE_DEFAULT_500, CalibrationStatus.INVALID_CACHE),
+        ):
             policy = resolve_calibrated_policy(session, cfg)
 
         assert policy.min_hold_margin_source == SOURCE_DEFAULT_500
@@ -128,7 +153,7 @@ class TestPreparePlaybackUsesCalibration:
     """Tests that prepare_playback (Textual path) uses the calibrated margin."""
 
     # Patch at the import site of playback_controller (where it imports from calibrated_policy)
-    _PREP_PATCH = "sky_music.orchestration.calibrated_policy.load_calibrated_margin_recommendation"
+    _PREP_PATCH = "sky_music.orchestration.calibrated_policy.load_calibration_resolution"
 
     def _make_song(self) -> Song:
         return Song(
@@ -150,7 +175,7 @@ class TestPreparePlaybackUsesCalibration:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(self._PREP_PATCH, return_value=(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
+        with patch(self._PREP_PATCH, return_value=_resolution(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
             plan = prepare_playback(song, session, cfg)
 
         assert isinstance(plan, PlaybackPlan)
@@ -170,7 +195,10 @@ class TestPreparePlaybackUsesCalibration:
 
         # Explicitly mock the loader — this test opts out of the conftest autouse mock
         # because its nodeid contains "test_calibration_regression".
-        with patch(_LOADER_PATCH, return_value=(None, SOURCE_DEFAULT_500)):
+        with patch(
+            _LOADER_PATCH,
+            return_value=_resolution(500, SOURCE_DEFAULT_500, CalibrationStatus.UNCALIBRATED),
+        ):
             plan = prepare_playback(song, session, cfg)
         assert isinstance(plan, PlaybackPlan)
         assert plan.active_policy.min_hold_margin_source == SOURCE_DEFAULT_500
@@ -209,6 +237,17 @@ class TestConsolePolicyMatchesTextual:
         )
 
 
+def test_runtime_session_uses_only_the_single_calibrated_policy_resolver() -> None:
+    import inspect
+
+    from sky_music.orchestration import runtime_session
+
+    source = inspect.getsource(runtime_session)
+    assert "resolve_calibrated_policy" in source
+    assert "load_calibrated_margin_recommendation" not in source
+    assert "load_calibration_resolution" not in source
+
+
 # ---------------------------------------------------------------------------
 # 4. Profile/tempo rebuild preserves calibration
 # ---------------------------------------------------------------------------
@@ -233,7 +272,7 @@ class TestRebuildPreservesCalibration:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(_LOADER_PATCH, return_value=(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
+        with patch(_LOADER_PATCH, return_value=_resolution(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
             plan = prepare_playback(song, session, cfg)
             assert isinstance(plan, PlaybackPlan)
             rebuilt = rebuild_with(plan, hold_frames=1.5)
@@ -253,7 +292,7 @@ class TestRebuildPreservesCalibration:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(_LOADER_PATCH, return_value=(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
+        with patch(_LOADER_PATCH, return_value=_resolution(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
             plan = prepare_playback(song, session, cfg)
             assert isinstance(plan, PlaybackPlan)
             rebuilt = rebuild_with(plan, tempo=0.9)
@@ -271,7 +310,7 @@ class TestPickerMetadataSignatureIncludesCalibration:
 
     # _effective_policy_signature does a local import of resolve_calibrated_policy,
     # so we patch at the single source: the calibrated_policy module's loader reference.
-    _SIG_PATCH = "sky_music.orchestration.calibrated_policy.load_calibrated_margin_recommendation"
+    _SIG_PATCH = "sky_music.orchestration.calibrated_policy.load_calibration_resolution"
 
     def test_signature_changes_when_margin_changes(self) -> None:
         from sky_music.ui.picker_metadata import _effective_policy_signature
@@ -279,10 +318,13 @@ class TestPickerMetadataSignatureIncludesCalibration:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        with patch(self._SIG_PATCH, return_value=(None, SOURCE_DEFAULT_500)):
+        with patch(
+            self._SIG_PATCH,
+            return_value=_resolution(500, SOURCE_DEFAULT_500, CalibrationStatus.UNCALIBRATED),
+        ):
             sig_default = _effective_policy_signature(session, cfg)
 
-        with patch(self._SIG_PATCH, return_value=(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
+        with patch(self._SIG_PATCH, return_value=_resolution(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
             sig_device = _effective_policy_signature(session, cfg)
 
         assert sig_default != sig_device, (
@@ -371,7 +413,7 @@ class TestKeymapCommandRename:
         cmd = self._get_command("calibrate_latency")
         assert cmd is not None, "calibrate_latency command missing from COMMANDS"
         assert cmd.key == "c", f"Expected key='c', got key={cmd.key!r}"
-        assert "Input Latency" in cmd.label, f"Label should say 'Input Latency', got {cmd.label!r}"
+        assert cmd.label == "Host Input Delivery Calibration"
 
     def test_calibration_has_no_direct_key(self) -> None:
         """Telemetry recommendation command must not be bound to 'c'."""
@@ -435,18 +477,19 @@ class TestCalibrationRegressionIntegration:
     def test_calibration_regression_cache_to_policy(self) -> None:
         """Given a valid .cache/input_latency.json, the active policy margin == 800 µs."""
         # Act: load the margin directly from synthetic data (avoids filesystem)
-        margin_us, source = load_calibrated_margin_recommendation(data=_INTEGRATION_CACHE)
+        resolution = load_calibration_resolution(data=_INTEGRATION_CACHE)
 
-        assert source == SOURCE_DEVICE_CACHE
-        assert margin_us == _EXPECTED_MARGIN_US
+        assert resolution.status is CalibrationStatus.VALID
+        assert resolution.margin_source == SOURCE_DEVICE_CACHE
+        assert resolution.resolved_margin_us == _EXPECTED_MARGIN_US
 
         # Build a policy through the resolver using the loaded margin
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
         policy = session.resolve_effective_policy(
             cfg,
-            calibrated_margin_us=margin_us,
-            calibrated_margin_source=source,
+            hold_margin_us=resolution.resolved_margin_us,
+            hold_margin_source=resolution.margin_source,
         )
 
         assert int(policy.min_hold_margin_us) == _EXPECTED_MARGIN_US
@@ -469,8 +512,8 @@ class TestCalibrationRegressionIntegration:
         cfg = AppConfig()
         policy = session.resolve_effective_policy(
             cfg,
-            calibrated_margin_us=_EXPECTED_MARGIN_US,
-            calibrated_margin_source=SOURCE_DEVICE_CACHE,
+            hold_margin_us=_EXPECTED_MARGIN_US,
+            hold_margin_source=SOURCE_DEVICE_CACHE,
         )
 
         sched = build_key_actions(song, policy=policy, scan_code_mode="physical")
@@ -488,12 +531,15 @@ class TestCalibrationRegressionIntegration:
         session = PlaybackSessionContext.default(fps=60)
         cfg = AppConfig()
 
-        _SIG_PATCH = "sky_music.orchestration.calibrated_policy.load_calibrated_margin_recommendation"
+        _SIG_PATCH = "sky_music.orchestration.calibrated_policy.load_calibration_resolution"
 
-        with patch(_SIG_PATCH, return_value=(None, SOURCE_DEFAULT_500)):
+        with patch(
+            _SIG_PATCH,
+            return_value=_resolution(500, SOURCE_DEFAULT_500, CalibrationStatus.UNCALIBRATED),
+        ):
             sig_before = _effective_policy_signature(session, cfg)
 
-        with patch(_SIG_PATCH, return_value=(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
+        with patch(_SIG_PATCH, return_value=_resolution(_EXPECTED_MARGIN_US, SOURCE_DEVICE_CACHE)):
             sig_after = _effective_policy_signature(session, cfg)
 
         assert sig_before != sig_after, (
@@ -507,7 +553,7 @@ class TestCalibrationRegressionIntegration:
 # ---------------------------------------------------------------------------
 
 class TestPublishedCalibrationResultContract:
-    """Tests for typed paired evidence and strict cache-v2 parsing."""
+    """Tests for typed paired evidence and strict v3/v2 cache parsing."""
 
     def test_raw_native_result_has_no_ui_down_us_contract(self) -> None:
         """Raw native dict has buckets, not top-level down_us."""
@@ -518,7 +564,9 @@ class TestPublishedCalibrationResultContract:
         )
 
         pub = PublishedCalibrationResult(
+            status=CalibrationStatus.VALID,
             margin_us=800,
+            candidate_margin_us=800,
             source="device_cache",
             sample_count=100,
             cache_path=Path(".cache/input_latency.json"),
@@ -529,6 +577,7 @@ class TestPublishedCalibrationResultContract:
             worst_bucket="15/cold",
             global_shrink_p99_us=700,
             guard_us=100,
+            ceiling_us=2_000,
         )
         assert pub.global_shrink_p99_us == 700
         assert pub.evidence_kind == "injected_raw_input_delivery_proxy"
@@ -562,8 +611,8 @@ class TestPublishedCalibrationResultContract:
         cache = json.loads(json.dumps(_INTEGRATION_CACHE))
         for bucket in cache["pair_buckets"].values():
             bucket["pair_worst_shrink_us"] = _signed_stats(-2)
-        cache["selected_margin"].update(
-            {"worst_bucket": "1/hot", "global_shrink_p99_us": 0, "recommended_margin_us": 300}
+        cache["qualification"].update(
+            {"worst_bucket": "1/hot", "global_shrink_p99_us": 0, "candidate_margin_us": 100, "applied_margin_us": 300}
         )
         summary = parse_calibration_cache_summary(cache)
         assert summary.margin_us == 300
@@ -618,7 +667,9 @@ class TestPublishedCalibrationResultContract:
         )
 
         pub = PublishedCalibrationResult(
+            status=CalibrationStatus.VALID,
             margin_us=800,
+            candidate_margin_us=800,
             source="device_cache",
             sample_count=100,
             cache_path=Path(".cache/input_latency.json"),
@@ -629,6 +680,7 @@ class TestPublishedCalibrationResultContract:
             worst_bucket="15/cold",
             global_shrink_p99_us=700,
             guard_us=100,
+            ceiling_us=2_000,
         )
 
         msg = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -314,6 +314,39 @@ def test_cli_doctor_routing(monkeypatch) -> None:
     assert called_args["input_check"] is False
 
 
+def test_doctor_calibrate_returns_one_for_out_of_envelope(monkeypatch, capsys) -> None:
+    from types import SimpleNamespace
+
+    from sky_music.cli import doctor_command
+    from sky_music.infrastructure.calibration_loader import CalibrationStatus
+    from sky_music.platform.win32 import native_calibration, window_target
+
+    monkeypatch.setattr(window_target, "get_sky_window", lambda: None)
+    monkeypatch.setattr(
+        native_calibration,
+        "run_published_native_calibration",
+        lambda: SimpleNamespace(
+            status=CalibrationStatus.OUT_OF_ENVELOPE,
+            global_shrink_p99_us=12_088,
+            worst_bucket="15/hot",
+            candidate_margin_us=12_188,
+            ceiling_us=2_000,
+            margin_us=None,
+            effective_min_hold_us=None,
+            sample_count=100,
+        ),
+    )
+
+    result = doctor_command.run_doctor_command(
+        full=False, timing=False, input_check=False, calibrate=True
+    )
+
+    assert result == 1
+    output = capsys.readouterr().out
+    assert "Calibration measurement completed, but host qualification failed." in output
+    assert "Calibration complete successfully" not in output
+
+
 def test_doctor_fps_advisory_prints_for_fps_above_60(capsys, monkeypatch) -> None:
     """Phase C: Doctor FPS advisory prints when configured fps > 60."""
     monkeypatch.setattr("sky_music.infrastructure.doctor.load_config", lambda: type("cfg", (), {"game_fps": 144})())
@@ -322,7 +355,6 @@ def test_doctor_fps_advisory_prints_for_fps_above_60(capsys, monkeypatch) -> Non
     captured = capsys.readouterr()
     assert "Configured game FPS is 144" in captured.out
     assert "Notes shorter than one 60 fps frame" in captured.out
-
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -334,6 +334,9 @@ def test_doctor_calibrate_returns_one_for_out_of_envelope(monkeypatch, capsys) -
             margin_us=None,
             effective_min_hold_us=None,
             sample_count=100,
+            guard_us=100,
+            evidence_kind="injected_raw_input_delivery_proxy",
+            cache_path=Path(".cache/input_latency.json"),
         ),
     )
 
@@ -344,6 +347,9 @@ def test_doctor_calibrate_returns_one_for_out_of_envelope(monkeypatch, capsys) -
     assert result == 1
     output = capsys.readouterr().out
     assert "Calibration measurement completed, but host qualification failed." in output
+    assert "Policy guard (us): 100" in output
+    assert "Evidence: injected_raw_input_delivery_proxy" in output
+    assert "Cache: .cache/input_latency.json" in output
     assert "Calibration complete successfully" not in output
 
 
@@ -355,6 +361,5 @@ def test_doctor_fps_advisory_prints_for_fps_above_60(capsys, monkeypatch) -> Non
     captured = capsys.readouterr()
     assert "Configured game FPS is 144" in captured.out
     assert "Notes shorter than one 60 fps frame" in captured.out
-
 
 

--- a/tests/test_min_hold_margin.py
+++ b/tests/test_min_hold_margin.py
@@ -25,12 +25,51 @@ def test_zero_margin_is_valid_for_one_frame() -> None:
     assert policy.hold_us == policy.min_hold_us == policy.frame_us
 
 
-def test_hold_margin_is_also_the_authorized_down_lateness_budget() -> None:
-    policy = FrameTimingPolicy.from_hold_frames(1.0, 60, margin_us=500)
-    authored_down = 100_000
-    authored_up = authored_down + policy.min_hold_us
-    latest_allowed_down = authored_down + policy.min_hold_margin_us
+def test_calibrated_hold_margin_does_not_change_down_late_grace() -> None:
+    policy = FrameTimingPolicy.from_hold_frames(1.0, 60, margin_us=1_800)
 
-    assert policy.min_hold_us == 17_167
-    assert authored_up - latest_allowed_down == 16_667
-    assert authored_up - latest_allowed_down == policy.min_hold_us - policy.min_hold_margin_us
+    assert policy.min_hold_margin_us == 1_800
+    assert policy.down_late_grace_us == 500
+
+
+def test_down_late_grace_does_not_change_materialized_hold() -> None:
+    a = FrameTimingPolicy.from_hold_frames(
+        1.0, 60, margin_us=800, down_late_grace_us=100
+    )
+    b = FrameTimingPolicy.from_hold_frames(
+        1.0, 60, margin_us=800, down_late_grace_us=500
+    )
+
+    assert a.min_hold_us == b.min_hold_us
+
+
+def test_calibration_does_not_shift_authored_note_on_timestamps() -> None:
+    from sky_music.domain import Millis, Note, NoteKey, Song
+    from sky_music.domain.scheduler import build_key_actions
+    from sky_music.domain.scheduler_types import ActionKind
+
+    song = Song(
+        name="timestamp-invariant",
+        notes=(
+            Note(time_ms=Millis(0), key=NoteKey("Key0")),
+            Note(time_ms=Millis(1_000), key=NoteKey("Key1")),
+        ),
+    )
+    actions_a = build_key_actions(
+        song, policy=FrameTimingPolicy.from_hold_frames(1.0, 60, margin_us=500)
+    ).actions
+    actions_b = build_key_actions(
+        song, policy=FrameTimingPolicy.from_hold_frames(1.0, 60, margin_us=1_800)
+    ).actions
+
+    downs_a = [
+        (action.scan_codes, int(action.at_us))
+        for action in actions_a
+        if action.kind is ActionKind.DOWN
+    ]
+    downs_b = [
+        (action.scan_codes, int(action.at_us))
+        for action in actions_b
+        if action.kind is ActionKind.DOWN
+    ]
+    assert downs_a == downs_b

--- a/tests/test_native_calibration.py
+++ b/tests/test_native_calibration.py
@@ -194,13 +194,15 @@ def test_directional_execution_is_rejected() -> None:
         )
 
 
-def test_cache_v2_uses_max_positive_p99_and_preserves_signed_values() -> None:
+def test_cache_v3_uses_max_positive_p99_and_preserves_signed_values() -> None:
     result = _native_result(p99_by_key={"15/cold": 42, "5/hot": -8})
-    cache = native_calibration._cache_v2(result)
+    cache = native_calibration._cache_v3(result)
     summary = loader.parse_calibration_cache_summary(cache)
+    assert cache["version"] == 3
     assert summary.global_shrink_p99_us == 42
     assert summary.worst_bucket == "15/cold"
     assert summary.margin_us == 300
+    assert summary.candidate_margin_us == 142
     assert summary.pair_buckets["5/hot"].pair_worst_shrink_us.p99 == -8
 
 
@@ -211,11 +213,162 @@ def test_cache_v1_is_rejected_and_falls_back() -> None:
 
 
 def test_cache_requires_100_clean_pairs_per_cell() -> None:
-    cache = native_calibration._cache_v2(_native_result())
+    cache = native_calibration._cache_v3(_native_result())
     cache["pair_buckets"]["1/hot"]["clean_pair_count"] = 99  # type: ignore[index]
     cache["pair_buckets"]["1/hot"]["rejected"] = 1  # type: ignore[index]
     with pytest.raises(ValueError, match="clean pairs"):
         loader.parse_calibration_cache_summary(cache)
+
+
+@pytest.mark.parametrize(
+    ("p99", "candidate", "status", "margin"),
+    [
+        (42, 142, loader.CalibrationStatus.VALID, 300),
+        (700, 800, loader.CalibrationStatus.VALID, 800),
+        (1_900, 2_000, loader.CalibrationStatus.VALID, 2_000),
+        (1_901, 2_001, loader.CalibrationStatus.OUT_OF_ENVELOPE, None),
+        (12_088, 12_188, loader.CalibrationStatus.OUT_OF_ENVELOPE, None),
+    ],
+)
+def test_qualification_boundaries(
+    p99: int,
+    candidate: int,
+    status: loader.CalibrationStatus,
+    margin: int | None,
+) -> None:
+    qualification = loader.qualify_calibration_margin(p99)
+    assert qualification.candidate_margin_us == candidate
+    assert qualification.status is status
+    assert qualification.applied_margin_us == margin
+
+
+def test_out_of_envelope_cache_keeps_candidate_and_no_applied_margin() -> None:
+    result = _native_result(
+        p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12088)
+    )
+    cache = native_calibration._cache_v3(result)
+    summary = loader.parse_calibration_cache_summary(cache)
+
+    assert summary.margin_us is None
+    assert summary.candidate_margin_us == 12_188
+    assert summary.status is loader.CalibrationStatus.OUT_OF_ENVELOPE
+    assert cache["qualification"]["applied_margin_us"] is None  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("candidate_margin_us", 2_000),
+        ("worst_bucket", "15/cold"),
+        ("global_shrink_p99_us", 0),
+    ],
+)
+def test_v3_rejects_tampered_qualification(field: str, value: object) -> None:
+    cache = native_calibration._cache_v3(_native_result())
+    cast(dict[str, object], cache["qualification"])[field] = value
+    with pytest.raises(ValueError):
+        loader.parse_calibration_cache_summary(cache)
+
+
+def test_v3_rejects_out_of_envelope_saturated_applied_margin() -> None:
+    cache = native_calibration._cache_v3(
+        _native_result(
+            p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12088)
+        )
+    )
+    cast(dict[str, object], cache["qualification"])["applied_margin_us"] = 2_000
+    with pytest.raises(ValueError):
+        loader.parse_calibration_cache_summary(cache)
+
+
+def test_v3_rejects_wrong_status_and_valid_null_applied_margin() -> None:
+    out_cache = native_calibration._cache_v3(
+        _native_result(
+            p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12_088)
+        )
+    )
+    out_cache["status"] = "valid"
+    with pytest.raises(ValueError):
+        loader.parse_calibration_cache_summary(out_cache)
+
+    valid_cache = native_calibration._cache_v3(_native_result())
+    cast(dict[str, object], valid_cache["qualification"])["applied_margin_us"] = None
+    with pytest.raises(ValueError):
+        loader.parse_calibration_cache_summary(valid_cache)
+
+
+def test_v2_current_saturation_migrates_to_out_of_envelope() -> None:
+    v3 = native_calibration._cache_v3(
+        _native_result(
+            p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12088)
+        )
+    )
+    legacy = dict(v3)
+    legacy["version"] = 2
+    legacy["source_formula_version"] = 2
+    legacy.pop("status")
+    qualification = cast(dict[str, object], legacy.pop("qualification"))
+    legacy["selected_margin"] = {
+        "basis": qualification["basis"],
+        "worst_bucket": qualification["worst_bucket"],
+        "global_shrink_p99_us": qualification["global_shrink_p99_us"],
+        "guard_us": qualification["guard_us"],
+        "floor_us": qualification["floor_us"],
+        "ceiling_us": qualification["ceiling_us"],
+        "recommended_margin_us": 2_000,
+    }
+    summary = loader.parse_calibration_cache_summary(legacy)
+    assert summary.status is loader.CalibrationStatus.OUT_OF_ENVELOPE
+    assert summary.margin_us is None
+    assert summary.candidate_margin_us == 12_188
+
+
+def test_v2_tampered_legacy_recommendation_is_rejected() -> None:
+    v3 = native_calibration._cache_v3(_native_result(p99_by_key={"15/cold": 700}))
+    legacy = dict(v3)
+    legacy["version"] = 2
+    legacy["source_formula_version"] = 2
+    legacy.pop("status")
+    qualification = cast(dict[str, object], legacy.pop("qualification"))
+    legacy["selected_margin"] = {
+        "basis": qualification["basis"],
+        "worst_bucket": qualification["worst_bucket"],
+        "global_shrink_p99_us": qualification["global_shrink_p99_us"],
+        "guard_us": qualification["guard_us"],
+        "floor_us": qualification["floor_us"],
+        "ceiling_us": qualification["ceiling_us"],
+        "recommended_margin_us": 2_000,
+    }
+    with pytest.raises(ValueError):
+        loader.parse_calibration_cache_summary(legacy)
+
+
+def test_load_calibration_resolution_states() -> None:
+    missing = loader.load_calibration_resolution(data=None, cache_path=Path("does-not-exist.json"))
+    assert missing.status is loader.CalibrationStatus.UNCALIBRATED
+    assert missing.resolved_margin_us == 500
+    assert missing.margin_source == loader.SOURCE_DEFAULT_500
+
+    corrupt = loader.load_calibration_resolution(data={"version": 1})
+    assert corrupt.status is loader.CalibrationStatus.INVALID_CACHE
+    assert corrupt.resolved_margin_us == 500
+    assert corrupt.margin_source == loader.SOURCE_INVALID_CACHE_DEFAULT_500
+
+    valid_cache = native_calibration._cache_v3(
+        _native_result(p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 700))
+    )
+    valid = loader.load_calibration_resolution(data=valid_cache)
+    assert valid.status is loader.CalibrationStatus.VALID
+    assert valid.resolved_margin_us == 800
+    assert valid.margin_source == loader.SOURCE_DEVICE_CACHE
+
+    out_cache = native_calibration._cache_v3(
+        _native_result(p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12088))
+    )
+    out = loader.load_calibration_resolution(data=out_cache)
+    assert out.status is loader.CalibrationStatus.OUT_OF_ENVELOPE
+    assert out.resolved_margin_us == 500
+    assert out.margin_source == loader.SOURCE_OUT_OF_ENVELOPE_DEFAULT_500
 
 
 def test_diagnostic_run_writes_report_but_never_production_cache(
@@ -244,6 +397,27 @@ def test_invalid_quick_result_leaves_existing_cache_untouched(
     with pytest.raises(native_calibration.NativeCalibrationError):
         native_calibration.run_native_calibration(cache_path=cache)
     assert cache.read_text(encoding="utf-8") == "sentinel\n"
+
+
+def test_completed_out_of_envelope_measurement_overwrites_existing_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    cache = tmp_path / "input_latency.json"
+    cache.write_text("old cache\n", encoding="utf-8")
+    result = _native_result(
+        p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12_088)
+    )
+    monkeypatch.setattr(native_calibration, "_find_binary", lambda: tmp_path / "native.exe")
+    monkeypatch.setattr(native_calibration, "_run_process", lambda *args, **kwargs: result)
+
+    native_calibration.run_native_calibration(cache_path=cache)
+
+    summary = loader.parse_calibration_cache_summary(
+        json.loads(cache.read_text(encoding="utf-8"))
+    )
+    assert summary.status is loader.CalibrationStatus.OUT_OF_ENVELOPE
+    assert summary.margin_us is None
+    assert summary.candidate_margin_us == 12_188
 
 
 def test_full_configuration_is_six_pair_buckets() -> None:
@@ -367,6 +541,8 @@ def test_published_result_populates_effective_native_floor(
     )
 
     assert published.effective_min_hold_us == 16_967
+    assert published.status is loader.CalibrationStatus.VALID
+    assert published.candidate_margin_us == 106
 
     stressed = _native_result(p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 700))
     monkeypatch.setattr(native_calibration, "_run_process", lambda *args, **kwargs: stressed)
@@ -378,3 +554,18 @@ def test_published_result_populates_effective_native_floor(
     )
     assert stressed_published.margin_us == 800
     assert stressed_published.effective_min_hold_us == 17_467
+
+    out = _native_result(
+        p99_by_key=dict.fromkeys(native_calibration.REQUIRED_BUCKETS, 12088)
+    )
+    monkeypatch.setattr(native_calibration, "_run_process", lambda *args, **kwargs: out)
+    out_published = native_calibration.run_published_native_calibration(
+        output_path=tmp_path / "out-raw.json",
+        cache_path=tmp_path / "out-cache.json",
+        fps=60,
+        hold_frames=1.0,
+    )
+    assert out_published.status is loader.CalibrationStatus.OUT_OF_ENVELOPE
+    assert out_published.margin_us is None
+    assert out_published.candidate_margin_us == 12_188
+    assert out_published.effective_min_hold_us is None

--- a/tests/test_native_calibration.py
+++ b/tests/test_native_calibration.py
@@ -323,6 +323,32 @@ def test_v2_current_saturation_migrates_to_out_of_envelope() -> None:
     assert summary.candidate_margin_us == 12_188
 
 
+def test_v2_valid_margin_migrates_to_valid_v3_semantics() -> None:
+    v3 = native_calibration._cache_v3(
+        _native_result(p99_by_key={"15/cold": 700})
+    )
+    legacy = dict(v3)
+    legacy["version"] = 2
+    legacy["source_formula_version"] = 2
+    legacy.pop("status")
+    qualification = cast(dict[str, object], legacy.pop("qualification"))
+    legacy["selected_margin"] = {
+        "basis": qualification["basis"],
+        "worst_bucket": qualification["worst_bucket"],
+        "global_shrink_p99_us": qualification["global_shrink_p99_us"],
+        "guard_us": qualification["guard_us"],
+        "floor_us": qualification["floor_us"],
+        "ceiling_us": qualification["ceiling_us"],
+        "recommended_margin_us": 800,
+    }
+
+    summary = loader.parse_calibration_cache_summary(legacy)
+
+    assert summary.status is loader.CalibrationStatus.VALID
+    assert summary.margin_us == 800
+    assert summary.candidate_margin_us == 800
+
+
 def test_v2_tampered_legacy_recommendation_is_rejected() -> None:
     v3 = native_calibration._cache_v3(_native_result(p99_by_key={"15/cold": 700}))
     legacy = dict(v3)

--- a/tests/test_native_dispatch_runtime.py
+++ b/tests/test_native_dispatch_runtime.py
@@ -278,7 +278,7 @@ def test_runtime_forwards_explicit_down_late_grace_to_native_session(monkeypatch
     assert captured["down_late_grace_us"] == 500
 
 
-def test_playback_engine_forwards_hold_margin_without_deriving_it(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_playback_engine_keeps_hold_margin_and_down_late_grace_independent(monkeypatch: pytest.MonkeyPatch) -> None:
     from sky_music.domain import Song
     from sky_music.domain.domain import Microseconds, ScanCode
     from sky_music.domain.scheduler_types import ActionKind, KeyAction
@@ -306,11 +306,13 @@ def test_playback_engine_forwards_hold_margin_without_deriving_it(monkeypatch: p
         ),
         require_focus=False,
         min_hold_us=17_167,
-        min_hold_margin_us=500,
+        min_hold_margin_us=1_800,
+        down_late_grace_us=500,
     )
 
     assert engine._play_native() == engine_module.PLAYBACK_FINISHED
     assert captured["down_late_grace_us"] == 500
+    assert captured["down_late_grace_us"] != engine.min_hold_margin_us
 
 
 def test_runtime_does_not_focus_before_native_worker(

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -52,13 +52,14 @@ def test_metadata_cache_key_changes_when_hold_or_fps_changes() -> None:
 def test_effective_policy_uses_one_hold_source_and_margin_metadata() -> None:
     session = PlaybackSessionContext(hold_frames=1.25, fps=60)
     policy = session.resolve_effective_policy(
-        AppConfig(), calibrated_margin_us=800, calibrated_margin_source="device_cache"
+        AppConfig(), hold_margin_us=800, hold_margin_source="device_cache"
     )
 
     assert policy.hold_frames == 1.25
     assert policy.hold_us == policy.min_hold_us == 21_634
     assert policy.min_hold_margin_us == 800
     assert policy.min_hold_margin_source == "device_cache"
+    assert policy.down_late_grace_us == 500
     assert policy.focus_restore_grace_us == 100_000
 
 

--- a/tests/test_textual_picker.py
+++ b/tests/test_textual_picker.py
@@ -924,22 +924,27 @@ def test_textual_picker_calibrate_latency_command(monkeypatch) -> None:
 
     from pathlib import Path
 
-    from sky_music.infrastructure.calibration_loader import CalibrationQuantiles
+    from sky_music.infrastructure.calibration_loader import CalibrationStatus
     from sky_music.platform.win32.native_calibration import PublishedCalibrationResult
 
     def dummy_harness(*args, **kwargs):
         nonlocal harness_called
         harness_called = True
         return PublishedCalibrationResult(
+            status=CalibrationStatus.VALID,
             margin_us=800,
+            candidate_margin_us=800,
             source="device_cache",
             sample_count=20,
-            down_us=CalibrationQuantiles(100, 200, 300),
-            up_us=CalibrationQuantiles(100, 200, 300),
             cache_path=Path(".cache/input_latency.json"),
             evidence_kind="injected_raw_input_delivery_proxy",
             source_git_sha="0" * 40,
             native_build_id="0" * 40,
+            worst_bucket="15/cold",
+            global_shrink_p99_us=700,
+            guard_us=100,
+            ceiling_us=2_000,
+            effective_min_hold_us=17_467,
         )
 
     monkeypatch.setattr(calibration_module, "run_published_native_calibration", dummy_harness)
@@ -975,5 +980,4 @@ def test_textual_picker_calibrate_latency_command(monkeypatch) -> None:
 
     app = run_picker(_run_app(actions))
     assert app.return_value is None
-
 

--- a/tests/test_textual_picker.py
+++ b/tests/test_textual_picker.py
@@ -11,6 +11,8 @@ from textual.widgets import Input
 
 from sky_music.config import AppConfig
 from sky_music.infrastructure.background import WorkerSnapshot
+from sky_music.infrastructure.calibration_loader import CalibrationStatus
+from sky_music.platform.win32.native_calibration import PublishedCalibrationResult
 from sky_music.ui.picker import SongPickerResult
 from sky_music.ui.picker_helpers import get_song_choices
 from sky_music.ui.picker_metadata import SongUiMetadata
@@ -911,7 +913,54 @@ def test_responsive_columns_dynamic_width(monkeypatch) -> None:
     assert app.return_value is None
 
 
-def test_textual_picker_calibrate_latency_command(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    (
+        "status",
+        "margin_us",
+        "candidate_margin_us",
+        "effective_min_hold_us",
+        "expected_modal_text",
+        "forbidden_modal_text",
+    ),
+    [
+        (
+            CalibrationStatus.VALID,
+            800,
+            800,
+            17_467,
+            ("VALID", "Applied hold margin", "Note-On timestamps: unchanged"),
+            ("OUT OF ENVELOPE",),
+        ),
+        (
+            CalibrationStatus.OUT_OF_ENVELOPE,
+            None,
+            12_188,
+            None,
+            (
+                "OUT OF ENVELOPE",
+                "Applied calibrated margin",
+                "NONE",
+                "Playback hold fallback",
+                "500 µs",
+                "Note-On timestamps: unchanged",
+            ),
+            (
+                "Calibrated device margin: 2000",
+                "Calibration Complete Successfully",
+                "Calibration complete successfully",
+            ),
+        ),
+    ],
+)
+def test_textual_picker_calibrate_latency_command(
+    monkeypatch,
+    status: CalibrationStatus,
+    margin_us: int | None,
+    candidate_margin_us: int,
+    effective_min_hold_us: int | None,
+    expected_modal_text: tuple[str, ...],
+    forbidden_modal_text: tuple[str, ...],
+) -> None:
     FakeMetadataCoordinator.instances.clear()
     monkeypatch.setattr("sky_music.ui.picker_helpers.get_song_choices", lambda force_refresh=False: SONGS)
     monkeypatch.setattr(picker_module, "MetadataCoordinator", FakeMetadataCoordinator)
@@ -924,27 +973,30 @@ def test_textual_picker_calibrate_latency_command(monkeypatch) -> None:
 
     from pathlib import Path
 
-    from sky_music.infrastructure.calibration_loader import CalibrationStatus
-    from sky_music.platform.win32.native_calibration import PublishedCalibrationResult
-
     def dummy_harness(*args, **kwargs):
         nonlocal harness_called
         harness_called = True
         return PublishedCalibrationResult(
-            status=CalibrationStatus.VALID,
-            margin_us=800,
-            candidate_margin_us=800,
-            source="device_cache",
-            sample_count=20,
+            status=status,
+            margin_us=margin_us,
+            candidate_margin_us=candidate_margin_us,
+            source=(
+                "device_cache"
+                if status is CalibrationStatus.VALID
+                else "out_of_envelope_default_500"
+            ),
+            sample_count=100,
             cache_path=Path(".cache/input_latency.json"),
             evidence_kind="injected_raw_input_delivery_proxy",
             source_git_sha="0" * 40,
             native_build_id="0" * 40,
             worst_bucket="15/cold",
-            global_shrink_p99_us=700,
+            global_shrink_p99_us=(
+                700 if status is CalibrationStatus.VALID else 12_088
+            ),
             guard_us=100,
             ceiling_us=2_000,
-            effective_min_hold_us=17_467,
+            effective_min_hold_us=effective_min_hold_us,
         )
 
     monkeypatch.setattr(calibration_module, "run_published_native_calibration", dummy_harness)
@@ -969,6 +1021,11 @@ def test_textual_picker_calibrate_latency_command(monkeypatch) -> None:
         # The harness should have been called and the InfoModal (success dialog) pushed
         assert harness_called is True
         assert type(app.screen).__name__ == "InfoModal"
+        modal_text = str(getattr(app.screen, "content", ""))
+        for expected in expected_modal_text:
+            assert expected in modal_text
+        for forbidden in forbidden_modal_text:
+            assert forbidden not in modal_text
         
         # Close InfoModal
         await pilot.press("escape")
@@ -980,4 +1037,3 @@ def test_textual_picker_calibrate_latency_command(monkeypatch) -> None:
 
     app = run_picker(_run_app(actions))
     assert app.return_value is None
-


### PR DESCRIPTION
## Summary

<!-- One paragraph: what this PR does and why. -->

## Validation (altitude table)

Apply the narrowest gate that matches your change scope per `AGENTS.md` §Validation. Mark each entry you'll run:

- [ ] `uv run ruff check .`
- [ ] `uv run pyright`
- [ ] `uv run pytest -m "<markers>"`
- [ ] `uv run --env-file .env python scripts/audit_security_mandates.py`
- [ ] `uv run --env-file .env python scripts/audit_free_threaded_wheels.py`
- [ ] `uv run --env-file .env python -m build_app` (only if `Sky-Auto-Player.spec` / `src/build_app.py` changed)

## AGENTS.md priority stack

- [ ] I read `AGENTS.md` Priority Stack (P0 security → P1 enforced config → P2 local evidence → P3 task intent). My change does not violate any rule above `P3`.
- [ ] If my change touched a `PORTING_GUIDE.md §6` boundary, I confirmed `AGENTS.md` still wins.
- [ ] I did not introduce new dependencies unless I justified them in the PR description.

## Change scope

<!-- Surgical, focused, no broad rewrites. List the files touched and the rationale per file. -->

## Tests

<!-- New tests added? Existing tests updated? Targeted refactors covered? -->

## Risk and rollback

<!-- How risky is this? How do we revert if it breaks? -->
