### PR TITLE
fix(updater): restore interactive console after update

### DIFF
--- a/rust/crates/sky_updater/src/error.rs
+++ b/rust/crates/sky_updater/src/error.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::path::Path;
 
 use thiserror::Error;
 
@@ -64,8 +65,25 @@ pub enum UpdaterError {
     RestartFailed(String),
     #[error("I/O failure: {0}")]
     Io(#[from] io::Error),
+    #[error("I/O failure during {phase}/{operation} at {path}: {source}")]
+    IoContext {
+        phase: String,
+        operation: String,
+        path: String,
+        #[source]
+        source: io::Error,
+    },
     #[error("JSON failure: {0}")]
     Json(#[from] serde_json::Error),
 }
 
 pub type Result<T> = std::result::Result<T, UpdaterError>;
+
+pub fn io_context(phase: &str, operation: &str, path: &Path, source: io::Error) -> UpdaterError {
+    UpdaterError::IoContext {
+        phase: phase.into(),
+        operation: operation.into(),
+        path: path.display().to_string(),
+        source,
+    }
+}

--- a/rust/crates/sky_updater/src/restart.rs
+++ b/rust/crates/sky_updater/src/restart.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[cfg(not(windows))]
 use std::process::Command;
 
 use crate::error::{Result, UpdaterError};
@@ -24,11 +27,132 @@ pub fn restart_verified(install_root: &Path) -> Result<()> {
             "installed project files failed integrity check: {error}"
         ))
     })?;
-    Command::new(&executable)
+    launch_verified_process(&executable, install_root).map_err(|err| {
+        UpdaterError::RestartFailed(format!("{APP_NAME} could not be started: {err}"))
+    })
+}
+
+#[cfg(windows)]
+#[derive(Debug, Eq, PartialEq)]
+struct ProcessLaunchSpec {
+    application_name: PathBuf,
+    current_directory: PathBuf,
+    creation_flags: u32,
+    inherit_handles: bool,
+}
+
+#[cfg(windows)]
+fn process_launch_spec(executable: &Path, install_root: &Path) -> ProcessLaunchSpec {
+    ProcessLaunchSpec {
+        application_name: executable.to_owned(),
+        current_directory: install_root.to_owned(),
+        creation_flags: windows_sys::Win32::System::Threading::CREATE_NEW_CONSOLE,
+        inherit_handles: false,
+    }
+}
+
+#[cfg(windows)]
+fn launch_verified_process(executable: &Path, install_root: &Path) -> io::Result<()> {
+    use std::iter::once;
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        CreateProcessW, PROCESS_INFORMATION, STARTUPINFOW,
+    };
+
+    let spec = process_launch_spec(executable, install_root);
+    let application_name = spec
+        .application_name
+        .as_os_str()
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<_>>();
+    let current_directory = spec
+        .current_directory
+        .as_os_str()
+        .encode_wide()
+        .chain(once(0))
+        .collect::<Vec<_>>();
+    let mut startup_info: STARTUPINFOW = unsafe { std::mem::zeroed() };
+    startup_info.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+    let mut process_info: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+
+    // The updater is deliberately launched without a console and with all
+    // standard handles redirected. Start the verified app in a fresh console
+    // instead of inheriting that hidden/non-interactive handle environment.
+    let created = unsafe {
+        CreateProcessW(
+            application_name.as_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            spec.inherit_handles as i32,
+            spec.creation_flags,
+            std::ptr::null_mut(),
+            current_directory.as_ptr(),
+            &startup_info,
+            &mut process_info,
+        )
+    };
+    if created == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    unsafe {
+        CloseHandle(process_info.hProcess);
+        CloseHandle(process_info.hThread);
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn launch_verified_process(executable: &Path, install_root: &Path) -> io::Result<()> {
+    Command::new(executable)
         .current_dir(install_root)
         .spawn()
         .map(|_| ())
-        .map_err(|err| {
-            UpdaterError::RestartFailed(format!("{APP_NAME} could not be started: {err}"))
-        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_canonical_executable_is_rejected_before_launch() {
+        let root = std::env::temp_dir().join(format!(
+            "sky-updater-restart-verification-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("restart fixture root");
+
+        let error = restart_verified(&root).expect_err("missing canonical executable");
+        assert!(matches!(
+            error,
+            UpdaterError::RestartFailed(message)
+                if message == "canonical app executable is missing"
+        ));
+
+        std::fs::remove_dir_all(root).expect("cleanup restart fixture");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_restart_uses_fresh_console_without_inherited_handles() {
+        let executable = PathBuf::from(r"C:\install\Sky-Auto-Player.exe");
+        let install_root = PathBuf::from(r"C:\install");
+        let spec = process_launch_spec(&executable, &install_root);
+
+        assert_eq!(spec.application_name, executable);
+        assert_eq!(spec.current_directory, install_root);
+        assert_eq!(
+            spec.creation_flags,
+            windows_sys::Win32::System::Threading::CREATE_NEW_CONSOLE
+        );
+        assert!(!spec.inherit_handles);
+    }
 }

--- a/rust/crates/sky_updater/src/result.rs
+++ b/rust/crates/sky_updater/src/result.rs
@@ -194,6 +194,7 @@ pub fn error_code(error: &UpdaterError) -> &'static str {
         UpdaterError::RollbackFailed(_) => "ROLLBACK_FAILED",
         UpdaterError::RestartFailed(_) => "RESTART_FAILED",
         UpdaterError::Io(_) => "IO_FAILURE",
+        UpdaterError::IoContext { .. } => "IO_FAILURE",
         UpdaterError::Json(_) => "JSON_FAILURE",
     }
 }
@@ -226,6 +227,17 @@ fn error_details(error: &UpdaterError) -> ErrorDetails {
             path: Some(bound_message(path.clone())),
             os_error: Some(*os_code),
         },
+        UpdaterError::IoContext {
+            phase,
+            operation,
+            path,
+            source,
+        } => ErrorDetails {
+            phase: Some(bound_message(phase.clone())),
+            operation: Some(bound_message(operation.clone())),
+            path: Some(bound_message(path.clone())),
+            os_error: source.raw_os_error().map(|value| value.unsigned_abs()),
+        },
         _ => ErrorDetails::default(),
     }
 }
@@ -250,6 +262,11 @@ fn bounded_log_message(message: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+    use std::path::Path;
+
+    use crate::error::io_context;
+
     use super::{MAX_MESSAGE_CHARS, bound_message};
 
     #[test]
@@ -265,5 +282,23 @@ mod tests {
         assert_eq!(bounded.chars().count(), MAX_MESSAGE_CHARS);
         assert_eq!(bounded.chars().last(), Some('…'));
         assert!(bounded.is_char_boundary(bounded.len()));
+    }
+
+    #[test]
+    fn io_context_preserves_failure_provenance_in_result() {
+        let error = io_context(
+            "path validation",
+            "read file attributes",
+            Path::new(r"C:\install\deep\file.txt"),
+            io::Error::from_raw_os_error(3),
+        );
+
+        let result = super::failure("3.3.0", "3.4.0", &error);
+
+        assert_eq!(result.error_code.as_deref(), Some("IO_FAILURE"));
+        assert_eq!(result.phase.as_deref(), Some("path validation"));
+        assert_eq!(result.operation.as_deref(), Some("read file attributes"));
+        assert_eq!(result.path.as_deref(), Some(r"C:\install\deep\file.txt"));
+        assert_eq!(result.os_error, Some(3));
     }
 }

--- a/rust/crates/sky_updater/src/transaction.rs
+++ b/rust/crates/sky_updater/src/transaction.rs
@@ -6,7 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::archive::{path_is_safe_under, sha256_file, validate_relative_path};
-use crate::error::{Result, UpdaterError};
+use crate::error::{Result, UpdaterError, io_context};
 use crate::file_replace::{probe_new_destination, probe_replaceable};
 use crate::manifest::{Manifest, PreserveClass, classify_preserved};
 use crate::{CALIBRATION_EXE, MANIFEST_NAME, PRIMARY_EXE, SCHEMA_VERSION, UPDATER_EXE};
@@ -244,7 +244,10 @@ fn prepare_journal_inner(
         install_root,
         &format!("{TRANSACTION_DIR}/{JOURNAL_FILE_NAME}"),
     )?;
-    write_json_atomic(&journal_file, &journal)?;
+    write_json_atomic(&journal_file, &journal).map_err(|error| match error {
+        UpdaterError::Io(source) => io_context("prepare", "write journal", &journal_file, source),
+        other => other,
+    })?;
     Ok(journal)
 }
 
@@ -291,7 +294,15 @@ pub fn apply(
     new_manifest: &Manifest,
     plan: &TransactionPlan,
 ) -> Result<()> {
-    let journal = read_journal(install_root)?;
+    let journal = read_journal(install_root).map_err(|error| match error {
+        UpdaterError::Io(source) => io_context(
+            "apply",
+            "read journal",
+            &transaction_root(install_root).join(JOURNAL_FILE_NAME),
+            source,
+        ),
+        other => other,
+    })?;
     if journal.state != JournalState::Prepared {
         return Err(UpdaterError::TransactionRecoveryRequired(
             "transaction is not prepared".into(),
@@ -337,7 +348,15 @@ pub fn apply(
     verify_installed_managed(install_root, new_manifest)?;
     let installed_manifest_path = safe_join(install_root, MANIFEST_NAME)
         .map_err(|error| UpdaterError::PostInstallVerifyFailed(error.to_string()))?;
-    let installed_manifest = Manifest::parse(&fs::read(installed_manifest_path)?)
+    let installed_manifest =
+        Manifest::parse(&fs::read(&installed_manifest_path).map_err(|error| {
+            io_context(
+                "apply",
+                "read installed manifest",
+                &installed_manifest_path,
+                error,
+            )
+        })?)
         .map_err(|error| UpdaterError::PostInstallVerifyFailed(error.to_string()))?;
     if installed_manifest != *new_manifest {
         return Err(UpdaterError::PostInstallVerifyFailed(
@@ -350,7 +369,10 @@ pub fn apply(
         install_root,
         &format!("{TRANSACTION_DIR}/{JOURNAL_FILE_NAME}"),
     )?;
-    write_json_atomic(&journal_file, &committed)?;
+    write_json_atomic(&journal_file, &committed).map_err(|error| match error {
+        UpdaterError::Io(source) => io_context("apply", "commit journal", &journal_file, source),
+        other => other,
+    })?;
     Ok(())
 }
 
@@ -375,10 +397,16 @@ fn copy_managed_file(
         )));
     }
     if let Some(parent) = destination.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent)
+            .map_err(|error| io_context("apply", "create destination parent", parent, error))?;
     }
     let expected_hash = if relative == MANIFEST_NAME {
-        sha256_file(&source)?
+        sha256_file(&source).map_err(|error| match error {
+            UpdaterError::Io(source_error) => {
+                io_context("apply", "hash staged file", &source, source_error)
+            }
+            other => other,
+        })?
     } else {
         new_manifest
             .files_by_path()
@@ -391,7 +419,13 @@ fn copy_managed_file(
             })?
     };
     let replacement =
-        crate::file_replace::prepare_replacement(&source, &destination, &expected_hash, relative)?;
+        crate::file_replace::prepare_replacement(&source, &destination, &expected_hash, relative)
+            .map_err(|error| match error {
+            UpdaterError::Io(source_error) => {
+                io_context("apply", "prepare replacement", &destination, source_error)
+            }
+            other => other,
+        })?;
     if replaces_existing && destination.is_file() {
         crate::file_replace::atomic_replace_existing(replacement, "apply", index)
     } else {
@@ -407,7 +441,14 @@ pub fn verify_installed_managed(install_root: &Path, manifest: &Manifest) -> Res
         let path = safe_join(install_root, &file.path)?;
         let metadata = fs::metadata(&path)
             .map_err(|_| UpdaterError::PostInstallVerifyFailed(file.path.clone()))?;
-        if metadata.len() != file.size || sha256_file(&path)? != file.sha256.to_ascii_lowercase() {
+        if metadata.len() != file.size
+            || sha256_file(&path).map_err(|error| match error {
+                UpdaterError::Io(source_error) => {
+                    io_context("apply", "hash installed file", &path, source_error)
+                }
+                other => other,
+            })? != file.sha256.to_ascii_lowercase()
+        {
             return Err(UpdaterError::PostInstallVerifyFailed(file.path.clone()));
         }
     }
@@ -420,7 +461,10 @@ pub fn read_journal(install_root: &Path) -> Result<Journal> {
         &format!("{TRANSACTION_DIR}/{JOURNAL_FILE_NAME}"),
     )
     .map_err(|err| UpdaterError::TransactionRecoveryRequired(err.to_string()))?;
-    let journal: Journal = serde_json::from_slice(&fs::read(journal_file)?)?;
+    let journal: Journal = serde_json::from_slice(
+        &fs::read(&journal_file)
+            .map_err(|error| io_context("recovery", "read journal", &journal_file, error))?,
+    )?;
     if journal.schema_version != SCHEMA_VERSION
         || journal.install_root != install_root.to_string_lossy()
     {
@@ -463,17 +507,22 @@ pub fn write_json_atomic<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     let parent = path
         .parent()
         .ok_or_else(|| UpdaterError::Io(std::io::Error::other("JSON path has no parent")))?;
-    fs::create_dir_all(parent)?;
+    fs::create_dir_all(parent)
+        .map_err(|error| io_context("persistence", "create JSON parent", parent, error))?;
     let temporary = path.with_extension("tmp");
     let mut file = OpenOptions::new()
         .create(true)
         .truncate(true)
         .write(true)
-        .open(&temporary)?;
+        .open(&temporary)
+        .map_err(|error| io_context("persistence", "open JSON temporary", &temporary, error))?;
     let bytes = serde_json::to_vec_pretty(value)?;
-    file.write_all(&bytes)?;
-    file.flush()?;
-    file.sync_all()?;
+    file.write_all(&bytes)
+        .map_err(|error| io_context("persistence", "write JSON temporary", &temporary, error))?;
+    file.flush()
+        .map_err(|error| io_context("persistence", "flush JSON temporary", &temporary, error))?;
+    file.sync_all()
+        .map_err(|error| io_context("persistence", "sync JSON temporary", &temporary, error))?;
     atomic_replace(&temporary, path)?;
     Ok(())
 }
@@ -497,13 +546,19 @@ fn atomic_replace(temporary: &Path, destination: &Path) -> Result<()> {
             .collect::<Vec<_>>();
         let flags = MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH;
         if unsafe { MoveFileExW(source.as_ptr(), target.as_ptr(), flags) } == 0 {
-            return Err(UpdaterError::Io(std::io::Error::last_os_error()));
+            return Err(io_context(
+                "persistence",
+                "replace JSON file",
+                destination,
+                std::io::Error::last_os_error(),
+            ));
         }
         Ok(())
     }
     #[cfg(not(windows))]
     {
-        fs::rename(temporary, destination)?;
+        fs::rename(temporary, destination)
+            .map_err(|error| io_context("persistence", "replace JSON file", destination, error))?;
         Ok(())
     }
 }
@@ -529,7 +584,7 @@ fn ensure_no_reparse_components(root: &Path, path: &Path) -> Result<()> {
                 )));
             }
         }
-        Err(error) => return Err(UpdaterError::Io(error)),
+        Err(error) => return Err(io_context("path validation", "inspect root", root, error)),
     }
     let relative = path.strip_prefix(root).map_err(|_| {
         UpdaterError::InstallRootInvalid(format!("path escapes root: {}", path.display()))
@@ -553,7 +608,14 @@ fn ensure_no_reparse_components(root: &Path, path: &Path) -> Result<()> {
                 }
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => break,
-            Err(error) => return Err(UpdaterError::Io(error)),
+            Err(error) => {
+                return Err(io_context(
+                    "path validation",
+                    "inspect component",
+                    &current,
+                    error,
+                ));
+            }
         }
     }
     Ok(())
@@ -567,14 +629,27 @@ fn is_reparse_point(path: &Path) -> Result<bool> {
         FILE_ATTRIBUTE_REPARSE_POINT, GetFileAttributesW, INVALID_FILE_ATTRIBUTES,
     };
 
-    let wide = path
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect::<Vec<_>>();
+    let raw = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    let mut wide = if raw.starts_with(&[b'\\' as u16, b'\\' as u16]) {
+        let mut value = r"\\?\UNC\".encode_utf16().collect::<Vec<_>>();
+        value.extend_from_slice(&raw[2..]);
+        value
+    } else if raw.starts_with(&[b'\\' as u16, b'?' as u16, b'\\' as u16]) {
+        raw
+    } else {
+        let mut value = r"\\?\".encode_utf16().collect::<Vec<_>>();
+        value.extend_from_slice(&raw);
+        value
+    };
+    wide.push(0);
     let attributes = unsafe { GetFileAttributesW(wide.as_ptr()) };
     if attributes == INVALID_FILE_ATTRIBUTES {
-        return Err(UpdaterError::Io(std::io::Error::last_os_error()));
+        return Err(io_context(
+            "path validation",
+            "read file attributes",
+            path,
+            std::io::Error::last_os_error(),
+        ));
     }
     Ok(attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0)
 }
@@ -593,7 +668,8 @@ pub fn cleanup_committed(install_root: &Path) -> Result<()> {
                 "prepared transaction must be recovered".into(),
             ));
         }
-        fs::remove_dir_all(root)?;
+        fs::remove_dir_all(&root)
+            .map_err(|error| io_context("cleanup", "remove transaction directory", &root, error))?;
     }
     crate::file_replace::cleanup_stale_artifacts(install_root)?;
     Ok(())

--- a/scripts/test_windows_updater_e2e.ps1
+++ b/scripts/test_windows_updater_e2e.ps1
@@ -168,7 +168,51 @@ function Copy-TreeContents {
 
 function Add-PreservedFixture {
     param([string]$Root)
-    [IO.File]::WriteAllText((Join-Path $Root "config.json"), '{"e2e":"preserve"}')
+    # Keep the fixture schema-valid and disable the app's automatic update
+    # worker. The restart acceptance must test updater preservation, not let a
+    # freshly restarted app rewrite its own update-notification state.
+    $config = @'
+{
+    "e2e": "preserve",
+    "schema_version": 3,
+    "default_hold_frames": 1.0,
+    "theme": "aurora",
+    "ui_background_mode": "transparent",
+    "default_tempo_scale": 1.0,
+    "game_fps": 60,
+    "telemetry_enabled_by_default": false,
+    "verbose_hud": false,
+    "hotkeys": {
+        "pause": "f8",
+        "skip": "f9",
+        "quit": "f10",
+        "refocus": "f6",
+        "panic": "ctrl+alt+backspace"
+    },
+    "safety": {
+        "prompt_on_medium_risk": true,
+        "prompt_on_high_risk": true
+    },
+    "songs_dir": "songs",
+    "sky_process_names": [
+        "Sky.exe",
+        "Sky Children of the Light.exe"
+    ],
+    "allow_title_fallback": false,
+    "update": {
+        "auto_check": false,
+        "channel": "stable",
+        "skip_version": "",
+        "check_interval_s": 86400,
+        "last_check_ts": 0,
+        "last_error_ts": 0,
+        "last_notified_version": "",
+        "legacy_old_dir_sweep_pending": false
+    }
+}
+'@
+    $configText = [regex]::Replace($config.Trim(), '\r?\n', [Environment]::NewLine)
+    [IO.File]::WriteAllText((Join-Path $Root "config.json"), $configText)
     [IO.File]::WriteAllText((Join-Path $Root ".env"), "E2E_PRESERVED=1`r`n")
     New-Item -ItemType Directory -Path (Join-Path $Root "songs") -Force | Out-Null
     New-Item -ItemType Directory -Path (Join-Path $Root "logs") -Force | Out-Null
@@ -347,6 +391,22 @@ function Stop-RestartedApp {
             }
         } catch { }
     }
+}
+
+function Wait-ForPreparedJournal {
+    param(
+        [string]$Install,
+        [int]$TimeoutSeconds = 30
+    )
+    $journal = Join-Path $Install ".sky-update-transaction\journal.json"
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    do {
+        if (Test-Path -LiteralPath $journal -PathType Leaf) {
+            return $true
+        }
+        Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $deadline)
+    return $false
 }
 
 function Assert-PreservedState {
@@ -537,9 +597,9 @@ try {
     $prepared = Start-UpdaterProcess -Install $scenario.Install -Candidate $e2eCandidate `
         -CurrentVersion $fromManifest.version -TargetVersion $toManifest.version -ReleaseDir $syntheticRelease `
         -PauseAt "after-replace:apply:Sky-Auto-Player-Updater.exe" -KeepPaused
-    Start-Sleep -Milliseconds 2500
+    $preparedJournal = Wait-ForPreparedJournal $scenario.Install
     Stop-ProcessIfRunning $prepared.Process
-    if (-not (Test-Path (Join-Path $scenario.Install ".sky-update-transaction\journal.json"))) { throw "rollback fault fixture did not leave Prepared journal" }
+    if (-not $preparedJournal) { throw "rollback fault fixture did not leave Prepared journal" }
     $run = Invoke-Updater $scenario $e2eCandidate $fromManifest.version $toManifest.version $syntheticRelease `
         -FailAt "rollback:after-restore:Sky-Auto-Player-Updater.exe"
     if ($run.Result.error_code -ne "ROLLBACK_ATOMIC_REPLACE_FAILED" -or -not (Test-Path (Join-Path $scenario.Install ".sky-update-transaction"))) { throw "rollback fault safety check failed" }
@@ -557,9 +617,9 @@ try {
     $first = Start-UpdaterProcess -Install $scenario.Install -Candidate $e2eCandidate -CurrentVersion $fromManifest.version `
         -TargetVersion $toManifest.version -ReleaseDir $syntheticRelease `
         -PauseAt "after-replace:apply:Sky-Auto-Player-Updater.exe" -KeepPaused
-    Start-Sleep -Milliseconds 2500
+    $crashJournal = Wait-ForPreparedJournal $scenario.Install
     Stop-ProcessIfRunning $first.Process
-    if (-not (Test-Path (Join-Path $scenario.Install ".sky-update-transaction\journal.json"))) { throw "crash fixture did not leave Prepared journal" }
+    if (-not $crashJournal) { throw "crash fixture did not leave Prepared journal" }
     $run = Invoke-Updater $scenario $e2eCandidate $fromManifest.version $toManifest.version $syntheticRelease
     if ($run.Result.status -ne "success" -or (Test-Path (Join-Path $scenario.Install ".sky-update-transaction"))) { throw "crash recovery failed" }
     Assert-ManagedManifestFiles $scenario.Install $syntheticManifest | Out-Null


### PR DESCRIPTION
## Summary
- launch the verified app with a fresh Windows console and no inherited handles
- preserve contextual I/O failure evidence, including long-path validation failures
- make rollback/crash acceptance fixtures wait for the prepared journal deterministically

## Validation
- Windows updater E2E: H1/H2, rollback, crash recovery, Defender evidence PASS
- Rust fmt/check/clippy/tests PASS
- Ruff, Pyright, security audit, architecture audit PASS
- full pytest: 808 passed, 7 skipped, 1 xfailed