### PR TITLE
chore(release): prepare v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Sky Auto Player are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.1] - 2026-08-19
+
+Sky Auto Player v3.4.1 is a focused stability patch for input calibration,
+native updating, and playback reporting.
+
+### Changed
+
+- Hardened native updater replacement, rollback, recovery, and preserved-path
+  handling.
+- Updated Host Input Delivery Calibration so hold correction remains independent
+  from late-event grace and measurements beyond the trusted correction envelope
+  are reported explicitly instead of being saturated.
+
+### Fixed
+
+- Preserved authored Note-On timing and the safe 500 µs playback fallback when
+  calibration is unavailable, invalid, or out of envelope.
+- Corrected missed-note counts shown by the playback UI.
+
+### Security
+
+- Strengthened transactional update integrity and fail-safe recovery behavior.
+
 ## [3.4.0] - 2026-08-18
 
 Sky Auto Player v3.4.0 tightens deterministic playback timing and runtime recovery.

--- a/docs/releases/v3.4.1-release-notes.md
+++ b/docs/releases/v3.4.1-release-notes.md
@@ -1,0 +1,21 @@
+# Sky Auto Player v3.4.1
+
+v3.4.1 is a focused stability patch for input calibration, updating, and
+playback reporting.
+
+> **Manual update required for this bridge release:** users on v3.4.0 or
+> earlier should install v3.4.1 manually from GitHub Releases. After v3.4.1,
+> the hardened native updater becomes the trusted update path.
+
+## Highlights
+
+- Host Input Delivery Calibration now rejects corrections outside the trusted
+  envelope instead of silently saturating them, while keeping Note-On timing
+  unchanged.
+- Hardened native updater replacement, rollback, and recovery behavior.
+- Fixed missed-note counts in the playback UI.
+- Strengthened calibration provenance and regression coverage.
+
+## Platform
+
+Windows 10/11 x64.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sky-auto-player"
-version = "3.4.0"
+version = "3.4.1"
 description = "Sky Auto Player - Auto Music Sheet Player"
 readme = "README.md"
 # The dispatch loop tight-spins on `time.perf_counter_ns` for up to ~800 us per action, and a

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "sky-auto-player"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary
- bump Sky Auto Player to v3.4.1
- add v3.4.1 changelog entry and release notes
- prepare the manual bridge release for the hardened native updater

## Validation
- ruff
- pyright
- security audit
- Rust architecture, fmt, check, clippy, and tests
- version consistency test
- full pytest