### PR TITLE
chore(release): prepare v3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,32 @@ All notable changes to Sky Auto Player are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.4.1] - 2026-08-19
+## [3.4.2] - 2026-08-19
+
+Sky Auto Player v3.4.2 is a stability patch for input calibration, native
+updating, and playback reporting.
+
+### Changed
+
+- Hardened native updater replacement, rollback, recovery, and preserved-path
+  handling.
+- Updated Host Input Delivery Calibration to reject corrections outside the
+  trusted envelope while preserving authored Note-On timing.
+
+### Fixed
+
+- Fixed native updater restart so the updated application starts with its own
+  interactive Windows console instead of inheriting the updater's hidden
+  standard handles.
+- Corrected missed-note counts shown by the playback UI.
+- Preserved the safe 500 µs playback fallback when host input calibration is
+  unavailable, invalid, or outside the trusted correction envelope.
+
+## [3.4.1] - 2026-08-19 — Withdrawn before publication
+
+v3.4.1 completed build qualification but was not published after final
+updater acceptance exposed an interactive-console restart defect. The tag is
+retained for history and must not be treated as a stable public release.
 
 Sky Auto Player v3.4.1 is a focused stability patch for input calibration,
 native updating, and playback reporting.

--- a/docs/releases/v3.4.2-release-notes.md
+++ b/docs/releases/v3.4.2-release-notes.md
@@ -1,0 +1,22 @@
+# Sky Auto Player v3.4.2
+
+v3.4.2 is a focused stability patch for input calibration, updating, and
+playback reporting.
+
+> **Manual update required for this bridge release:** users on v3.4.0 or
+> earlier should install v3.4.2 manually from GitHub Releases. v3.4.1 was
+> withdrawn before publication. After v3.4.2, the hardened native updater
+> becomes the trusted update path.
+
+## Highlights
+
+- Fixed native updater restart so the updated app opens with a usable
+  interactive console.
+- Hardened native updater replacement, rollback, and recovery behavior.
+- Host Input Delivery Calibration now rejects corrections outside its trusted
+  envelope without changing Note-On timestamps.
+- Fixed missed-note counts in the playback UI.
+
+## Platform
+
+Windows 10/11 x64.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sky-auto-player"
-version = "3.4.1"
+version = "3.4.2"
 description = "Sky Auto Player - Auto Music Sheet Player"
 readme = "README.md"
 # The dispatch loop tight-spins on `time.perf_counter_ns` for up to ~800 us per action, and a

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "sky-auto-player"
-version = "3.4.1"
+version = "3.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary
- bump Sky Auto Player to v3.4.2
- add v3.4.2 changelog entry and release notes
- mark v3.4.1 withdrawn before publication
- prepare the manual bridge release for the hardened native updater

## Validation
- Ruff, Pyright, security audit, Rust architecture audit
- Rust fmt/check/clippy/tests
- version consistency and full pytest
- free-threaded wheel audit and packaged v3.4.2 smoke build
- updater H1/H2, rollback, crash recovery, and Defender evidence passed on merged hotfix