### PR TITLE
chore(release): prepare v3.4.3

### DIFF
--- a/docs/releases/v3.4.3-release-notes.md
+++ b/docs/releases/v3.4.3-release-notes.md
@@ -1,6 +1,6 @@
 # Sky Auto Player v3.4.3
 
-v3.4.3 improves sender-side timing consistency for rapid same-key repeats.
+v3.4.3 strengthens sender-side timing consistency for rapid same-key repeats.
 
 ## Highlights
 

--- a/docs/releases/v3.4.3-release-notes.md
+++ b/docs/releases/v3.4.3-release-notes.md
@@ -1,0 +1,15 @@
+# Sky Auto Player v3.4.3
+
+v3.4.3 improves sender-side timing consistency for rapid same-key repeats.
+
+## Highlights
+
+- Adds release-visibility headroom for repeated presses.
+- Uses one release-gap policy across scheduling, native admission, and diagnostics.
+- Adds dedicated same-key minimum-cycle acceptance coverage.
+- Refines the fixed precision scheduling runway to 1,000 µs.
+- Keeps out-of-envelope calibration explicitly unqualified.
+
+Sender-side timing does not guarantee game-side input sampling.
+
+**Platform:** Windows 10/11 x64.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sky-auto-player"
-version = "3.4.2"
+version = "3.4.3"
 description = "Sky Auto Player - Auto Music Sheet Player"
 readme = "README.md"
 # The dispatch loop tight-spins on `time.perf_counter_ns` for up to ~800 us per action, and a

--- a/uv.lock
+++ b/uv.lock
@@ -494,7 +494,7 @@ wheels = [
 
 [[package]]
 name = "sky-auto-player"
-version = "3.4.2"
+version = "3.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Release v3.4.3

- bump package version to `3.4.3`
- add concise release notes for the same-key timing reliability changes

Release wording stays sender-side and does not claim game-observation guarantees or unmeasured performance gains.