### PR TITLE
fix(timing): strengthen same-key release visibility

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,15 +62,26 @@ The compatibility `send_started_ticks` and `send_completed_ticks` fields refer
 to `pre_call_qpc` and `sendinput_completion_qpc`; they do not cause an
 additional production QPC sample.
 
+Timing evidence has four distinct boundaries: the authored target, sender
+pre-call QPC, SendInput completion QPC, and game observation. The application
+can verify only the first three; completion evidence cannot prove game
+sampling. `require_focus=true` is a safety profile with a final foreground
+verification cost, so it is not promised to have the same latency as
+`require_focus=false`.
+
 For an authored same-key Down→Up pair, the schedule must satisfy:
 
 ```text
 authored_up >= authored_down + effective_min_hold
-next_same_key_down - previous_same_key_up >= one_frame_period
+next_same_key_down - previous_same_key_up >= min_release_gap_us
 ```
 
 `effective_min_hold` is materialized by Python as
 `ceil(hold_frames * ceil(1_000_000 / fps)) + 500 µs + transport_margin`.
+The release visibility policy is materialized alongside it as
+`ceil(1_000_000 / fps) + 500 µs + transport_margin`. The 500 µs Down grace
+and calibrated transport component are one static sender headroom budget;
+the release gap is not a claim that the game observed the Up transition.
 The transport component defaults/falls back to `300 µs`; calibration may
 replace only that component. PyO3 passes the materialized value verbatim; Rust
 range-checks it and validates both relationships in QPC ticks. Same-timestamp
@@ -123,6 +134,14 @@ hold selection, and schedule timing before creating a native session. The
 native boundary exposes lifecycle commands, target/focus hints, a small live
 snapshot, and one final report. `snapshot_lite` excludes trace records, maps,
 generation detail, and compatibility estimator payloads.
+
+The resolved `min_release_gap_us` is one application contract value: it is
+materialized by `FrameTimingPolicy`, forwarded by `PlaybackEngine` and
+`RustDispatchRuntime`, carried by PyO3 `SessionConfig` into native
+`TimingOptions`, used by microsecond and QPC admission, and converted once for
+production release-gap forensics. The Rust application path does not derive a
+replacement value from FPS; only the backward-compatible omitted PyO3 argument
+uses the legacy one-frame fallback for external callers.
 
 The active Python/native session contract does not carry estimator state.
 Historical lead and estimator artifacts are not timing inputs and cannot

--- a/docs/hold-frame-model.md
+++ b/docs/hold-frame-model.md
@@ -4,6 +4,13 @@ Sky Auto Player accepts exactly three explicit hold selections: `1.0`,
 `1.25`, and `1.5` frames. The default is `1.0` at the user-selected game
 FPS. FPS is never detected, inferred, or changed from runtime observations.
 
+Timing evidence has four boundaries: the authored target, sender pre-call QPC,
+SendInput completion QPC, and game observation. This application can verify
+the first three sender-side boundaries only; completion evidence does not prove
+that the game sampled the transition. `require_focus=true` is a safety profile
+with a final foreground-verification cost, so the two focus modes are not
+promised identical latency.
+
 For a selected ratio and FPS, Python first materializes the requested hold:
 
 ```text
@@ -14,6 +21,8 @@ transport_margin_us = max(0, calibrated_or_default_transport_margin_us)
 effective_min_hold_us = (
     frame_base_hold_us + down_late_grace_us + transport_margin_us
 )
+sender_headroom_us = down_late_grace_us + transport_margin_us
+min_release_gap_us = frame_us + sender_headroom_us
 ```
 
 The independent Down late-discovery grace is `500 µs`. The default and every
@@ -32,6 +41,11 @@ keeps the evidence unhealthy, and falls back to the `300 µs` transport floor.
 Protocol 9/cache v5/v6/v7 evidence is incompatible with protocol 10/cache v8
 and falls back to the explicit transport floor.
 
+The release gap reserves the same static sender headroom as the hold floor:
+one base game frame plus `down_late_grace_us + transport_margin_us`. It is an
+authored schedule value, not a runtime delay or a guarantee that the game
+sampled Up before the next Down.
+
 The sender evidence is computed in raw QPC ticks before conversion:
 
 ```text
@@ -43,10 +57,11 @@ sender_hold_shrink = ((P_D - T_D) - (P_U - T_U))
 The identity is checked with checked arithmetic. It describes completion
 interval compression in the Rust/SendInput sender only; it is not a claim
 about game-observed timing.
-The native worker receives only the materialized `effective_min_hold_us` and
-uses it as a fixed duration. PyO3 does not add another frame-relative floor;
-Rust only range-checks and validates this value in QPC ticks. It does not learn
-or subtract SendInput cost. `FrameTimingPolicy.min_hold_margin_us` is the
+The native worker receives the materialized `effective_min_hold_us` and
+`min_release_gap_us` values and uses them as fixed durations. PyO3 does not add
+another frame-relative floor; Rust only range-checks and validates these values
+in QPC ticks. It does not learn or subtract SendInput cost.
+`FrameTimingPolicy.min_hold_margin_us` is the
 compatibility aggregate of the fixed Down grace and transport margin; the
 explicit policy fields retain the frame-base, grace, transport, and release-gap
 components. `min_hold_margin_source` records transport provenance.
@@ -64,11 +79,16 @@ the first QPC tick beyond it is a missed Down. Up-only releases remain exempt.
 
 At 60 FPS with the default margin:
 
-| Hold | Requested | Effective |
-|---:|---:|---:|
-| 1.0 frame | 16,667 µs | 17,467 µs |
-| 1.25 frames | 20,834 µs | 21,634 µs |
-| 1.5 frames | 25,001 µs | 25,801 µs |
+| Hold | Requested | Effective hold | Release gap |
+|---:|---:|---:|---:|
+| 1.0 frame | 16,667 µs | 17,467 µs | 17,467 µs |
+| 1.25 frames | 20,834 µs | 21,634 µs | 17,467 µs |
+| 1.5 frames | 25,001 µs | 25,801 µs | 17,467 µs |
+
+At 60 FPS with the default 1.0-frame selection, the exact same-key minimum
+cycle is `17,467 + 17,467 = 34,934 µs` (about 28.63 repeated presses per
+second per key). This is a deliberate sender-side reliability tradeoff; it is
+not a claim about game frame registration.
 
 ## Authored minimum-hold validation
 
@@ -81,17 +101,18 @@ authored_up >= authored_down + effective_min_hold_us
 
 The static margin is materialized once while building the authored schedule.
 The native boundary validates this interval in checked QPC ticks before the
-worker starts. It also requires at least one frame period between a same-key
-Up and the next same-key Down. An invalid schedule is rejected; the runtime
-never delays or replaces authored targets to repair it.
+worker starts. It also requires `min_release_gap_us` between a same-key Up and
+the next same-key Down. An invalid schedule is rejected; the runtime never
+delays or replaces authored targets to repair it.
 
 ## Feasibility and diagnostics
 
 Authored validation rejects a same-key interval below the selected hold floor.
 The native-boundary validator performs this check before the worker can send
 anything, including exact same-timestamp retriggers and timestamp overflow
-cases. It also requires the next same-key Down to be at least one frame period
-after the previous same-key Up. Equal release-gap boundaries are valid;
+cases. It also requires the next same-key Down to meet the materialized
+`min_release_gap_us` after the previous same-key Up. Equal release-gap
+boundaries are valid;
 same-timestamp same-key overlaps are rejected, while disjoint masks may still
 coalesce. Runtime never delays, retries, or rewrites these authored targets.
 Completion is evidence for sender-side telemetry and ownership accounting

--- a/docs/rt-dispatch-architecture.md
+++ b/docs/rt-dispatch-architecture.md
@@ -240,19 +240,23 @@ frame_base_hold_us = ceil(hold_frames * frame_us)
 down_late_grace_us = policy.down_late_grace_us
 transport_margin_us = max(0, calibrated_or_default_transport_margin_us)
 effective_min_hold_us = frame_base_hold_us + down_late_grace_us + transport_margin_us
+sender_headroom_us = down_late_grace_us + transport_margin_us
+min_release_gap_us = frame_us + sender_headroom_us
 ```
 
 Native admission checked tick arithmetic enforces before worker start:
 
 ```text
 authored_up >= authored_down + effective_min_hold
-next_same_key_down - previous_same_key_up >= one_frame_period
+next_same_key_down - previous_same_key_up >= min_release_gap_us
 ```
 
 The static components are materialized once into the authored schedule. The
 `FrameTimingPolicy.min_hold_margin_us` compatibility field contains the
 Down-grace-plus-transport aggregate; explicit fields retain the frame base,
-grace, transport margin, release gap, and transport provenance.
+grace, transport margin, release gap, and transport provenance. The release
+gap reserves one frame plus the same bounded sender headroom; it is sender-side
+visibility policy, not evidence that the game sampled the Up transition.
 An invalid
 interval fails native admission before any musical SendInput. The worker never
 combines Down completion with the authored hold to create a second floor, never
@@ -274,7 +278,7 @@ while Up-only safety releases remain exempt.
 
 The worker uses a high-resolution waitable timer and event interruption to the
 `T - 2,000 µs` admission boundary with zero waiter spin. The final authored
-precision stage has a bounded QPC spin fixed at `700 µs` in production. A timer guard may wake early;
+precision stage has a bounded QPC spin fixed at `1,000 µs` in production. A timer guard may wake early;
 the final QPC deadline gate
 decides whether to wait again or enter the physical path. A wake that is only
 for lease, command, focus, pause, or interrupt replans and cannot dispatch the

--- a/docs/timing-principles.md
+++ b/docs/timing-principles.md
@@ -23,12 +23,18 @@ microsecond conversions.
 | `effective_min_hold` | Fixed materialized hold floor passed into the native worker. |
 | `down_late_grace` | Independent fixed sender correctness grace for authorized Down admission; production is `500 µs`. |
 | `transport_margin` | Calibrated sender transport component; default/fallback is `300 µs` and calibration never changes the Down grace. |
-| `min_release_gap` | One frame period at the selected FPS between a same-key Up and the next same-key Down. |
+| `min_release_gap` | One frame period plus the same static sender headroom reserved for the hold floor, between a same-key Up and the next same-key Down. |
 | `authored_hold_valid` | Pre-start proof that authored Down→Up spacing meets the materialized hold. |
 
 The worker never applies a learned dispatch-cost lead to `scheduled` or
 `physical_target`. Historical `dispatch_lead_us`, estimator state, and lead
 saturation fields are accepted only for compatibility and are non-operative.
+
+The timing evidence has four distinct boundaries: the authored target, the
+sender pre-call QPC, the SendInput completion QPC, and game observation. Only
+the first three are available to this application. `require_focus=true` is a
+safety profile with a final foreground-verification cost; it must not be
+described as having the same latency as `require_focus=false`.
 
 ## 2. Hold and release contract
 
@@ -43,7 +49,8 @@ transport_margin_us = max(0, calibrated_or_default_transport_margin_us)
 effective_min_hold = (
     frame_base_hold_us + down_late_grace_us + transport_margin_us
 )
-min_release_gap_us = frame_us
+sender_headroom_us = down_late_grace_us + transport_margin_us
+min_release_gap_us = frame_us + sender_headroom_us
 ```
 
 For every authored same-key Down→Up pair:
@@ -59,6 +66,11 @@ checks this relationship before worker start in
 the same QPC tick domain used by dispatch. If the interval is invalid, native
 admission fails before any musical packet can be sent; the worker never
 reschedules the Up target.
+
+The release gap is authored statically and uses the same bounded sender-side
+headroom as the hold floor. Runtime never delays the next Down to repair a
+boundary. Sender completion evidence can verify the sender-side interval, but
+it does not prove that the game sampled either transition.
 
 `FrameTimingPolicy.min_hold_margin_us` remains a compatibility aggregate of the
 Down grace and transport component. The explicit policy fields are
@@ -371,7 +383,7 @@ authorization.
 
 The production wait path is a high-resolution waitable timer to the
 `T - 2,000 µs` admission boundary with zero waiter spin. The only production
-busy-spin is the final authored precision stage, fixed at `700 µs`; no adaptive
+busy-spin is the final authored precision stage, fixed at `1,000 µs`; no adaptive
 probe, EMA, PID, or runtime threshold controller is allowed. Timer/wake guard
 is kept separate from the absolute physical target.
 Interrupts, lease-only wakes, focus changes, and command transitions invalidate

--- a/rust/crates/sky_player_rs/src/engine/config.rs
+++ b/rust/crates/sky_player_rs/src/engine/config.rs
@@ -3,7 +3,7 @@ use sky_dispatch_core::model::RuntimeSchedule;
 use sky_dispatch_win32::mmcss::PriorityMode;
 
 pub(crate) const DEFAULT_ADMISSION_GUARD_US: u64 = 2_000;
-pub(crate) const DEFAULT_SPIN_THRESHOLD_US: u64 = 700;
+pub(crate) const DEFAULT_SPIN_THRESHOLD_US: u64 = 1_000;
 pub(crate) const MIN_PRODUCTION_PREROLL_US: u64 = 50_000;
 
 pub(crate) fn validate_timing_constants() -> Result<(), String> {
@@ -209,7 +209,13 @@ pub(crate) struct PriorityOptions {
 
 #[cfg(test)]
 mod tests {
-    use super::DispatchProfile;
+    use super::{DEFAULT_SPIN_THRESHOLD_US, DispatchProfile};
+
+    #[test]
+    fn production_wait_policy_uses_fixed_spin_threshold() {
+        assert_eq!(DEFAULT_SPIN_THRESHOLD_US, 1_000);
+        assert!(super::validate_timing_constants().is_ok());
+    }
 
     #[test]
     fn production_profile_has_no_deferred_observer() {

--- a/rust/crates/sky_player_rs/src/engine/config.rs
+++ b/rust/crates/sky_player_rs/src/engine/config.rs
@@ -139,6 +139,7 @@ impl Default for WorkerConfig {
             timing: TimingOptions {
                 game_fps: 60,
                 min_hold_us: 10_000,
+                min_release_gap_us: 16_667,
                 // Production's public default is 500 us. Test-support
                 // sessions supply their own explicit timing policy.
                 down_late_grace_us: 500,
@@ -172,6 +173,7 @@ impl Default for WorkerConfig {
 pub(crate) struct TimingOptions {
     pub(crate) game_fps: u16,
     pub(crate) min_hold_us: u64,
+    pub(crate) min_release_gap_us: u64,
     pub(crate) down_late_grace_us: u64,
     pub(crate) strict_timing: bool,
     pub(crate) strict_down_completion_late_us: u64,

--- a/rust/crates/sky_player_rs/src/engine/session.rs
+++ b/rust/crates/sky_player_rs/src/engine/session.rs
@@ -87,7 +87,7 @@ impl NativeDispatchSession {
         // after the worker has started.
         let qpc_clock = QpcClock::initialize()
             .map_err(|error| format!("QPC admission failed before session creation: {error:?}"))?;
-        let min_release_gap_us = 1_000_000u64.div_ceil(u64::from(options.timing.game_fps));
+        let min_release_gap_us = options.timing.min_release_gap_us;
         validate_native_schedule_timing_with_release_gap(
             &options.schedule,
             options.timing.min_hold_us,

--- a/rust/crates/sky_player_rs/src/engine/tests.rs
+++ b/rust/crates/sky_player_rs/src/engine/tests.rs
@@ -41,6 +41,7 @@ fn test_session_options(
         timing: TimingOptions {
             game_fps: 60,
             min_hold_us: 0,
+            min_release_gap_us: 16_667,
             down_late_grace_us: 500,
             strict_timing: false,
             strict_down_completion_late_us: 2_000,
@@ -4672,6 +4673,134 @@ fn native_min_hold_admission_uses_runtime_qpc_tick_domain() {
             .as_ref()
             .is_err_and(|error| error.contains("same-key hold too short")),
         "tick-domain admission must reject before worker creation: {result:?}"
+    );
+}
+
+#[test]
+fn native_release_gap_admission_accepts_exact_explicit_boundary() {
+    let actions = [
+        KeyActionInput {
+            source_action_index: 0,
+            kind: ActionKind::Down,
+            scheduled_us: 0,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "down-a".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 1,
+            kind: ActionKind::Up,
+            scheduled_us: 100,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "up-a".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 2,
+            kind: ActionKind::Down,
+            scheduled_us: 16_767,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "down-b".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 3,
+            kind: ActionKind::Up,
+            scheduled_us: 16_867,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "up-b".to_string().into(),
+        },
+    ];
+    let schedule = sky_dispatch_core::compile::compile_runtime_intents(&actions, &[0x15])
+        .expect("valid exact release-gap schedule");
+    let qpc_clock = QpcClock::from_frequency_hz(
+        std::num::NonZeroU64::new(1_000_000).expect("non-zero test frequency"),
+    );
+    let result = super::session::validate_native_schedule_timing_with_release_gap(
+        &schedule, 100, 16_667, qpc_clock,
+    );
+    assert!(
+        result.is_ok(),
+        "exact release gap must be accepted: {result:?}"
+    );
+}
+
+#[test]
+fn native_release_gap_admission_rejects_one_microsecond_short() {
+    let actions = [
+        KeyActionInput {
+            source_action_index: 0,
+            kind: ActionKind::Down,
+            scheduled_us: 0,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "down-a".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 1,
+            kind: ActionKind::Up,
+            scheduled_us: 100,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "up-a".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 2,
+            kind: ActionKind::Down,
+            scheduled_us: 16_766,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "down-b".to_string().into(),
+        },
+    ];
+    let schedule = sky_dispatch_core::compile::compile_runtime_intents(&actions, &[0x15])
+        .expect("valid short release-gap schedule");
+    let qpc_clock = QpcClock::from_frequency_hz(
+        std::num::NonZeroU64::new(1_000_000).expect("non-zero test frequency"),
+    );
+    let result = super::session::validate_native_schedule_timing_with_release_gap(
+        &schedule, 100, 16_667, qpc_clock,
+    );
+    assert!(
+        result
+            .as_ref()
+            .is_err_and(|error| error.contains("release gap")),
+        "one microsecond below the release policy must reject: {result:?}"
+    );
+}
+
+#[test]
+fn native_release_gap_admission_checks_qpc_tick_rounding() {
+    let actions = [
+        KeyActionInput {
+            source_action_index: 0,
+            kind: ActionKind::Down,
+            scheduled_us: 0,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "down-a".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 1,
+            kind: ActionKind::Up,
+            scheduled_us: 100,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "up-a".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 2,
+            kind: ActionKind::Down,
+            scheduled_us: 200,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "down-b".to_string().into(),
+        },
+    ];
+    let schedule = sky_dispatch_core::compile::compile_runtime_intents(&actions, &[0x15])
+        .expect("valid microsecond release-gap schedule");
+    let qpc_clock = QpcClock::from_frequency_hz(
+        std::num::NonZeroU64::new(3_125_000).expect("non-zero test frequency"),
+    );
+    let result = super::session::validate_native_schedule_timing_with_release_gap(
+        &schedule, 100, 100, qpc_clock,
+    );
+    assert!(
+        result
+            .as_ref()
+            .is_err_and(|error| error.contains("tick-domain") && error.contains("release gap")),
+        "QPC tick rounding must remain authoritative: {result:?}"
     );
 }
 

--- a/rust/crates/sky_player_rs/src/engine/worker/boot.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/boot.rs
@@ -165,9 +165,19 @@ pub(super) fn initialize(worker: &mut Worker<'_>, wait_fault: bool) -> u8 {
             );
         }
     };
+    let release_gap_ticks = match qpc_clock.duration_from_us(config.timing.min_release_gap_us) {
+        Ok(ticks) => ticks,
+        Err(error) => {
+            return admission_failure(
+                &mut backend,
+                metrics,
+                format!("release-gap conversion failed: {error:?}"),
+            );
+        }
+    };
     core.runtime
         .production_forensics
-        .set_frame_policies(frame_ticks, frame_ticks);
+        .set_frame_policies(frame_ticks, release_gap_ticks);
     let down_late_grace_ticks = match qpc_clock.duration_from_us(config.timing.down_late_grace_us) {
         Ok(ticks) => ticks,
         Err(error) => {

--- a/rust/crates/sky_player_rs/src/engine/worker/dispatch/hold_forensics_tests.rs
+++ b/rust/crates/sky_player_rs/src/engine/worker/dispatch/hold_forensics_tests.rs
@@ -401,7 +401,7 @@ fn production_forensics_pairs_fixed_sender_evidence_and_release_gap() {
     let mut forensics = ProductionHoldForensics::default();
     forensics.set_frame_policies(
         DurationTicks::from_raw(16_667),
-        DurationTicks::from_raw(16_667),
+        DurationTicks::from_raw(17_467),
     );
     let mut metrics = WorkerMetricsLocal::default();
     observe_production(
@@ -425,18 +425,18 @@ fn production_forensics_pairs_fixed_sender_evidence_and_release_gap() {
     observe_production(
         &mut forensics,
         PhysicalPacket::new(0, 1),
-        35_000,
-        35_100,
-        35_150,
+        35_500,
+        35_617,
+        35_667,
         SendTransactionStatus::Complete,
         &mut metrics,
     );
     observe_production(
         &mut forensics,
         PhysicalPacket::new(1, 0),
-        52_000,
-        52_100,
-        52_150,
+        52_500,
+        52_617,
+        52_667,
         SendTransactionStatus::Complete,
         &mut metrics,
     );
@@ -445,8 +445,8 @@ fn production_forensics_pairs_fixed_sender_evidence_and_release_gap() {
     assert_eq!(metrics.production_hold_pair_samples, 2);
     assert_eq!(metrics.production_release_gap_samples, 1);
     // Release-gap forensic evidence is measured at the actual Down pre-call
-    // boundary: 35_100 - 18_150, not the authored target 35_000 - 18_150.
-    assert_eq!(metrics.production_min_release_gap_ticks, 16_950);
+    // boundary: 35_617 - 18_150, not the authored target 35_500 - 18_150.
+    assert_eq!(metrics.production_min_release_gap_ticks, 17_467);
     assert_eq!(metrics.production_forensics_anomaly_count, 0);
 }
 

--- a/rust/crates/sky_player_rs/src/python.rs
+++ b/rust/crates/sky_player_rs/src/python.rs
@@ -62,6 +62,7 @@ impl<'a, 'py> FromPyObject<'a, 'py> for StrictU64 {
 struct NativeSessionConfigPy {
     game_fps: u16,
     min_hold_us: u64,
+    min_release_gap_us: u64,
     down_late_grace_us: u64,
     require_focus: bool,
     focus_restore_grace_us: u64,
@@ -75,6 +76,7 @@ impl Default for NativeSessionConfigPy {
         Self {
             game_fps: 60,
             min_hold_us: 50_000,
+            min_release_gap_us: 1_000_000u64.div_ceil(60),
             down_late_grace_us: 500,
             require_focus: false,
             focus_restore_grace_us: 100_000,
@@ -96,7 +98,8 @@ impl NativeSessionConfigPy {
         focus_restore_grace_us = StrictU64(100000),
         target_hwnd = StrictU64(0),
         telemetry = false,
-        profile = "production"
+        profile = "production",
+        min_release_gap_us = None
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -108,6 +111,7 @@ impl NativeSessionConfigPy {
         target_hwnd: StrictU64,
         telemetry: bool,
         profile: &str,
+        min_release_gap_us: Option<StrictU64>,
     ) -> PyResult<Self> {
         let target_hwnd = isize::try_from(target_hwnd.0)
             .map_err(|_| PyValueError::new_err("target_hwnd is outside the platform range"))?;
@@ -138,9 +142,17 @@ impl NativeSessionConfigPy {
         if !(15..=240).contains(&game_fps) {
             return Err(PyValueError::new_err("game_fps must be in 15..=240"));
         }
+        let frame_us = 1_000_000u64.div_ceil(u64::from(game_fps));
+        let min_release_gap_us = min_release_gap_us.map(|value| value.0).unwrap_or(frame_us);
+        if min_release_gap_us < frame_us || min_release_gap_us > 60_000_000 {
+            return Err(PyValueError::new_err(format!(
+                "min_release_gap_us must be in {frame_us}..=60000000"
+            )));
+        }
         Ok(Self {
             game_fps,
             min_hold_us: min_hold_us.0,
+            min_release_gap_us,
             down_late_grace_us: down_late_grace_us.0,
             require_focus,
             focus_restore_grace_us: focus_restore_grace_us.0,
@@ -158,6 +170,11 @@ impl NativeSessionConfigPy {
     #[getter]
     fn min_hold_us(&self) -> u64 {
         self.min_hold_us
+    }
+
+    #[getter]
+    fn min_release_gap_us(&self) -> u64 {
+        self.min_release_gap_us
     }
 
     #[getter]
@@ -223,6 +240,8 @@ mod tests {
 
     #[test]
     fn production_session_config_defaults_to_five_hundred_us_grace() {
-        assert_eq!(NativeSessionConfigPy::default().down_late_grace_us, 500);
+        let config = NativeSessionConfigPy::default();
+        assert_eq!(config.down_late_grace_us, 500);
+        assert_eq!(config.min_release_gap_us, 16_667);
     }
 }

--- a/rust/crates/sky_player_rs/src/python/session.rs
+++ b/rust/crates/sky_player_rs/src/python/session.rs
@@ -17,6 +17,7 @@ struct EffectiveSessionConfig {
     game_fps: u16,
     requested_min_hold_us: u64,
     effective_min_hold_us: u64,
+    min_release_gap_us: u64,
     down_late_grace_us: u64,
     require_focus: bool,
     focus_restore_grace_us: u64,
@@ -30,6 +31,7 @@ impl EffectiveSessionConfig {
         dict.set_item("game_fps", self.game_fps)?;
         dict.set_item("requested_min_hold_us", self.requested_min_hold_us)?;
         dict.set_item("effective_min_hold_us", self.effective_min_hold_us)?;
+        dict.set_item("min_release_gap_us", self.min_release_gap_us)?;
         dict.set_item("down_late_grace_us", self.down_late_grace_us)?;
         dict.set_item("require_focus", self.require_focus)?;
         dict.set_item("focus_restore_grace_us", self.focus_restore_grace_us)?;
@@ -48,6 +50,7 @@ impl NativeDispatchSessionPy {
         let parsed_profile = config.profile;
         let game_fps = config.game_fps;
         let min_hold_us = config.min_hold_us;
+        let min_release_gap_us = config.min_release_gap_us;
         let down_late_grace_us = config.down_late_grace_us;
         // Python materializes the authored hold (frame duration plus the
         // calibrated static margin). Rust receives that value verbatim and
@@ -75,7 +78,6 @@ impl NativeDispatchSessionPy {
             ));
         }
         let schedule = parse_schedule(py_actions)?;
-        let min_release_gap_us = 1_000_000u64.div_ceil(u64::from(game_fps));
         validate_schedule_timing(&schedule, effective_min_hold_us, min_release_gap_us)?;
         let session = NativeDispatchSession::new(NativeSessionOptions {
             schedule,
@@ -84,6 +86,7 @@ impl NativeDispatchSessionPy {
             timing: TimingOptions {
                 game_fps,
                 min_hold_us: effective_min_hold_us,
+                min_release_gap_us,
                 down_late_grace_us,
                 strict_timing,
                 strict_down_completion_late_us,
@@ -124,6 +127,7 @@ impl NativeDispatchSessionPy {
                 game_fps,
                 requested_min_hold_us: min_hold_us,
                 effective_min_hold_us,
+                min_release_gap_us,
                 down_late_grace_us,
                 require_focus,
                 focus_restore_grace_us,
@@ -635,14 +639,15 @@ impl TestDispatchSessionPy {
         game_fps = StrictU64(60),
         mock_latency_base_us = StrictU64(80),
         mock_latency_per_key_us = StrictU64(40),
-         telemetry_capacity = StrictU64(1024),
-         dispatch_lead_us = StrictU64(0),
+        telemetry_capacity = StrictU64(1024),
+        dispatch_lead_us = StrictU64(0),
         rt_priority_mode = "off",
         enable_waitable_timer = true,
         enable_event_wait = true,
         enable_adaptive_spin = true,
         enable_dispatch_cost_lead = true,
-        fault_mode = "none"
+        fault_mode = "none",
+        min_release_gap_us = None
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -660,6 +665,7 @@ impl TestDispatchSessionPy {
         enable_adaptive_spin: bool,
         enable_dispatch_cost_lead: bool,
         fault_mode: &str,
+        min_release_gap_us: Option<StrictU64>,
     ) -> PyResult<Self> {
         let _ = (enable_adaptive_spin, enable_dispatch_cost_lead);
         let min_hold_us = min_hold_us.0;
@@ -667,6 +673,13 @@ impl TestDispatchSessionPy {
             .map_err(|_| PyValueError::new_err("game_fps must be an integer in 15..=240"))?;
         if !(15..=240).contains(&game_fps) {
             return Err(PyValueError::new_err("game_fps must be in 15..=240"));
+        }
+        let frame_us = 1_000_000u64.div_ceil(u64::from(game_fps));
+        let min_release_gap_us = min_release_gap_us.map(|value| value.0).unwrap_or(frame_us);
+        if min_release_gap_us < frame_us || min_release_gap_us > 60_000_000 {
+            return Err(PyValueError::new_err(format!(
+                "min_release_gap_us must be in {frame_us}..=60000000"
+            )));
         }
         let mock_latency_base_us = mock_latency_base_us.0;
         let mock_latency_per_key_us = mock_latency_per_key_us.0;
@@ -717,7 +730,6 @@ impl TestDispatchSessionPy {
         let effective_min_hold_us = min_hold_us;
         let (schedule, _allowed_scan_codes) =
             parse_schedule_with_allowlist(py_actions, allowed_scan_codes)?;
-        let min_release_gap_us = 1_000_000u64.div_ceil(60);
         validate_schedule_timing(&schedule, effective_min_hold_us, min_release_gap_us)?;
         let session = NativeDispatchSession::new(NativeSessionOptions {
             schedule,
@@ -728,8 +740,9 @@ impl TestDispatchSessionPy {
             },
             profile: DispatchProfile::MockTest,
             timing: TimingOptions {
-                game_fps: 60,
+                game_fps,
                 min_hold_us: effective_min_hold_us,
+                min_release_gap_us,
                 down_late_grace_us: 0,
                 strict_timing: false,
                 strict_down_completion_late_us: 2_000,
@@ -747,7 +760,7 @@ impl TestDispatchSessionPy {
                 #[cfg(any(test, feature = "test-support"))]
                 // Test-support sessions use a fixed, test-only precision
                 // margin so correctness fixtures do not become host-wake
-                // latency probes. Production keeps its locked 700 us value.
+                // latency probes. Production keeps its locked 1000 us value.
                 test_spin_threshold_us: Some(20_000),
             },
             telemetry: TelemetryOptions {

--- a/rust/crates/sky_player_rs/type_stubs/sky_player_rs.pyi
+++ b/rust/crates/sky_player_rs/type_stubs/sky_player_rs.pyi
@@ -7,13 +7,14 @@ PlaybackProfile = Literal["production", "strict_timing_diagnostic"]
 class SessionConfig:
     game_fps: int
     min_hold_us: int
+    min_release_gap_us: int
     down_late_grace_us: int
     require_focus: bool
     target_hwnd: int
     telemetry: bool
     focus_restore_grace_us: int
     profile: PlaybackProfile
-    def __init__(self, *, game_fps: int, min_hold_us: int = ..., down_late_grace_us: int = 0, require_focus: bool = ..., target_hwnd: int = ..., telemetry: bool = ..., focus_restore_grace_us: int = ..., profile: PlaybackProfile = ...) -> None: ...
+    def __init__(self, *, game_fps: int, min_hold_us: int = ..., down_late_grace_us: int = 0, require_focus: bool = ..., target_hwnd: int = ..., telemetry: bool = ..., focus_restore_grace_us: int = ..., profile: PlaybackProfile = ..., min_release_gap_us: int | None = ...) -> None: ...
 
 
 class BackendHealthSnapshot:

--- a/scripts/bench_native_acceptance.py
+++ b/scripts/bench_native_acceptance.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
+from sky_music.domain.scheduler_types import FrameTimingPolicy
 from sky_music.layouts import SKY_15_SCAN_CODES
 from sky_music.orchestration.telemetry import (
     TelemetryRecord,
@@ -63,8 +64,6 @@ LATENCY_SEGMENT_DOMAIN = "native_trace_v1"
 SEND_COLD_THRESHOLD_US = 20_000
 HOT_CYCLE_US = 10_000
 COLD_CYCLE_US = 60_000
-DEFAULT_DOWN_LATE_GRACE_US = 500
-DEFAULT_TRANSPORT_MARGIN_US = 300
 MIN_QUALIFICATION_PHYSICAL_BOUNDARIES = 10_000
 
 PRODUCTION_CORRECTNESS_COUNTERS = (
@@ -167,20 +166,36 @@ def _cycle_us(*, game_fps: int, gap_profile: str) -> int:
         return COLD_CYCLE_US
     if gap_profile != "hot":
         raise ValueError("gap_profile must be hot or cold")
-    frame_period_us = (1_000_000 + game_fps - 1) // game_fps
-    hold_us = frame_period_us + DEFAULT_DOWN_LATE_GRACE_US + DEFAULT_TRANSPORT_MARGIN_US
-    return max(HOT_CYCLE_US, hold_us + frame_period_us)
+    return max(HOT_CYCLE_US, _same_key_cycle_us(game_fps=game_fps, gap_profile=gap_profile))
 
 
 def _materialized_hold_us(*, game_fps: int, gap_profile: str) -> int:
     if not 15 <= game_fps <= 240:
         raise ValueError("game_fps must be in 15..=240")
     if gap_profile == "hot":
-        frame_period_us = (1_000_000 + game_fps - 1) // game_fps
-        return frame_period_us + DEFAULT_DOWN_LATE_GRACE_US + DEFAULT_TRANSPORT_MARGIN_US
+        policy = FrameTimingPolicy.from_hold_frames(1.0, game_fps)
+        return int(policy.min_hold_us)
     if gap_profile == "cold":
         return COLD_CYCLE_US // 2
     raise ValueError("gap_profile must be hot or cold")
+
+
+def _materialized_release_gap_us(*, game_fps: int) -> int:
+    """Materialize the static sender-side release visibility policy."""
+
+    if not 15 <= game_fps <= 240:
+        raise ValueError("game_fps must be in 15..=240")
+    policy = FrameTimingPolicy.from_hold_frames(1.0, game_fps)
+    return int(policy.min_release_gap_us)
+
+
+def _same_key_cycle_us(*, game_fps: int, gap_profile: str) -> int:
+    """Return one exact same-key Down/Up/Down cycle duration."""
+
+    return _materialized_hold_us(
+        game_fps=game_fps,
+        gap_profile=gap_profile,
+    ) + _materialized_release_gap_us(game_fps=game_fps)
 
 
 def _actions(
@@ -197,8 +212,12 @@ def _actions(
         raise ValueError(f"polyphony must be in 1..{len(SKY_15_SCAN_CODES)}")
     if gap_profile not in {"hot", "cold"}:
         raise ValueError("gap_profile must be hot or cold")
-    if scenario not in {"paired", "mixed", "coalesced"}:
-        raise ValueError("scenario must be paired, mixed, or coalesced")
+    if scenario not in {"paired", "mixed", "coalesced", "same_key_min_cycle"}:
+        raise ValueError(
+            "scenario must be paired, mixed, coalesced, or same_key_min_cycle"
+        )
+    if scenario == "same_key_min_cycle" and polyphony != 1:
+        raise ValueError("same_key_min_cycle requires polyphony=1")
     if scenario in {"mixed", "coalesced"} and polyphony < 2:
         raise ValueError(
             "mixed/coalesced scenarios require polyphony >= 2; "
@@ -221,7 +240,26 @@ def _actions(
             for group in range(count)
             for offset in range(key_count)
         ]
-    else:
+    elif scenario == "same_key_min_cycle":
+        scan_code = int(SKY_15_SCAN_CODES[0])
+        for index in range(count):
+            at_us = start_delay_us + index * _same_key_cycle_us(
+                game_fps=game_fps,
+                gap_profile=gap_profile,
+            )
+            actions.extend(
+                (
+                    (index * 2, "down", at_us, [scan_code], "same-key-down"),
+                    (
+                        index * 2 + 1,
+                        "up",
+                        at_us + hold_us,
+                        [scan_code],
+                        "same-key-up",
+                    ),
+                )
+            )
+    elif scenario != "same_key_min_cycle":
         boundary_scan_codes = []
     if scenario in {"mixed", "coalesced"}:
         # Each group has one clean Down, one Up+Down mixed boundary, and one
@@ -265,7 +303,7 @@ def _actions(
                     ),
                 )
             )
-    else:
+    elif scenario != "same_key_min_cycle":
         for index in range(count):
             scan_codes = [
                 int(
@@ -370,6 +408,9 @@ def _benchmark_config(
             game_fps=args.game_fps,
             gap_profile=args.gap_profile,
         ),
+        "materialized_release_gap_us": _materialized_release_gap_us(
+            game_fps=args.game_fps,
+        ),
     }
 
 
@@ -435,8 +476,10 @@ def _expected_record_layout(
     actions: list[tuple[int, str, int, list[int], str]],
     scenario: str,
 ) -> list[tuple[int, str, set[int]]]:
-    if scenario not in {"paired", "mixed", "coalesced"}:
-        raise ValueError("scenario must be paired, mixed, or coalesced")
+    if scenario not in {"paired", "mixed", "coalesced", "same_key_min_cycle"}:
+        raise ValueError(
+            "scenario must be paired, mixed, coalesced, or same_key_min_cycle"
+        )
     combined_boundaries = scenario in {"mixed", "coalesced"}
     if combined_boundaries and (len(actions) < 2 or len(actions) % 2 != 0):
         raise ValueError("mixed/coalesced scenarios require Down/Up action pairs")
@@ -495,8 +538,10 @@ def _expected_hold_pair_samples(
     the packet builder's all-Up-before-all-Down ordering.
     """
 
-    if scenario not in {"paired", "mixed", "coalesced"}:
-        raise ValueError("scenario must be paired, mixed, or coalesced")
+    if scenario not in {"paired", "mixed", "coalesced", "same_key_min_cycle"}:
+        raise ValueError(
+            "scenario must be paired, mixed, coalesced, or same_key_min_cycle"
+        )
     grouped: dict[int, list[tuple[str, list[int]]]] = {}
     for _index, kind, scheduled_us, scan_codes, _label in actions:
         slots = {int(scan_code) for scan_code in scan_codes}
@@ -683,6 +728,7 @@ def _correctness_counters(
         "unexpected_transport_failures": partial + zero_progress,
         "authored_trace_missing_duplicate_mismatch": trace_errors,
         "missed_down_boundaries": int(snapshot.get("missed_down_boundaries", 0)),
+        "missed_down_keys": int(snapshot.get("missed_down_keys", 0)),
         "pre_call_hold_shrink_over_grace_count": int(
             snapshot.get("pre_call_hold_shrink_over_grace_count", 0)
         ),
@@ -712,6 +758,7 @@ def _aggregate_correctness(runs: list[dict[str, Any]]) -> dict[str, int]:
         "unexpected_transport_failures",
         "authored_trace_missing_duplicate_mismatch",
         "missed_down_boundaries",
+        "missed_down_keys",
         "pre_call_hold_shrink_over_grace_count",
         "hold_unmatched_up_count",
         "hold_anchor_overwrite_count",
@@ -1160,6 +1207,7 @@ def _new_session(
         game_fps=game_fps,
         gap_profile=gap_profile,
     )
+    materialized_release_gap_us = _materialized_release_gap_us(game_fps=game_fps)
 
     if backend == "mock":
         test_session = getattr(sky_player_rs, "TestDispatchSession", None)
@@ -1172,6 +1220,7 @@ def _new_session(
             actions,
             list(SKY_15_SCAN_CODES),
             min_hold_us=materialized_min_hold_us,
+            min_release_gap_us=materialized_release_gap_us,
             game_fps=game_fps,
             mock_latency_base_us=mock_base_latency_us,
             mock_latency_per_key_us=mock_per_key_latency_us,
@@ -1197,6 +1246,7 @@ def _new_session(
         config=sky_player_rs.SessionConfig(  # type: ignore[attr-defined]
             game_fps=game_fps,
             min_hold_us=materialized_min_hold_us,
+            min_release_gap_us=materialized_release_gap_us,
             require_focus=require_focus,
             target_hwnd=target_hwnd,
             telemetry=True,
@@ -1435,6 +1485,10 @@ def _run_dispatch(
             ),
             "completion_error_us": _completion_error_report_pairs(completion_error_rows),
             "spin_cpu_time_us": int(snapshot.get("spin_time_us", 0)),
+            "effective_spin_threshold_us": _required_int(
+                snapshot.get("effective_spin_threshold_us"),
+                "effective_spin_threshold_us",
+            ),
             "worker_cpu_time_us": int(snapshot.get("worker_cpu_time_us", 0)),
             "process_cpu_time_us": int(snapshot.get("process_cpu_time_us", 0)),
             "playback_wall_time_us": int(snapshot.get("playback_wall_time_us", 0)),
@@ -1473,6 +1527,7 @@ def _run_dispatch(
             "lead_by_polyphony": lead_by_polyphony,
             "generation_status_counts": dict(snapshot.get("generation_status_counts", {})),
             "missed_down_boundaries": int(snapshot.get("missed_down_boundaries", 0)),
+            "missed_down_keys": int(snapshot.get("missed_down_keys", 0)),
             "missed_backlog_boundaries": int(
                 snapshot.get("missed_backlog_boundaries", 0)
             ),
@@ -1754,11 +1809,11 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--scenario",
-        choices=("paired", "mixed", "coalesced"),
+        choices=("paired", "mixed", "coalesced", "same_key_min_cycle"),
         default="paired",
         help=(
             "authored action profile; mixed/coalesced use disjoint adjacent Up/Down "
-            "masks and are correctness-only per requested suite"
+            "masks, while same_key_min_cycle hammers one physical key"
         ),
     )
     parser.add_argument(
@@ -1977,6 +2032,7 @@ def _assert_report_correctness(report: dict[str, Any]) -> None:
         "unexpected_transport_failures",
         "authored_trace_missing_duplicate_mismatch",
         "missed_down_boundaries",
+        "missed_down_keys",
         "pre_call_hold_shrink_over_grace_count",
         "hold_unmatched_up_count",
         "hold_anchor_overwrite_count",
@@ -2156,6 +2212,7 @@ def _assert_baseline_compatible(
         "native_build_flavor",
         "require_focus",
         "materialized_min_hold_us",
+        "materialized_release_gap_us",
     )
     baseline_config = baseline.get("benchmark_config")
     report_config = report.get("benchmark_config")
@@ -2421,6 +2478,11 @@ def main() -> int:
         raise SystemExit(
             "mixed/coalesced scenarios require every --polyphony value to be >= 2; "
             "polyphony=1 would silently change packet size"
+        )
+    if args.scenario == "same_key_min_cycle" and polyphonies != [1]:
+        raise SystemExit(
+            "same_key_min_cycle requires exactly --polyphony 1 so every boundary "
+            "uses one physical scan code"
         )
     benchmark_config = _benchmark_config(
         args=args,
@@ -2696,6 +2758,9 @@ def main() -> int:
             "warmup_records": _aggregate_warmup_records(runs),
             "measurement_records": sum(run["measurement_records"] for run in runs),
             "physical_boundaries": sum(run["measurement_records"] for run in runs),
+            "effective_spin_threshold_us": _aggregate_scalar_max(
+                runs, "effective_spin_threshold_us"
+            ),
             "native_packet_size_counts": _aggregate_native_packet_size_counts(runs),
             "wake_error_us": _aggregate_metric(runs, "wake_error_us"),
             "pre_send_software_latency_us": _aggregate_metric(
@@ -2722,6 +2787,7 @@ def main() -> int:
             "missed_down_boundaries": _aggregate_scalar_sum(
                 runs, "missed_down_boundaries"
             ),
+            "missed_down_keys": _aggregate_scalar_sum(runs, "missed_down_keys"),
             "missed_backlog_boundaries": _aggregate_scalar_sum(
                 runs, "missed_backlog_boundaries"
             ),
@@ -2845,6 +2911,12 @@ def main() -> int:
         "command_timing_domain": COMMAND_TIMING_DOMAIN,
         "latency_segment_domain": LATENCY_SEGMENT_DOMAIN,
         "benchmark_config": benchmark_config,
+        "scenario": args.scenario,
+        "game_fps": args.game_fps,
+        "materialized_min_hold_us": benchmark_config["materialized_min_hold_us"],
+        "materialized_release_gap_us": benchmark_config[
+            "materialized_release_gap_us"
+        ],
         "timing_comparison_scope": (
             "aggregate_actual_packets"
             if args.scenario in {"mixed", "coalesced"}
@@ -2864,6 +2936,11 @@ def main() -> int:
         "warmup_records": _aggregate_warmup_records(dispatch_runs),
         "measurement_records": physical_boundaries,
         "physical_boundaries": physical_boundaries,
+        "physical_boundary_count": physical_boundaries,
+        "effective_spin_threshold_us": _aggregate_scalar_max(
+            dispatch_runs, "effective_spin_threshold_us"
+        ),
+        "require_focus": benchmark_config["require_focus"],
         "qualification_gate": {
             "minimum_physical_boundaries": MIN_QUALIFICATION_PHYSICAL_BOUNDARIES,
             "measured_physical_boundaries": physical_boundaries,
@@ -2912,6 +2989,7 @@ def main() -> int:
         "missed_down_boundaries": _aggregate_scalar_sum(
             dispatch_runs, "missed_down_boundaries"
         ),
+        "missed_down_keys": _aggregate_scalar_sum(dispatch_runs, "missed_down_keys"),
         "missed_backlog_boundaries": _aggregate_scalar_sum(
             dispatch_runs, "missed_backlog_boundaries"
         ),

--- a/scripts/bench_native_reference_bridge.py
+++ b/scripts/bench_native_reference_bridge.py
@@ -82,7 +82,7 @@ def _native_policy(
         "lead_mode": "adaptive" if historical else "fixed",
         "fixed_lead_us": 0,
         "adaptive_lead": historical,
-        "spin_policy": "adaptive_floor_700_threshold_150" if historical else "fixed_700",
+        "spin_policy": "adaptive_floor_700_threshold_150" if historical else "fixed_1000",
     }
 
 
@@ -247,11 +247,15 @@ def _install_patches(native_build_commit: str) -> None:
             game_fps=game_fps,
             gap_profile=gap_profile,
         )
+        materialized_release_gap_us = acceptance._materialized_release_gap_us(
+            game_fps=game_fps,
+        )
         require_focus = bool(kwargs.get("require_focus", True))
         target_hwnd = acceptance._real_input_target_hwnd(require_focus=require_focus)
         config = sky_player_rs.SessionConfig(
             game_fps=game_fps,
             min_hold_us=materialized_min_hold_us,
+            min_release_gap_us=materialized_release_gap_us,
             require_focus=require_focus,
             target_hwnd=target_hwnd,
             telemetry=True,

--- a/src/main.py
+++ b/src/main.py
@@ -534,13 +534,20 @@ def _run_rust_selftest() -> int:
         runtime_contract = True
         import sky_player_rs  # type: ignore[import-not-found]
 
+        from sky_music.domain.scheduler_types import FrameTimingPolicy
         from sky_music.orchestration.native_admission import EXPECTED_NATIVE_ABI
         from sky_music.orchestration.native_models import RUST_DISPATCH_SCHEMA_VERSION
+
+        frame_policy = FrameTimingPolicy.from_hold_frames(1.0, 60)
+        if frame_policy.min_release_gap_us is None:
+            raise RuntimeError("FrameTimingPolicy did not materialize min_release_gap_us")
 
         session = sky_player_rs.DispatchSession(  # type: ignore[attr-defined]
             [],
             config=sky_player_rs.SessionConfig(  # type: ignore[attr-defined]
                 game_fps=60,
+                min_hold_us=int(frame_policy.min_hold_us),
+                min_release_gap_us=int(frame_policy.min_release_gap_us),
                 require_focus=False,
                 telemetry=False,
                 profile="production",

--- a/src/sky_music/cli/console_playback.py
+++ b/src/sky_music/cli/console_playback.py
@@ -328,7 +328,9 @@ def print_schedule_summary(actions: tuple[Any, ...], sched_meta: Any, *, fps: in
     text.append(f"Infeasible same-key repeats : {sched_meta.impossible_same_key_repeats}\n", style=muted)
     if sched_meta.impossible_same_key_repeats > 0:
         text.append(
-            f"  ({sched_meta.impossible_same_key_repeats} same-key repeats faster than one frame @{fps}fps - the game may merge them)\n",
+            f"  ({sched_meta.impossible_same_key_repeats} same-key repeats are infeasible under "
+            f"the materialized hold/release policy @{fps}fps; sender-side policy does not "
+            "prove game observation)\n",
             style=warning,
         )
     text.append(f"Risky same-key repeats      : {sched_meta.risky_same_key_repeats}\n", style=muted)
@@ -603,6 +605,8 @@ def play_selected_song(
     # ProgressRenderer only erases its own previously-rendered lines; static print()
     # output from _mini_preflight would otherwise remain visible above the HUD.
     clear_terminal()
+    if active_policy.min_release_gap_us is None:
+        raise RuntimeError("FrameTimingPolicy did not materialize min_release_gap_us")
 
     engine = PlaybackEngine(
         song=song,
@@ -618,6 +622,7 @@ def play_selected_song(
         tempo_scale=current_tempo,
         focus_restore_grace_us=int(active_policy.focus_restore_grace_us),
         min_hold_us=int(active_policy.min_hold_us),
+        min_release_gap_us=int(active_policy.min_release_gap_us),
         min_hold_margin_us=int(active_policy.min_hold_margin_us),
         min_hold_margin_source=active_policy.min_hold_margin_source,
         down_late_grace_us=int(active_policy.down_late_grace_us),

--- a/src/sky_music/domain/analyzer.py
+++ b/src/sky_music/domain/analyzer.py
@@ -127,7 +127,8 @@ def _evaluate_risk_severity(res: ScheduleMetadata, dense_clusters_list: list[Den
         severity = "high"
         reasons_list.append("infeasible same-key repeats")
         recommendations.append(
-            f"{res.impossible_same_key_repeats} same-key repeat(s) faster than one frame - the game may merge them."
+            f"{res.impossible_same_key_repeats} same-key repeat(s) are infeasible under the "
+            "materialized hold/release policy; sender-side policy does not prove game observation."
         )
         recommendations.append(
             "Reduce tempo or edit the arrangement so the same key has more time between downs."

--- a/src/sky_music/domain/scheduler.py
+++ b/src/sky_music/domain/scheduler.py
@@ -275,7 +275,7 @@ def build_key_actions(
             if (
                 int(policy.frame_us) > 0
                 and planned_hold.risk != "severe"
-                and same_key_up_gap_us < int(policy.frame_us)
+                and same_key_up_gap_us < _release_gap_us(policy)
             ):
                 gap_below_frame_repeats += 1
                 diagnostics.append(ScheduleDiagnostic(
@@ -284,9 +284,10 @@ def build_key_actions(
                     scan_code=draft.scan_code,
                     code="gap_below_frame",
                     message=(
-                        f"Release-to-repress gap {same_key_up_gap_us / 1000:.1f}ms is below one frame "
-                        f"({int(policy.frame_us) / 1000:.1f}ms); the game may sample the key as continuously "
-                        "held and miss the repeat."
+                        f"Authored release gap {same_key_up_gap_us}us is below the required "
+                        f"release visibility gap {_release_gap_us(policy)}us; base game frame "
+                        f"is {int(policy.frame_us)}us. This is a sender-side policy, not a "
+                        "guarantee that the game observed Up."
                     ),
                 ))
             
@@ -368,8 +369,9 @@ def build_key_actions(
     if gap_below_frame_repeats > 0:
         warnings.append(
             f"Detected {gap_below_frame_repeats} same-key repeat(s) whose release-to-repress gap is "
-            f"below one game frame ({int(policy.frame_us) / 1000:.1f}ms). The game may miss these repeats; "
-            "consider lowering the tempo scale or accepting probabilistic repeat registration."
+            f"below the required release visibility policy ({_release_gap_us(policy) / 1000:.1f}ms; "
+            f"base game frame {int(policy.frame_us) / 1000:.1f}ms). The sender-side policy does not "
+            "prove game observation; consider lowering the tempo scale."
         )
 
     duration_us = Microseconds(key_actions_list[-1].at_us) if key_actions_list else Microseconds(0)

--- a/src/sky_music/domain/scheduler_types.py
+++ b/src/sky_music/domain/scheduler_types.py
@@ -103,9 +103,24 @@ class FrameTimingPolicy:
         elif self.transport_margin_us < 0:
             raise ValueError("transport_margin_us must be non-negative")
         if self.min_release_gap_us is None:
-            object.__setattr__(self, "min_release_gap_us", Microseconds(self.frame_us))
-        elif self.min_release_gap_us < 0:
-            raise ValueError("min_release_gap_us must be non-negative")
+            fallback_release_gap_us = int(self.frame_us) + int(self.min_hold_margin_us)
+            if fallback_release_gap_us > 60_000_000:
+                raise ValueError("min_release_gap_us must be at most 60000000")
+            object.__setattr__(
+                self,
+                "min_release_gap_us",
+                Microseconds(fallback_release_gap_us),
+            )
+        elif (
+            not isinstance(self.min_release_gap_us, int)
+            or isinstance(self.min_release_gap_us, bool)
+            or self.min_release_gap_us < self.frame_us
+            or self.min_release_gap_us > 60_000_000
+        ):
+            raise ValueError(
+                "min_release_gap_us must be an integer in "
+                f"{int(self.frame_us)}..=60000000"
+            )
 
     @classmethod
     def from_timing_policy(
@@ -136,7 +151,9 @@ class FrameTimingPolicy:
             down_late_grace_us=Microseconds(down_late_grace_us),
             frame_base_hold_us=Microseconds(base_hold_us),
             transport_margin_us=Microseconds(transport_margin_us),
-            min_release_gap_us=Microseconds(frame_us),
+            min_release_gap_us=Microseconds(
+                frame_us + down_late_grace_us + transport_margin_us
+            ),
         )
 
     @classmethod

--- a/src/sky_music/domain/validation.py
+++ b/src/sky_music/domain/validation.py
@@ -130,8 +130,9 @@ def validate_key_actions(
                                 message=(
                                     f"Scan code {sc} was released at {last_ups[sc]}us and "
                                     f"re-pressed at {action.at_us}us; release gap "
-                                    f"{release_gap}us is below one frame "
-                                    f"({int(min_release_gap_us)}us)"
+                                    f"{release_gap}us is below the required release "
+                                    f"visibility gap ({int(min_release_gap_us)}us); base "
+                                    f"game frame is {int(policy.frame_us)}us"
                                 ),
                                 at_us=action.at_us,
                                 scan_code=sc,

--- a/src/sky_music/orchestration/engine.py
+++ b/src/sky_music/orchestration/engine.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from sky_music.domain.domain import Song
+from sky_music.domain.hold_timing import frame_duration_us
 from sky_music.domain.scheduler_types import (
     DEFAULT_DOWN_LATE_GRACE_US,
     DEFAULT_FOCUS_RESTORE_GRACE_US,
@@ -50,6 +51,7 @@ class PlaybackEngine:
         self,
         song: Song,
         actions: tuple[KeyAction, ...],
+        min_release_gap_us: int,
         controls: Any = None,
         renderer: Any = None,
         telemetry_enabled: bool = False,
@@ -83,6 +85,15 @@ class PlaybackEngine:
         self.game_fps = int(game_fps)
         if not 15 <= self.game_fps <= 240:
             raise ValueError("game_fps must be in 15..=240")
+        if type(min_release_gap_us) is not int:
+            raise ValueError("min_release_gap_us must be an integer")
+        frame_us = frame_duration_us(self.game_fps)
+        if not frame_us <= min_release_gap_us <= 60_000_000:
+            raise ValueError(
+                "min_release_gap_us must be in "
+                f"{frame_us}..=60000000"
+            )
+        self.min_release_gap_us = min_release_gap_us
         self.min_hold_us = max(0, int(min_hold_us))
         self.min_hold_margin_us = min_hold_margin_us
         if type(down_late_grace_us) is not int or down_late_grace_us < 0:
@@ -116,6 +127,7 @@ class PlaybackEngine:
                 "rust_dispatch_schema_version": RUST_DISPATCH_SCHEMA_VERSION,
                 "dry_run": self.dry_run,
                 "min_hold_us": self.min_hold_us,
+                "min_release_gap_us": self.min_release_gap_us,
                 "down_late_grace_us": self.down_late_grace_us,
                 "focus_required": self.require_focus,
             }
@@ -135,6 +147,7 @@ class PlaybackEngine:
             song_name=self.song.name,
             game_fps=self.game_fps,
             min_hold_us=self.min_hold_us,
+            min_release_gap_us=self.min_release_gap_us,
             down_late_grace_us=self.down_late_grace_us,
             require_focus=self.require_focus,
             focus_restore_grace_us=self.focus_restore_grace_us,
@@ -235,6 +248,7 @@ class PlaybackEngine:
                 "wait_strategy_acquired": snapshot.get("wait_strategy_acquired"),
                 "input_path_degraded": snapshot.get("input_path_degraded", False),
                 "min_hold_us": self.min_hold_us,
+                "min_release_gap_us": self.min_release_gap_us,
                 "min_hold_margin_us": self.min_hold_margin_us,
                 "min_hold_margin_source": self.telemetry.min_hold_margin_source,
                 "down_late_grace_us": self.down_late_grace_us,

--- a/src/sky_music/orchestration/native_dispatch.py
+++ b/src/sky_music/orchestration/native_dispatch.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Sequence
 from typing import Any, Protocol, cast
 
+from sky_music.domain.hold_timing import frame_duration_us
 from sky_music.domain.scheduler_types import KeyAction
 from sky_music.orchestration.native_models import (
     LIVE_NATIVE_STATUSES,
@@ -118,6 +119,7 @@ class RustDispatchRuntime:
         "_last_hwnd",
         "_manual_paused",
         "_min_hold_us",
+        "_min_release_gap_us",
         "_pre_roll_us",
         "_renderer",
         "_require_focus",
@@ -135,6 +137,7 @@ class RustDispatchRuntime:
         song_name: str,
         game_fps: int,
         min_hold_us: int,
+        min_release_gap_us: int,
         down_late_grace_us: int,
         require_focus: bool,
         focus_guard: Any,
@@ -154,6 +157,16 @@ class RustDispatchRuntime:
             raise ValueError("down_late_grace_us must be a non-negative integer")
         if down_late_grace_us > min_hold_us:
             raise ValueError("down_late_grace_us must not exceed min_hold_us")
+        if type(game_fps) is not int or not 15 <= game_fps <= 240:
+            raise ValueError("game_fps must be in 15..=240")
+        if type(min_release_gap_us) is not int:
+            raise ValueError("min_release_gap_us must be an integer")
+        frame_us = frame_duration_us(game_fps)
+        if not frame_us <= min_release_gap_us <= 60_000_000:
+            raise ValueError(
+                "min_release_gap_us must be in "
+                f"{frame_us}..=60000000"
+            )
 
         native_actions = (
             (
@@ -171,6 +184,7 @@ class RustDispatchRuntime:
             config=session_config_type(
                 game_fps=int(game_fps),
                 min_hold_us=min_hold_us,
+                min_release_gap_us=min_release_gap_us,
                 down_late_grace_us=down_late_grace_us,
                 require_focus=require_focus,
                 focus_restore_grace_us=focus_restore_grace_us,
@@ -181,6 +195,7 @@ class RustDispatchRuntime:
         )
         self._song_name = song_name
         self._min_hold_us = min_hold_us
+        self._min_release_gap_us = min_release_gap_us
         if type(pre_roll_us) is not int or pre_roll_us < 0:
             raise ValueError("pre_roll_us must be a non-negative integer")
         self._pre_roll_us = pre_roll_us

--- a/src/sky_music/ui/textual_app/app.py
+++ b/src/sky_music/ui/textual_app/app.py
@@ -758,6 +758,8 @@ class SkyPickerApp(App[SongPickerResult | None]):
         command_bridge = PlaybackCommandBridge(self.controls)
         self._active_playback_commands = command_bridge
         self._shutting_down_playback = False
+        if plan.active_policy.min_release_gap_us is None:
+            raise RuntimeError("FrameTimingPolicy did not materialize min_release_gap_us")
 
         engine = PlaybackEngine(
             song=plan.song,
@@ -773,6 +775,7 @@ class SkyPickerApp(App[SongPickerResult | None]):
             tempo_scale=plan.session.tempo_scale,
             focus_restore_grace_us=int(plan.active_policy.focus_restore_grace_us),
             min_hold_us=int(plan.active_policy.min_hold_us),
+            min_release_gap_us=int(plan.active_policy.min_release_gap_us),
             min_hold_margin_us=int(plan.active_policy.min_hold_margin_us),
             min_hold_margin_source=plan.active_policy.min_hold_margin_source,
             down_late_grace_us=int(plan.active_policy.down_late_grace_us),

--- a/tests/test_min_hold_margin.py
+++ b/tests/test_min_hold_margin.py
@@ -10,6 +10,7 @@ def test_default_margin_applies_to_both_hold_outputs() -> None:
     assert policy.hold_us == policy.min_hold_us == 7_745
     assert policy.min_hold_margin_us == 800
     assert policy.transport_margin_us == 300
+    assert policy.min_release_gap_us == 7_745
     assert policy.min_hold_margin_source == "default_transport_300"
 
 
@@ -21,6 +22,7 @@ def test_calibrated_margin_is_forwarded() -> None:
     assert policy.hold_us == policy.min_hold_us == 22_134
     assert policy.min_hold_margin_us == 1_300
     assert policy.transport_margin_us == 800
+    assert policy.min_release_gap_us == 17_967
     assert policy.min_hold_margin_source == "device_cache"
 
 
@@ -30,6 +32,30 @@ def test_zero_margin_is_valid_for_one_frame() -> None:
     )
 
     assert policy.hold_us == policy.min_hold_us == policy.frame_us
+    assert policy.min_release_gap_us == policy.frame_us
+
+
+@pytest.mark.parametrize(
+    ("fps", "expected_frame_us", "expected_policy_us"),
+    ((60, 16_667, 17_467), (120, 8_334, 9_134)),
+)
+def test_release_gap_reserves_the_same_static_headroom_as_hold(
+    fps: int,
+    expected_frame_us: int,
+    expected_policy_us: int,
+) -> None:
+    policy = FrameTimingPolicy.from_hold_frames(1.0, fps)
+
+    assert policy.frame_us == expected_frame_us
+    assert policy.min_hold_us == expected_policy_us
+    assert policy.min_release_gap_us == expected_policy_us
+
+
+def test_calibrated_transport_margin_reaches_release_gap() -> None:
+    policy = FrameTimingPolicy.from_hold_frames(1.0, 60, margin_us=1_000)
+
+    assert policy.min_hold_us == 18_167
+    assert policy.min_release_gap_us == 18_167
 
 
 def test_calibrated_hold_margin_does_not_change_down_late_grace() -> None:

--- a/tests/test_native_acceptance.py
+++ b/tests/test_native_acceptance.py
@@ -187,6 +187,7 @@ def test_real_backend_uses_effective_native_settings_and_materialized_hold() -> 
     assert config["native_profile"] == "strict_timing_diagnostic"
     assert config["require_focus"] is True
     assert config["materialized_min_hold_us"] == 17_467
+    assert config["materialized_release_gap_us"] == 17_467
 
 
 def test_sendinput_qualification_requires_at_least_10000_physical_boundaries() -> None:
@@ -228,10 +229,11 @@ def test_schema_seven_baseline_requires_matching_timing_domain_and_config() -> N
             "start_delay_us": 0,
             "scenario": "paired",
             "native_profile": "mock_test",
-        "native_build_flavor": "test_support",
-        "require_focus": False,
-        "materialized_min_hold_us": 17_467,
-    }
+            "native_build_flavor": "test_support",
+            "require_focus": False,
+            "materialized_min_hold_us": 17_467,
+            "materialized_release_gap_us": 17_467,
+        }
     report = {
         "benchmark_schema_version": 8,
         "candidate_sha": "candidate-sha",
@@ -512,9 +514,10 @@ def test_zero_hold_samples_cannot_pass_completeness_gate() -> None:
             "telemetry_integrity_failures",
             "sender_integrity_failures",
             "unexpected_transport_failures",
-            "authored_trace_missing_duplicate_mismatch",
-            "missed_down_boundaries",
-            "pre_call_hold_shrink_over_grace_count",
+        "authored_trace_missing_duplicate_mismatch",
+        "missed_down_boundaries",
+        "missed_down_keys",
+        "pre_call_hold_shrink_over_grace_count",
             "hold_unmatched_up_count",
         "hold_anchor_overwrite_count",
         "production_completion_hold_below_frame_count",
@@ -541,6 +544,7 @@ def test_zero_hold_samples_cannot_pass_completeness_gate() -> None:
 def test_hold_forensics_anomalies_are_acceptance_correctness_gates() -> None:
     snapshot = {
         "missed_down_boundaries": 1,
+        "missed_down_keys": 3,
         "pre_call_hold_shrink_over_grace_count": 2,
         "hold_unmatched_up_count": 3,
         "hold_anchor_overwrite_count": 4,
@@ -549,6 +553,7 @@ def test_hold_forensics_anomalies_are_acceptance_correctness_gates() -> None:
     counters = ACCEPTANCE._correctness_counters(snapshot, {})
 
     assert counters["missed_down_boundaries"] == 1
+    assert counters["missed_down_keys"] == 3
     assert counters["pre_call_hold_shrink_over_grace_count"] == 2
     assert counters["hold_unmatched_up_count"] == 3
     assert counters["hold_anchor_overwrite_count"] == 4
@@ -647,11 +652,57 @@ def test_trace_metrics_reject_missing_required_field() -> None:
 def test_hot_and_cold_action_spacing() -> None:
     hot = ACCEPTANCE._actions(2, 1, gap_profile="hot")
     cold = ACCEPTANCE._actions(2, 1, gap_profile="cold")
-    assert hot[2][2] - hot[0][2] == 34_134
+    assert hot[2][2] - hot[0][2] == 34_934
     assert hot[1][2] - hot[0][2] == 17_467
     assert cold[2][2] - cold[0][2] == 60_000
     assert cold[1][2] - cold[0][2] == 30_000
     assert cold[2][2] - cold[1][2] > ACCEPTANCE.SEND_COLD_THRESHOLD_US
+
+
+def test_same_key_min_cycle_materializes_one_physical_key_and_exact_boundaries() -> None:
+    count = 5
+    actions = ACCEPTANCE._actions(
+        count,
+        1,
+        game_fps=60,
+        gap_profile="hot",
+        scenario="same_key_min_cycle",
+    )
+    scan_code = int(ACCEPTANCE.SKY_15_SCAN_CODES[0])
+    hold_us = ACCEPTANCE._materialized_hold_us(game_fps=60, gap_profile="hot")
+    release_gap_us = ACCEPTANCE._materialized_release_gap_us(game_fps=60)
+    cycle_us = ACCEPTANCE._same_key_cycle_us(game_fps=60, gap_profile="hot")
+
+    assert len(actions) == count * 2
+    assert sum(action[1] == "down" for action in actions) == count
+    assert sum(action[1] == "up" for action in actions) == count
+    assert all(action[3] == [scan_code] for action in actions)
+    assert all(action[4] in {"same-key-down", "same-key-up"} for action in actions)
+    assert [action[0] for action in actions] == list(range(count * 2))
+    assert [action[2] for action in actions] == sorted(action[2] for action in actions)
+    assert actions == ACCEPTANCE._actions(
+        count,
+        1,
+        game_fps=60,
+        gap_profile="hot",
+        scenario="same_key_min_cycle",
+    )
+
+    for cycle in range(count):
+        down = actions[cycle * 2]
+        up = actions[cycle * 2 + 1]
+        assert down[1] == "down"
+        assert up[1] == "up"
+        assert up[2] - down[2] == hold_us
+        if cycle + 1 < count:
+            next_down = actions[(cycle + 1) * 2]
+            assert next_down[2] - up[2] == release_gap_us
+            assert next_down[2] - down[2] == cycle_us
+
+
+def test_same_key_min_cycle_requires_one_polyphony() -> None:
+    with pytest.raises(ValueError, match="requires polyphony=1"):
+        ACCEPTANCE._actions(1, 2, scenario="same_key_min_cycle")
 
 
 def test_start_delay_shifts_authored_actions_without_changing_spacing() -> None:
@@ -668,9 +719,7 @@ def test_hot_action_spacing_is_frame_safe_at_supported_fps() -> None:
     for fps in (30, 60, 120, 240):
         actions = ACCEPTANCE._actions(2, 15, gap_profile="hot", game_fps=fps)
         assert actions[2][2] - actions[0][2] >= (
-            (1_000_000 + fps - 1) // fps
-            + 500
-            + ACCEPTANCE.DEFAULT_TRANSPORT_MARGIN_US
+            ACCEPTANCE._same_key_cycle_us(game_fps=fps, gap_profile="hot")
         )
 
 

--- a/tests/test_native_calibration.py
+++ b/tests/test_native_calibration.py
@@ -798,6 +798,7 @@ def test_load_calibration_resolution_states(monkeypatch: pytest.MonkeyPatch) -> 
     )
     valid = loader.load_calibration_resolution(data=valid_cache)
     assert valid.status is loader.CalibrationStatus.VALID
+    assert valid.calibration_timing_qualified is True
     assert valid.resolved_margin_us == 800
     assert valid.margin_source == loader.SOURCE_DEVICE_CACHE
 
@@ -806,6 +807,7 @@ def test_load_calibration_resolution_states(monkeypatch: pytest.MonkeyPatch) -> 
     )
     out = loader.load_calibration_resolution(data=out_cache)
     assert out.status is loader.CalibrationStatus.OUT_OF_ENVELOPE
+    assert out.calibration_timing_qualified is False
     assert out.resolved_margin_us == 300
     assert out.margin_source == loader.SOURCE_OUT_OF_ENVELOPE_TRANSPORT_300
 

--- a/tests/test_native_dispatch_runtime.py
+++ b/tests/test_native_dispatch_runtime.py
@@ -267,6 +267,7 @@ def test_runtime_forwards_explicit_down_late_grace_to_native_session(monkeypatch
         song_name="test",
         game_fps=60,
         min_hold_us=17_467,
+        min_release_gap_us=17_467,
         down_late_grace_us=500,
         require_focus=False,
         focus_guard=SimpleNamespace(),
@@ -276,6 +277,7 @@ def test_runtime_forwards_explicit_down_late_grace_to_native_session(monkeypatch
     )
 
     assert captured["down_late_grace_us"] == 500
+    assert captured["min_release_gap_us"] == 17_467
 
 
 def test_playback_engine_keeps_hold_margin_and_down_late_grace_independent(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -305,6 +307,7 @@ def test_playback_engine_keeps_hold_margin_and_down_late_grace_independent(monke
             ),
         ),
         require_focus=False,
+        min_release_gap_us=16_667,
         min_hold_us=17_467,
         min_hold_margin_us=1_800,
         down_late_grace_us=500,
@@ -312,6 +315,7 @@ def test_playback_engine_keeps_hold_margin_and_down_late_grace_independent(monke
 
     assert engine._play_native() == engine_module.PLAYBACK_FINISHED
     assert captured["down_late_grace_us"] == 500
+    assert captured["min_release_gap_us"] == 16_667
     assert captured["down_late_grace_us"] != engine.min_hold_margin_us
 
 

--- a/tests/test_native_session_contract.py
+++ b/tests/test_native_session_contract.py
@@ -45,6 +45,7 @@ def test_session_config_validates_target_and_exposes_user_fields() -> None:
     config = sky_player_rs.SessionConfig(  # type: ignore[attr-defined]
         game_fps=120,
         min_hold_us=50_000,
+        min_release_gap_us=9_134,
         down_late_grace_us=500,
         require_focus=True,
         focus_restore_grace_us=12_345,
@@ -53,6 +54,7 @@ def test_session_config_validates_target_and_exposes_user_fields() -> None:
         profile="production",
     )
     assert config.min_hold_us == 50_000
+    assert config.min_release_gap_us == 9_134
     assert config.down_late_grace_us == 500
     assert config.game_fps == 120
     assert config.require_focus is True
@@ -66,6 +68,7 @@ def test_session_config_defaults_down_late_grace_to_five_hundred_us() -> None:
     config = sky_player_rs.SessionConfig(game_fps=60)  # type: ignore[attr-defined]
 
     assert config.down_late_grace_us == 500
+    assert config.min_release_gap_us == 16_667
 
 
 def test_session_config_rejects_down_late_grace_above_min_hold() -> None:
@@ -129,6 +132,46 @@ def test_native_constructor_accepts_exact_effective_hold_boundary() -> None:
     assert session is not None
 
 
+def test_native_constructor_accepts_exact_explicit_release_gap_boundary() -> None:
+    hold_us = 17_467
+    release_gap_us = 17_467
+    scan_code = SKY_15_SCAN_CODES[0]
+    session = sky_player_rs.DispatchSession(  # type: ignore[attr-defined]
+        [
+            (0, "down", 0, [scan_code], "down-a"),
+            (1, "up", hold_us, [scan_code], "up-a"),
+            (2, "down", hold_us + release_gap_us, [scan_code], "down-b"),
+            (3, "up", hold_us * 2 + release_gap_us, [scan_code], "up-b"),
+        ],
+        config=sky_player_rs.SessionConfig(  # type: ignore[attr-defined]
+            game_fps=60,
+            min_hold_us=hold_us,
+            min_release_gap_us=release_gap_us,
+        ),
+    )
+    assert session is not None
+
+
+def test_native_constructor_rejects_one_microsecond_short_release_gap() -> None:
+    hold_us = 17_467
+    release_gap_us = 17_466
+    scan_code = SKY_15_SCAN_CODES[0]
+    with pytest.raises(ValueError, match="release gap"):
+        sky_player_rs.DispatchSession(  # type: ignore[attr-defined]
+            [
+                (0, "down", 0, [scan_code], "down-a"),
+                (1, "up", hold_us, [scan_code], "up-a"),
+                (2, "down", hold_us + release_gap_us, [scan_code], "down-b"),
+                (3, "up", hold_us * 2 + release_gap_us, [scan_code], "up-b"),
+            ],
+            config=sky_player_rs.SessionConfig(  # type: ignore[attr-defined]
+                game_fps=60,
+                min_hold_us=hold_us,
+                min_release_gap_us=17_467,
+            ),
+        )
+
+
 @pytest.mark.parametrize("margin_us", [300, 400, 499, 500])
 def test_native_constructor_accepts_python_materialized_calibration_margin(
     margin_us: int,
@@ -184,6 +227,7 @@ def test_session_reports_lite_progress_then_one_final_report() -> None:
         "game_fps": 60,
         "requested_min_hold_us": 100,
         "effective_min_hold_us": 100,
+        "min_release_gap_us": 16_667,
         "down_late_grace_us": 0,
         "require_focus": False,
         "focus_restore_grace_us": 1_234,

--- a/tests/test_scheduler_new.py
+++ b/tests/test_scheduler_new.py
@@ -60,6 +60,36 @@ def test_plan_same_key_hold_reports_compression_and_infeasibility() -> None:
     assert (severe.hold_us, severe.risk, severe.compressed) == (10_000, "severe", False)
 
 
+def test_same_key_cycle_exact_release_policy_is_feasible() -> None:
+    planned = plan_same_key_hold(
+        target_hold_us=10_000,
+        min_hold_us=10_000,
+        effective_delta_us=20_000,
+        min_release_gap_us=10_000,
+    )
+
+    assert (planned.hold_us, planned.risk, planned.compressed) == (
+        10_000,
+        "ok",
+        False,
+    )
+
+
+def test_same_key_cycle_one_microsecond_short_is_infeasible() -> None:
+    planned = plan_same_key_hold(
+        target_hold_us=10_000,
+        min_hold_us=10_000,
+        effective_delta_us=19_999,
+        min_release_gap_us=10_000,
+    )
+
+    assert (planned.hold_us, planned.risk, planned.compressed) == (
+        10_000,
+        "severe",
+        False,
+    )
+
+
 def test_chord_batching_and_deduplication() -> None:
     song = Song(
         "Test Chord",

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -61,6 +61,7 @@ def test_effective_policy_uses_one_hold_source_and_margin_metadata() -> None:
     assert policy.hold_us == policy.min_hold_us == 22_134
     assert policy.min_hold_margin_us == 1_300
     assert policy.transport_margin_us == 800
+    assert policy.min_release_gap_us == 17_967
     assert policy.min_hold_margin_source == "device_cache"
     assert policy.down_late_grace_us == 500
     assert policy.focus_restore_grace_us == 100_000

--- a/tests/test_window_target_focus.py
+++ b/tests/test_window_target_focus.py
@@ -71,6 +71,7 @@ def _make_engine(
     return PlaybackEngine(
         song=song,
         actions=actions,
+        min_release_gap_us=16_667,
         require_focus=require_focus,
         dry_run=dry_run,
         pre_roll_us=pre_roll_us,


### PR DESCRIPTION
## Summary
- propagate one explicit `min_release_gap_us` policy through scheduler, native admission, and production forensics
- reserve static sender-side headroom for same-key release visibility
- add exact-key minimum-cycle acceptance coverage
- move the fixed precision spin threshold from 700µs to 1000µs

## Validation
- Python, Ruff, Pyright, Rust fmt/check/clippy/test, security/architecture audits reported green
- static review found no blocking correctness or architecture regressions

## Qualification note
The 1000µs spin change is not claimed as a measured performance win until Windows real-SendInput A/B evidence is available.