### PR TITLE
build(rust): migrate toolchain to 1.98

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,17 +160,17 @@ jobs:
       - name: Rust — check
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
-        run: cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --all-features
+        run: cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --all-features --locked
 
       - name: Rust — clippy
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
-        run: cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features --locked -- -D warnings
 
       - name: Rust — unit tests
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
-        run: cargo test --manifest-path rust/Cargo.toml --workspace --all-features
+        run: cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked
 
       - name: Rust — build wheel
         env:
@@ -221,7 +221,7 @@ jobs:
             --release-dir "dist\Sky-Auto-Player-v$version" --version $version
 
       - name: Native updater security E2E
-        run: cargo test --manifest-path rust/Cargo.toml -p sky_updater --test packaged_update_e2e --all-features
+        run: cargo test --manifest-path rust/Cargo.toml -p sky_updater --test packaged_update_e2e --all-features --locked
 
 
   status:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,20 @@ jobs:
         with:
           run-runtime-audit: "true"
 
+      - name: Rust — install pinned stable toolchain for packaged build
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: rustup toolchain install 1.98.0 --profile minimal --target x86_64-pc-windows-msvc --component rustfmt --component clippy
+
+      - name: Rust — verify packaged-build compiler
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          $version = (rustc --version)
+          if ($version -notmatch '^rustc 1\.98\.0\s') {
+            throw "Expected stable Rust 1.98.0 for packaged build, got: $version"
+          }
+
       - name: Build source PyInstaller bootloader
         run: |
           $bootloader = Join-Path $env:RUNNER_TEMP "sky-auto-player-pyinstaller-bootloader"
@@ -211,6 +225,7 @@ jobs:
 
       - name: Build packaged unsigned app
         env:
+          RUSTUP_TOOLCHAIN: 1.98.0
           SKY_EXPECTED_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
         run: uv run --env-file .env python -m build_app --manifest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,8 @@ jobs:
             --release-dir "dist\Sky-Auto-Player-v$version" --version $version
 
       - name: Native updater security E2E
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
         run: cargo test --manifest-path rust/Cargo.toml -p sky_updater --test packaged_update_e2e --all-features --locked
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
           "SKY_REQUIRE_SOURCE_BOOTLOADER=1" | Add-Content $env:GITHUB_ENV -Encoding ASCII
 
       - name: Build unsigned native app and smoke tests
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
         run: uv run --env-file .env python -m build_app
 
       - name: Generate unsigned-byte manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,9 @@ jobs:
             throw "Expected stable Rust 1.98.0 from rust/rust-toolchain.toml, got: $version"
           }
           cargo fmt --manifest-path rust/Cargo.toml --all -- --check
-          cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --all-features
-          cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features -- -D warnings
-          cargo test --manifest-path rust/Cargo.toml --workspace --all-features
+          cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --all-features --locked
+          cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features --locked -- -D warnings
+          cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked
           uv run --env-file .env python scripts/build_rust_wheel.py
 
       - name: Tests — full

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@ These files represent the current system state and contracts:
 * [hold-frame-model.md](hold-frame-model.md) — Explicit hold-frame choices, FPS selection, and materialization formulas.
 * [perf-baselines/2026-06-baseline.md](perf-baselines/2026-06-baseline.md) — Pipeline CPU baselines and post-optimization gate numbers.
 * [distribution-and-update.md](distribution-and-update.md) — Canonical unsigned portable distribution, user-triggered native update flow with manual fallback, exact manifest/SHA/provenance contract, and release assets (tracks the `pyproject.toml` `[project].version`).
+* [rust-toolchain-policy.md](rust-toolchain-policy.md) — Current Rust compiler pin, MSRV, edition, target, lockfile, upgrade, branch-freeze, and qualification policy.
 * [releases/v3.0.0-acceptance.md](releases/v3.0.0-acceptance.md) — Exact-SHA acceptance evidence for the v3.0.0 release candidate.
 
 ---

--- a/docs/rust-dispatch-migration/README.md
+++ b/docs/rust-dispatch-migration/README.md
@@ -1,10 +1,16 @@
 # Sky Auto Player — Rust Dispatch Migration Guide
 
+> **Trạng thái:** tài liệu và các template trong thư mục này là hồ sơ migration
+> lịch sử. Các phiên bản Rust bên dưới là snapshot tại thời điểm viết, không
+> phải hợp đồng build hiện tại. Hãy dùng
+> [`docs/rust-toolchain-policy.md`](../rust-toolchain-policy.md) và workflow
+> đang chạy trong `.github/workflows/` cho toolchain hiện hành.
+
 **Mục tiêu:** chuyển toàn bộ lõi phát nhạc thời gian thực và gửi phím sang Rust, giữ nguyên UI/Textual và luồng ứng dụng Python hiện tại thông qua PyO3.
 
 - Baseline mã nguồn đã phân tích: `main@45fa3c83b1642fb6c91caa2c13b3ce7d1a6cad52`
 - Ngày rà soát: `2026-07-30`
-- Rust toolchain mục tiêu: **Rust 1.97.1**, edition 2024
+- Rust toolchain lịch sử tại thời điểm viết: **Rust 1.97.1**, edition 2024
 - PyO3 mục tiêu: **0.29.0**
 - Maturin mục tiêu: **1.13.3**
 - Windows bindings: **windows-sys 0.61.2**

--- a/docs/rust-toolchain-policy.md
+++ b/docs/rust-toolchain-policy.md
@@ -13,6 +13,11 @@ they were written; they do not define the current build contract.
 - Dependency resolution: `rust/Cargo.lock` is committed and must remain
   unchanged during a compiler-only migration. CI, release, and native wheel
   builds use Cargo's locked mode.
+- Every root-level native build, including `build_app`, explicitly exports
+  `RUSTUP_TOOLCHAIN=1.98.0`; the shipped wheel, calibration binary, and updater
+  are each built with `--locked`.
+- Native wheel and packaged-app provenance checks require the embedded
+  `rustc_version` metadata to start with the exact pinned compiler prefix.
 
 The nested toolchain file is discovered reliably when commands run from
 `rust/`. Root-level commands must set `RUSTUP_TOOLCHAIN=1.98.0` explicitly,

--- a/docs/rust-toolchain-policy.md
+++ b/docs/rust-toolchain-policy.md
@@ -1,0 +1,53 @@
+# Rust toolchain policy
+
+This is the current source of truth for the native Rust toolchain. Historical
+migration notes and release acceptance records retain the versions used when
+they were written; they do not define the current build contract.
+
+## Current contract
+
+- Production compiler: Rust `1.98.0`, pinned by `rust/rust-toolchain.toml`.
+- Workspace MSRV: Rust `1.98`, declared by `rust/Cargo.toml`.
+- Edition: Rust `2024`.
+- Target: `x86_64-pc-windows-msvc`.
+- Dependency resolution: `rust/Cargo.lock` is committed and must remain
+  unchanged during a compiler-only migration. CI, release, and native wheel
+  builds use Cargo's locked mode.
+
+The nested toolchain file is discovered reliably when commands run from
+`rust/`. Root-level commands must set `RUSTUP_TOOLCHAIN=1.98.0` explicitly,
+as the CI and release workflows do.
+
+## Upgrade policy
+
+1. Start from the current `origin/main` and record the exact base commit.
+2. Pin the candidate compiler without running `cargo update`.
+3. Run format, locked check, locked Clippy with `-D warnings`, and locked tests
+   for the complete workspace, all targets, and all features.
+4. Review Windows-specific runtime changes, especially TLS destructor behavior
+   for the `sky_dispatch_win32` thread-local waitable timer.
+5. Raise the workspace MSRV only after the compatibility pass succeeds. Do not
+   add a new stable API merely to demonstrate compiler adoption.
+6. Build and verify the exact free-threaded native wheel, including Rust
+   version, target ABI, and source commit provenance.
+
+Compiler migration and dependency upgrades are separate changes. A dependency
+or lockfile change requires its own review and evidence.
+
+## Branch and release policy
+
+`main` tracks the explicitly pinned current stable compiler and its deliberate
+MSRV. Release branches may freeze their compiler and MSRV; they must not be
+rewritten as part of a `main` migration unless a backport is explicitly
+requested. A reproducible regression preserves its evidence and rolls back the
+compiler/MSRV change without lowering timing or security gates.
+
+## Qualification policy
+
+Green CI establishes compiler/build/test compatibility only. The final native
+1.98 production binary still requires the existing Rust, Python, static,
+security, package, and updater gates, followed by the physical 10,000-boundary
+qualification and 100,000-boundary rare-tail soak. Those runs require the
+isolated project-owned target window and must preserve their raw JSON evidence.
+No compiler migration may claim final real-time acceptance without those
+reports.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,9 +9,9 @@ members = [
 
 [workspace.package]
 edition = "2024"
-# MSRV is 1.97; the reproducible production compiler is pinned separately in
-# rust-toolchain.toml at stable Rust 1.98.0.
-rust-version = "1.97"
+# Main tracks the explicitly pinned production compiler; release branches may
+# freeze their own compiler and MSRV policy.
+rust-version = "1.98"
 authors = ["Sky Auto Player Team"]
 
 [profile.release]

--- a/rust/crates/sky_dispatch_win32/src/sleeper.rs
+++ b/rust/crates/sky_dispatch_win32/src/sleeper.rs
@@ -77,7 +77,7 @@ pub fn measure_spin_overhead_us() -> Result<u64, QpcError> {
     Ok((total_overhead_us / ITERATIONS as u64).max(1))
 }
 
-#[cfg(all(test, windows))]
+#[cfg(all(test, feature = "test-support", windows))]
 mod tests {
     use super::THREAD_TIMER;
     use crate::timer::test_support;

--- a/rust/crates/sky_dispatch_win32/src/sleeper.rs
+++ b/rust/crates/sky_dispatch_win32/src/sleeper.rs
@@ -76,3 +76,36 @@ pub fn measure_spin_overhead_us() -> Result<u64, QpcError> {
 
     Ok((total_overhead_us / ITERATIONS as u64).max(1))
 }
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::THREAD_TIMER;
+    use crate::timer::test_support;
+
+    #[test]
+    fn thread_local_timer_is_dropped_after_repeated_worker_thread_exit() {
+        const ITERATIONS: usize = 16;
+        let counters = test_support::new_counters();
+
+        for _ in 0..ITERATIONS {
+            let counters_for_thread = std::sync::Arc::clone(&counters);
+            std::thread::spawn(move || {
+                test_support::with_context(&counters_for_thread, || {
+                    THREAD_TIMER.with(|timer| {
+                        assert!(
+                            timer.is_some(),
+                            "high-resolution waitable timer creation failed"
+                        );
+                    });
+                });
+            })
+            .join()
+            .expect("timer worker thread must exit without panic");
+        }
+
+        let counts = test_support::snapshot(&counters);
+        assert_eq!(counts.created, ITERATIONS);
+        assert_eq!(counts.dropped, ITERATIONS);
+        assert_eq!(counts.live, 0);
+    }
+}

--- a/rust/crates/sky_dispatch_win32/src/timer.rs
+++ b/rust/crates/sky_dispatch_win32/src/timer.rs
@@ -1,37 +1,40 @@
 //! High-resolution Waitable Timer wrapper for microsecond-accurate kernel sleeps.
 
-#[cfg(all(test, windows))]
-pub(crate) mod test_support {
+#[cfg(all(feature = "test-support", windows))]
+pub mod test_support {
     use std::cell::RefCell;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     thread_local! {
-        static ACTIVE_COUNTERS: RefCell<Option<Arc<TimerCounters>>> = const { RefCell::new(None) };
+        static ACTIVE_COUNTERS: RefCell<Option<Arc<TimerLifecycleCounters>>> =
+            const { RefCell::new(None) };
     }
 
-    pub(crate) struct TimerCounters {
+    pub struct TimerLifecycleCounters {
         created: AtomicUsize,
         dropped: AtomicUsize,
         live: AtomicUsize,
     }
 
+    pub type TimerLifecycleContext = Arc<TimerLifecycleCounters>;
+
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub(crate) struct TimerCounts {
-        pub(crate) created: usize,
-        pub(crate) dropped: usize,
-        pub(crate) live: usize,
+    pub struct TimerLifecycleCounts {
+        pub created: usize,
+        pub dropped: usize,
+        pub live: usize,
     }
 
-    pub(crate) fn new_counters() -> Arc<TimerCounters> {
-        Arc::new(TimerCounters {
+    pub fn new_counters() -> TimerLifecycleContext {
+        Arc::new(TimerLifecycleCounters {
             created: AtomicUsize::new(0),
             dropped: AtomicUsize::new(0),
             live: AtomicUsize::new(0),
         })
     }
 
-    pub(crate) fn with_context<R>(counters: &Arc<TimerCounters>, f: impl FnOnce() -> R) -> R {
+    pub fn with_context<R>(counters: &TimerLifecycleContext, f: impl FnOnce() -> R) -> R {
         ACTIVE_COUNTERS.with(|active| {
             let previous = active.replace(Some(Arc::clone(counters)));
             let result = f();
@@ -40,15 +43,15 @@ pub(crate) mod test_support {
         })
     }
 
-    pub(crate) fn snapshot(counters: &Arc<TimerCounters>) -> TimerCounts {
-        TimerCounts {
+    pub fn snapshot(counters: &TimerLifecycleContext) -> TimerLifecycleCounts {
+        TimerLifecycleCounts {
             created: counters.created.load(Ordering::SeqCst),
             dropped: counters.dropped.load(Ordering::SeqCst),
             live: counters.live.load(Ordering::SeqCst),
         }
     }
 
-    pub(super) fn record_created() -> Option<Arc<TimerCounters>> {
+    pub(super) fn record_created() -> Option<TimerLifecycleContext> {
         let counters = ACTIVE_COUNTERS.with(|active| active.borrow().clone());
         if let Some(counters) = counters.as_ref() {
             counters.created.fetch_add(1, Ordering::SeqCst);
@@ -57,7 +60,7 @@ pub(crate) mod test_support {
         counters
     }
 
-    pub(super) fn record_dropped(counters: &Arc<TimerCounters>) {
+    pub(super) fn record_dropped(counters: &TimerLifecycleContext) {
         counters.dropped.fetch_add(1, Ordering::SeqCst);
         counters.live.fetch_sub(1, Ordering::SeqCst);
     }
@@ -66,8 +69,8 @@ pub(crate) mod test_support {
 pub struct WaitableTimer {
     #[cfg(windows)]
     handle: windows_sys::Win32::Foundation::HANDLE,
-    #[cfg(all(test, windows))]
-    counters: Option<std::sync::Arc<test_support::TimerCounters>>,
+    #[cfg(all(feature = "test-support", windows))]
+    counters: Option<test_support::TimerLifecycleContext>,
 }
 
 pub struct TimerResolutionGuard {
@@ -130,11 +133,11 @@ impl WaitableTimer {
                 )
             };
             if !handle.is_null() {
-                #[cfg(all(test, windows))]
+                #[cfg(all(feature = "test-support", windows))]
                 let counters = test_support::record_created();
                 return Ok(WaitableTimer {
                     handle,
-                    #[cfg(all(test, windows))]
+                    #[cfg(all(feature = "test-support", windows))]
                     counters,
                 });
             }
@@ -207,7 +210,7 @@ impl Drop for WaitableTimer {
                 unsafe {
                     windows_sys::Win32::Foundation::CloseHandle(self.handle);
                 }
-                #[cfg(all(test, windows))]
+                #[cfg(all(feature = "test-support", windows))]
                 if let Some(counters) = self.counters.as_ref() {
                     test_support::record_dropped(counters);
                 }

--- a/rust/crates/sky_dispatch_win32/src/timer.rs
+++ b/rust/crates/sky_dispatch_win32/src/timer.rs
@@ -1,8 +1,73 @@
 //! High-resolution Waitable Timer wrapper for microsecond-accurate kernel sleeps.
 
+#[cfg(all(test, windows))]
+pub(crate) mod test_support {
+    use std::cell::RefCell;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    thread_local! {
+        static ACTIVE_COUNTERS: RefCell<Option<Arc<TimerCounters>>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) struct TimerCounters {
+        created: AtomicUsize,
+        dropped: AtomicUsize,
+        live: AtomicUsize,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) struct TimerCounts {
+        pub(crate) created: usize,
+        pub(crate) dropped: usize,
+        pub(crate) live: usize,
+    }
+
+    pub(crate) fn new_counters() -> Arc<TimerCounters> {
+        Arc::new(TimerCounters {
+            created: AtomicUsize::new(0),
+            dropped: AtomicUsize::new(0),
+            live: AtomicUsize::new(0),
+        })
+    }
+
+    pub(crate) fn with_context<R>(counters: &Arc<TimerCounters>, f: impl FnOnce() -> R) -> R {
+        ACTIVE_COUNTERS.with(|active| {
+            let previous = active.replace(Some(Arc::clone(counters)));
+            let result = f();
+            active.replace(previous);
+            result
+        })
+    }
+
+    pub(crate) fn snapshot(counters: &Arc<TimerCounters>) -> TimerCounts {
+        TimerCounts {
+            created: counters.created.load(Ordering::SeqCst),
+            dropped: counters.dropped.load(Ordering::SeqCst),
+            live: counters.live.load(Ordering::SeqCst),
+        }
+    }
+
+    pub(super) fn record_created() -> Option<Arc<TimerCounters>> {
+        let counters = ACTIVE_COUNTERS.with(|active| active.borrow().clone());
+        if let Some(counters) = counters.as_ref() {
+            counters.created.fetch_add(1, Ordering::SeqCst);
+            counters.live.fetch_add(1, Ordering::SeqCst);
+        }
+        counters
+    }
+
+    pub(super) fn record_dropped(counters: &Arc<TimerCounters>) {
+        counters.dropped.fetch_add(1, Ordering::SeqCst);
+        counters.live.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 pub struct WaitableTimer {
     #[cfg(windows)]
     handle: windows_sys::Win32::Foundation::HANDLE,
+    #[cfg(all(test, windows))]
+    counters: Option<std::sync::Arc<test_support::TimerCounters>>,
 }
 
 pub struct TimerResolutionGuard {
@@ -65,7 +130,13 @@ impl WaitableTimer {
                 )
             };
             if !handle.is_null() {
-                return Ok(WaitableTimer { handle });
+                #[cfg(all(test, windows))]
+                let counters = test_support::record_created();
+                return Ok(WaitableTimer {
+                    handle,
+                    #[cfg(all(test, windows))]
+                    counters,
+                });
             }
             Err(unsafe { windows_sys::Win32::Foundation::GetLastError() })
         }
@@ -135,6 +206,10 @@ impl Drop for WaitableTimer {
                 // SAFETY: this wrapper is the unique owner and Drop runs once.
                 unsafe {
                     windows_sys::Win32::Foundation::CloseHandle(self.handle);
+                }
+                #[cfg(all(test, windows))]
+                if let Some(counters) = self.counters.as_ref() {
+                    test_support::record_dropped(counters);
                 }
             }
         }

--- a/rust/crates/sky_player_rs/src/engine/config.rs
+++ b/rust/crates/sky_player_rs/src/engine/config.rs
@@ -82,6 +82,9 @@ pub(crate) struct NativeSessionOptions {
     pub(crate) startup_ordering_hook: Option<Arc<StartupOrderingHook>>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) restore_race_hook: Option<RestoreRaceHook>,
+    #[cfg(any(test, feature = "test-support"))]
+    pub(crate) timer_lifecycle_context:
+        Option<sky_dispatch_win32::timer::test_support::TimerLifecycleContext>,
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/rust/crates/sky_player_rs/src/engine/session.rs
+++ b/rust/crates/sky_player_rs/src/engine/session.rs
@@ -216,6 +216,9 @@ impl NativeDispatchSession {
             return Err("session configuration is no longer available".to_string());
         };
 
+        #[cfg(any(test, feature = "test-support"))]
+        let timer_lifecycle_context = config.timer_lifecycle_context.clone();
+
         let shared = Arc::clone(&self.shared);
         self.shared
             .publication
@@ -238,6 +241,19 @@ impl NativeDispatchSession {
         let spawn_result = std::thread::Builder::new()
             .name("sky-native-dispatch".to_string())
             .spawn(move || {
+                #[cfg(any(test, feature = "test-support"))]
+                let worker_result = if let Some(context) = timer_lifecycle_context {
+                    sky_dispatch_win32::timer::test_support::with_context(&context, || {
+                        catch_unwind(AssertUnwindSafe(|| {
+                            Worker::new(config, shared.as_ref(), epoch_qpc).run()
+                        }))
+                    })
+                } else {
+                    catch_unwind(AssertUnwindSafe(|| {
+                        Worker::new(config, shared.as_ref(), epoch_qpc).run()
+                    }))
+                };
+                #[cfg(not(any(test, feature = "test-support")))]
                 let worker_result = catch_unwind(AssertUnwindSafe(|| {
                     Worker::new(config, shared.as_ref(), epoch_qpc).run()
                 }));

--- a/rust/crates/sky_player_rs/src/engine/tests.rs
+++ b/rust/crates/sky_player_rs/src/engine/tests.rs
@@ -66,11 +66,40 @@ fn test_session_options(
         },
         startup_ordering_hook: None,
         restore_race_hook: None,
+        timer_lifecycle_context: None,
     }
 }
 
 fn start_with_test_wall_clock_slack(session: &NativeDispatchSession) {
     session.arm(TEST_WALL_CLOCK_PREROLL_US).expect("worker arm");
+}
+
+#[cfg(all(feature = "test-support", windows))]
+#[test]
+fn actual_worker_wait_path_drops_waitable_timer_after_session_exit() {
+    let timer_context = sky_dispatch_win32::timer::test_support::new_counters();
+    let mut options = test_session_options(
+        startup_boundary_schedule(),
+        1,
+        BackendConfig::Mock {
+            latency_base_us: 0,
+            latency_per_key_us: 0,
+            fault_script: FaultInjectionScript::none(),
+        },
+    );
+    options.timer_lifecycle_context = Some(Arc::clone(&timer_context));
+    let session = NativeDispatchSession::new(options).expect("test session admission");
+
+    session.arm(TEST_WALL_CLOCK_PREROLL_US).expect("worker arm");
+    assert!(session.join(Duration::from_secs(5)).expect("worker join"));
+
+    let counts = sky_dispatch_win32::timer::test_support::snapshot(&timer_context);
+    assert!(
+        counts.created >= 1,
+        "worker wait path must create a waitable timer"
+    );
+    assert_eq!(counts.created, counts.dropped);
+    assert_eq!(counts.live, 0);
 }
 
 #[test]

--- a/rust/crates/sky_player_rs/src/engine/worker.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker.rs
@@ -543,6 +543,8 @@ impl<'a> Worker<'a> {
             startup_ordering_hook,
             #[cfg(any(test, feature = "test-support"))]
             restore_race_hook,
+            #[cfg(any(test, feature = "test-support"))]
+                timer_lifecycle_context: _,
         } = options;
         #[cfg(any(test, feature = "test-support"))]
         let runtime = WorkerRuntime {

--- a/rust/crates/sky_player_rs/src/python/session.rs
+++ b/rust/crates/sky_player_rs/src/python/session.rs
@@ -112,6 +112,8 @@ impl NativeDispatchSessionPy {
             startup_ordering_hook: None,
             #[cfg(any(test, feature = "test-support"))]
             restore_race_hook: None,
+            #[cfg(any(test, feature = "test-support"))]
+            timer_lifecycle_context: None,
         })
         .map_err(PyRuntimeError::new_err)?;
         session.set_target_hwnd(config.target_hwnd);
@@ -759,6 +761,8 @@ impl TestDispatchSessionPy {
             startup_ordering_hook: None,
             #[cfg(any(test, feature = "test-support"))]
             restore_race_hook: None,
+            #[cfg(any(test, feature = "test-support"))]
+            timer_lifecycle_context: None,
         })
         .map_err(PyRuntimeError::new_err)?;
         Ok(Self {

--- a/scripts/build_rust_wheel.py
+++ b/scripts/build_rust_wheel.py
@@ -176,6 +176,7 @@ def main() -> int:
         "maturin",
         "build",
         "--release",
+        "--locked",
         "--manifest-path",
         str(cargo_manifest),
         "--interpreter",

--- a/scripts/build_rust_wheel.py
+++ b/scripts/build_rust_wheel.py
@@ -12,9 +12,11 @@ import argparse
 import base64
 import hashlib
 import os
+import re
 import subprocess
 import sys
 import tempfile
+import tomllib
 import zipfile
 from pathlib import Path
 
@@ -23,6 +25,40 @@ from packaging.utils import canonicalize_name, parse_wheel_filename
 
 EXPECTED_NATIVE_TAG = Tag("cp314", "cp314t", "win_amd64")
 EXPECTED_NATIVE_ABI = "cp314t-win_amd64"
+
+
+def pinned_rust_toolchain(rust_dir: Path) -> str:
+    toolchain_path = rust_dir / "rust-toolchain.toml"
+    try:
+        with toolchain_path.open("rb") as source:
+            data = tomllib.load(source)
+    except OSError as exc:
+        raise RuntimeError(f"cannot read Rust toolchain file: {toolchain_path}") from exc
+    channel = data.get("toolchain", {}).get("channel")
+    if not isinstance(channel, str) or re.fullmatch(r"\d+\.\d+\.\d+", channel) is None:
+        raise RuntimeError(f"Rust toolchain must pin an exact x.y.z channel: {toolchain_path}")
+    return channel
+
+
+def verify_build_info(
+    info: dict[str, object], *, expected_commit: str, expected_rustc_prefix: str
+) -> None:
+    rustc_version = info.get("rustc_version")
+    if not isinstance(rustc_version, str) or not rustc_version.startswith(expected_rustc_prefix):
+        raise RuntimeError(
+            "native wheel reports the wrong compiler: "
+            f"expected prefix {expected_rustc_prefix!r}, actual {rustc_version!r}"
+        )
+    if info.get("native_abi") != EXPECTED_NATIVE_ABI:
+        raise RuntimeError(
+            f"native wheel reports the wrong ABI: expected {EXPECTED_NATIVE_ABI!r}, "
+            f"actual {info.get('native_abi')!r}"
+        )
+    if info.get("native_build_commit") != expected_commit:
+        raise RuntimeError(
+            "native wheel reports the wrong build commit: "
+            f"expected {expected_commit!r}, actual {info.get('native_build_commit')!r}"
+        )
 
 
 def git_head(repo_root: Path) -> str:
@@ -159,6 +195,8 @@ def main() -> int:
             print("[build_rust_wheel] WARNING: Interpreter has GIL enabled!", file=sys.stderr)
 
     cargo_manifest = rust_dir / "crates" / "sky_player_rs" / "Cargo.toml"
+    rust_toolchain = pinned_rust_toolchain(rust_dir)
+    expected_rustc_prefix = f"rustc {rust_toolchain} "
     try:
         expected_commit = expected_build_commit(
             repo_root,
@@ -186,6 +224,7 @@ def main() -> int:
         cmd.extend(["--features", "test-support"])
 
     build_env = os.environ.copy()
+    build_env["RUSTUP_TOOLCHAIN"] = rust_toolchain
     build_env["GITHUB_SHA"] = expected_commit
     build_env["SKY_NATIVE_BUILD_COMMIT"] = expected_commit
     build_env["SKY_NATIVE_DIRTY_WORKTREE"] = str(expected_commit.endswith("-dirty")).lower()
@@ -247,6 +286,7 @@ def main() -> int:
             "print('build_info:', info); "
             "assert info.get('native_abi') == 'cp314t-win_amd64', info; "
             "assert info.get('native_build_commit') == os.environ['SKY_EXPECTED_BUILD_COMMIT'], info; "
+            "assert info.get('rustc_version', '').startswith(os.environ['SKY_EXPECTED_RUSTC_PREFIX']), info; "
             "gil_after = sys._is_gil_enabled() if hasattr(sys, '_is_gil_enabled') else True; "
             "print('gil_after_import:', gil_after); "
             "assert not gil_after, 'GIL was re-enabled by sky_player_rs import!'"
@@ -255,6 +295,7 @@ def main() -> int:
         clean_env.pop("PYTHONPATH", None)
         clean_env.pop("VIRTUAL_ENV", None)
         clean_env["SKY_EXPECTED_BUILD_COMMIT"] = expected_commit
+        clean_env["SKY_EXPECTED_RUSTC_PREFIX"] = expected_rustc_prefix
         print("[build_rust_wheel] Verifying exact wheel import, ABI, commit and GIL...")
         test_res = subprocess.run(
             [str(clean_python), "-c", test_code],
@@ -291,8 +332,21 @@ def main() -> int:
         )
         return active_install.returncode
 
+    try:
+        import sky_player_rs
+
+        verify_build_info(
+            dict(sky_player_rs.build_info()),
+            expected_commit=expected_commit,
+            expected_rustc_prefix=expected_rustc_prefix,
+        )
+    except (ImportError, RuntimeError) as exc:
+        print(f"[build_rust_wheel] ERROR: active wheel metadata verification failed: {exc}", file=sys.stderr)
+        return 1
+
     active_env = os.environ.copy()
     active_env["SKY_EXPECTED_BUILD_COMMIT"] = expected_commit
+    active_env["SKY_EXPECTED_RUSTC_PREFIX"] = expected_rustc_prefix
     active_env.pop("PYTHONPATH", None)
     print("[build_rust_wheel] Verifying the active environment wheel...")
     active_test = subprocess.run(
@@ -302,7 +356,8 @@ def main() -> int:
             "import os, sky_player_rs; info = sky_player_rs.build_info(); "
             "print('active_build_info:', info); "
             "assert info.get('native_abi') == 'cp314t-win_amd64', info; "
-            "assert info.get('native_build_commit') == os.environ['SKY_EXPECTED_BUILD_COMMIT'], info",
+            "assert info.get('native_build_commit') == os.environ['SKY_EXPECTED_BUILD_COMMIT'], info; "
+            "assert info.get('rustc_version', '').startswith(os.environ['SKY_EXPECTED_RUSTC_PREFIX']), info",
         ],
         cwd=str(repo_root),
         env=active_env,

--- a/src/build_app.py
+++ b/src/build_app.py
@@ -35,9 +35,49 @@ NATIVE_CALIBRATION_BINARY = "native_calibration.exe"
 NATIVE_UPDATER_BINARY = "Sky-Auto-Player-Updater.exe"
 REQUIRED_ASSETS = ("config.json", "songs")
 OPTIONAL_ASSETS = ("README.md",)
+RUST_TOOLCHAIN_FILE = PROJECT_ROOT / "rust" / "rust-toolchain.toml"
 
 VERSION_PY = PROJECT_ROOT / "src" / "sky_music" / "_version.py"
 NATIVE_BUILD_PY = PROJECT_ROOT / "src" / "sky_music" / "_native_build.py"
+
+
+def get_pinned_rust_toolchain() -> str:
+    """Read and validate the exact Rust channel used by native builds."""
+    try:
+        with RUST_TOOLCHAIN_FILE.open("rb") as source:
+            data = tomllib.load(source)
+    except OSError as exc:
+        raise RuntimeError(f"Cannot read Rust toolchain file: {RUST_TOOLCHAIN_FILE}") from exc
+
+    channel = data.get("toolchain", {}).get("channel")
+    if not isinstance(channel, str) or re.fullmatch(r"\d+\.\d+\.\d+", channel) is None:
+        raise RuntimeError(
+            f"Rust toolchain file must pin an exact x.y.z channel: {RUST_TOOLCHAIN_FILE}"
+        )
+    return channel
+
+
+def expected_rustc_version_prefix() -> str:
+    return f"rustc {get_pinned_rust_toolchain()} "
+
+
+def native_build_environment() -> dict[str, str]:
+    env = os.environ.copy()
+    env["RUSTUP_TOOLCHAIN"] = get_pinned_rust_toolchain()
+    return env
+
+
+def cargo_release_build_command(manifest: Path, binary: str) -> list[str]:
+    return [
+        "cargo",
+        "build",
+        "--manifest-path",
+        str(manifest),
+        "--bin",
+        binary,
+        "--release",
+        "--locked",
+    ]
 
 def generate_version_py(version: str) -> None:
     """Write the current version into ``_version.py`` so frozen builds
@@ -127,6 +167,13 @@ def verify_native_build_info(expected_commit: str) -> None:
                 f"native build metadata mismatch for {field}: "
                 f"expected {expected!r}, actual {info.get(field)!r}"
             )
+    rustc_version = info.get("rustc_version")
+    expected_prefix = expected_rustc_version_prefix()
+    if not isinstance(rustc_version, str) or not rustc_version.startswith(expected_prefix):
+        raise RuntimeError(
+            "native build metadata mismatch for rustc_version: "
+            f"expected prefix {expected_prefix!r}, actual {rustc_version!r}"
+        )
 
 def get_project_version() -> str:
     path = PROJECT_ROOT / "pyproject.toml"
@@ -459,16 +506,17 @@ def main() -> None:
     if rust_dir.exists():
         print("[+] Rust workspace detected. Running Rust wheel precheck...")
         build_script = PROJECT_ROOT / "scripts" / "build_rust_wheel.py"
+        native_build_env = native_build_environment()
         subprocess.run(
             [sys.executable, str(build_script)],
             check=True,
             cwd=str(PROJECT_ROOT),
+            env=native_build_env,
         )
         verify_native_build_info(git_head)
         calibration_manifest = rust_dir / "crates" / "sky_dispatch_win32" / "Cargo.toml"
         print("[+] Building the process-isolated native calibration binary...")
         native_build_commit = git_head
-        native_build_env = os.environ.copy()
         native_build_env["GITHUB_SHA"] = native_build_commit
         native_build_env["SKY_NATIVE_BUILD_COMMIT"] = native_build_commit
         from sky_music.orchestration.native_provenance import native_source_fingerprint
@@ -478,15 +526,7 @@ def main() -> None:
         )
         native_build_env["SKY_NATIVE_DIRTY_WORKTREE"] = "false"
         subprocess.run(
-            [
-                "cargo",
-                "build",
-                "--manifest-path",
-                str(calibration_manifest),
-                "--bin",
-                "native_calibration",
-                "--release",
-            ],
+            cargo_release_build_command(calibration_manifest, "native_calibration"),
             check=True,
             cwd=str(PROJECT_ROOT),
             env=native_build_env,
@@ -494,15 +534,7 @@ def main() -> None:
         updater_manifest = rust_dir / "crates" / "sky_updater" / "Cargo.toml"
         print("[+] Building the native self-updater...")
         subprocess.run(
-            [
-                "cargo",
-                "build",
-                "--manifest-path",
-                str(updater_manifest),
-                "--bin",
-                "sky_updater",
-                "--release",
-            ],
+            cargo_release_build_command(updater_manifest, "sky_updater"),
             check=True,
             cwd=str(PROJECT_ROOT),
             env=native_build_env,

--- a/tests/test_build_rust_wheel.py
+++ b/tests/test_build_rust_wheel.py
@@ -21,6 +21,30 @@ def _load_build_module() -> ModuleType:
 BUILD = _load_build_module()
 
 
+def test_wheel_build_reads_exact_toolchain_and_checks_compiler_metadata() -> None:
+    rust_dir = Path(__file__).parents[1] / "rust"
+    assert BUILD.pinned_rust_toolchain(rust_dir) == "1.98.0"
+    BUILD.verify_build_info(
+        {
+            "rustc_version": "rustc 1.98.0 (test)",
+            "native_abi": "cp314t-win_amd64",
+            "native_build_commit": "commit",
+        },
+        expected_commit="commit",
+        expected_rustc_prefix="rustc 1.98.0 ",
+    )
+    with pytest.raises(RuntimeError, match="wrong compiler"):
+        BUILD.verify_build_info(
+            {
+                "rustc_version": "rustc 1.97.1 (wrong-toolchain)",
+                "native_abi": "cp314t-win_amd64",
+                "native_build_commit": "commit",
+            },
+            expected_commit="commit",
+            expected_rustc_prefix="rustc 1.98.0 ",
+        )
+
+
 def test_build_commit_requires_clean_matching_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(BUILD, "git_head", lambda repo_root: "head-commit")
     monkeypatch.setattr(BUILD, "git_status", lambda repo_root: "")

--- a/tests/test_native_acceptance.py
+++ b/tests/test_native_acceptance.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -441,6 +443,49 @@ def test_test_support_native_rejects_same_key_zero_gap_before_start() -> None:
         rt_priority_mode="off",
         game_fps=60,
     )
+
+
+@pytest.mark.windows
+def test_test_support_worker_wait_path_exits_cleanly_in_child_process() -> None:
+    if not callable(getattr(sky_player_rs, "TestDispatchSession", None)):
+        pytest.skip("requires the test-support native wheel")
+
+    child_code = """
+import sky_player_rs
+
+scan_code = sky_player_rs.instrument_scan_codes()[0]
+actions = [
+    (0, "down", 100_000, [scan_code], "worker-down"),
+    (1, "up", 200_000, [scan_code], "worker-up"),
+]
+session = sky_player_rs.TestDispatchSession(
+    actions,
+    [scan_code],
+    min_hold_us=100,
+    game_fps=60,
+    mock_latency_base_us=0,
+    mock_latency_per_key_us=0,
+    enable_waitable_timer=True,
+    enable_event_wait=True,
+)
+session.start()
+assert session.join(timeout_ms=5000) is True
+snapshot = dict(session.snapshot())
+assert snapshot["is_finished"] is True, snapshot
+info = sky_player_rs.build_info()
+assert info["rustc_version"].startswith("rustc 1.98.0 "), info
+"""
+    child_env = os.environ.copy()
+    child_env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [sys.executable, "-c", child_code],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=child_env,
+        check=False,
+    )
+    assert result.returncode == 0, f"child stdout={result.stdout}\nchild stderr={result.stderr}"
 
 
 def test_production_correctness_counters_are_acceptance_gates() -> None:

--- a/tests/test_native_acceptance.py
+++ b/tests/test_native_acceptance.py
@@ -727,9 +727,9 @@ def test_workflow_keeps_required_gates_without_optional_benchmark_wiring() -> No
     assert workflow.index(manual_branch) < workflow.index(path_diff)
     assert "fetch-depth: 0" in workflow
     assert "cargo fmt --manifest-path rust/Cargo.toml --all -- --check" in workflow
-    assert "cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --all-features" in workflow
-    assert "cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features -- -D warnings" in workflow
-    assert "cargo test --manifest-path rust/Cargo.toml --workspace --all-features" in workflow
+    assert "cargo check --manifest-path rust/Cargo.toml --workspace --all-targets --all-features --locked" in workflow
+    assert "cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --all-features --locked -- -D warnings" in workflow
+    assert "cargo test --manifest-path rust/Cargo.toml --workspace --all-features --locked" in workflow
     assert "scripts/build_rust_wheel.py --test-support" in workflow
     assert "uv run pytest -m \"not slow\"" in workflow
     assert "baseline_sha:" not in workflow

--- a/tests/test_native_admission.py
+++ b/tests/test_native_admission.py
@@ -11,7 +11,7 @@ APP_COMMIT = "a" * 40
 BASE_INFO: dict[str, object] = {
     "version": "0.1.0",
     "rust_core_version": "0.1.0",
-    "rustc_version": "rustc 1.97.1",
+    "rustc_version": "rustc 1.98.0",
     "schema_version": 4,
     "native_schema_version": 4,
     "native_abi": "cp314t-win_amd64",

--- a/tests/test_native_doctor.py
+++ b/tests/test_native_doctor.py
@@ -11,7 +11,7 @@ APP_COMMIT = "a" * 40
 def test_native_doctor_reports_build_metadata(monkeypatch) -> None:
     info = {
         "rust_core_version": "0.1.0",
-        "rustc_version": "rustc 1.97.1",
+        "rustc_version": "rustc 1.98.0",
         "pyo3_version": "0.29.0",
         "native_abi": "cp314t-win_amd64",
         "schema_version": 4,
@@ -34,7 +34,7 @@ def test_native_doctor_reports_build_metadata(monkeypatch) -> None:
 
     assert result["ok"] is True
     assert result["required"] is True
-    assert "rustc 1.97.1" in result["msg"]
+    assert "rustc 1.98.0" in result["msg"]
     assert "cp314t-win_amd64" in result["msg"]
     assert result["mode"] == "source development"
     assert result["commit_match"] is None
@@ -43,7 +43,7 @@ def test_native_doctor_reports_build_metadata(monkeypatch) -> None:
 
 def test_native_doctor_reports_frozen_release_contract(monkeypatch) -> None:
     info = {
-        "rustc_version": "rustc 1.97.1",
+        "rustc_version": "rustc 1.98.0",
         "native_abi": "cp314t-win_amd64",
         "schema_version": 4,
         "native_schema_version": 4,

--- a/tests/test_unsigned_release_contract.py
+++ b/tests/test_unsigned_release_contract.py
@@ -55,6 +55,12 @@ def test_native_package_paths_pin_rust_compiler_explicitly() -> None:
     assert "RUSTUP_TOOLCHAIN: 1.98.0" in ci_workflow
     assert "RUSTUP_TOOLCHAIN: 1.98.0" in release_workflow
     assert "uv run --env-file .env python -m build_app" in release_workflow
+    assert (
+        "- name: Native updater security E2E\n"
+        "        env:\n"
+        "          RUSTUP_TOOLCHAIN: 1.98.0\n"
+        "        run: cargo test"
+    ) in ci_workflow
 
 
 def test_unsigned_release_tree_is_exact_and_has_verified_native_updater(tmp_path: Path) -> None:

--- a/tests/test_unsigned_release_contract.py
+++ b/tests/test_unsigned_release_contract.py
@@ -44,6 +44,19 @@ def test_release_workflow_is_unsigned_but_keeps_integrity_gates() -> None:
         assert required in workflow
 
 
+def test_native_package_paths_pin_rust_compiler_explicitly() -> None:
+    ci_workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Rust — install pinned stable toolchain for packaged build" in ci_workflow
+    assert "Expected stable Rust 1.98.0 for packaged build" in ci_workflow
+    assert "RUSTUP_TOOLCHAIN: 1.98.0" in ci_workflow
+    assert "RUSTUP_TOOLCHAIN: 1.98.0" in release_workflow
+    assert "uv run --env-file .env python -m build_app" in release_workflow
+
+
 def test_unsigned_release_tree_is_exact_and_has_verified_native_updater(tmp_path: Path) -> None:
     verifier = _load_manifest_verifier()
     release_dir = tmp_path / "release"

--- a/tests/test_write_release_manifest.py
+++ b/tests/test_write_release_manifest.py
@@ -71,6 +71,18 @@ def test_get_git_head_rejects_dirty_release_checkout(monkeypatch: pytest.MonkeyP
     assert build_app.get_git_head(require_clean=False) == "abc123-dirty"
 
 
+def test_native_build_commands_use_pinned_toolchain_and_locked_dependencies() -> None:
+    import build_app
+
+    assert build_app.get_pinned_rust_toolchain() == "1.98.0"
+    assert build_app.native_build_environment()["RUSTUP_TOOLCHAIN"] == "1.98.0"
+    for command in (
+        build_app.cargo_release_build_command(Path("calibration/Cargo.toml"), "native_calibration"),
+        build_app.cargo_release_build_command(Path("updater/Cargo.toml"), "sky_updater"),
+    ):
+        assert command[-1] == "--locked"
+
+
 def test_verify_native_build_info_requires_matching_release_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -79,6 +91,7 @@ def test_verify_native_build_info_requires_matching_release_metadata(
     expected_commit = "a" * 40
     native_info = {
         "native_build_commit": expected_commit,
+        "rustc_version": "rustc 1.98.0 (test)",
         "native_abi": build_app.EXPECTED_NATIVE_ABI,
         "schema_version": build_app.RUST_DISPATCH_SCHEMA_VERSION,
         "native_schema_version": build_app.RUST_DISPATCH_SCHEMA_VERSION,
@@ -92,4 +105,9 @@ def test_verify_native_build_info_requires_matching_release_metadata(
 
     native_info["native_build_commit"] = "b" * 40
     with pytest.raises(RuntimeError, match="native_build_commit"):
+        build_app.verify_native_build_info(expected_commit)
+
+    native_info["native_build_commit"] = expected_commit
+    native_info["rustc_version"] = "rustc 1.97.1 (wrong-toolchain)"
+    with pytest.raises(RuntimeError, match="rustc_version"):
         build_app.verify_native_build_info(expected_commit)


### PR DESCRIPTION
## Summary

Follow-up to the Rust 1.98 migration audit.

- Enforce the exact pin from `rust/rust-toolchain.toml` through `build_app`, wheel, calibration, updater, packaged CI, and release paths.
- Add `--locked` to shipped calibration/updater builds.
- Fail closed when native metadata does not report the exact `rustc 1.98.0 ` prefix.
- Add production-like worker wait/timer teardown evidence plus test-support child-process smoke.
- Add regression coverage and update the current toolchain policy.

## Validation

- Rust fmt, Clippy `-D warnings`, and locked workspace tests: pass.
- Python Ruff, Pyright, security audit, architecture check, and full pytest: pass.
- Clean `build_app --manifest` with Rust 1.98: pass, including frozen textual/optimization/Rust smoke tests and manifest verification.
- Physical 10k/100k qualification remains pending and is intentionally not claimed here.