### PR TITLE
fix(release): preserve tag-source provenance on manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,28 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.release_tag || github.ref }}
 
+      - name: Bind release source provenance
+        run: |
+          $head = (git rev-parse --verify HEAD).Trim()
+          if (-not $head) { throw "Cannot resolve checkout HEAD" }
+
+          if ("${{ github.event_name }}" -eq "workflow_dispatch") {
+            $tag = "${{ inputs.release_tag }}"
+            if ($tag -notmatch '^v[0-9A-Za-z][0-9A-Za-z._+-]*$') {
+              throw "Invalid manual release tag: $tag"
+            }
+            git fetch --force --tags origin
+            $tagHead = (git rev-parse --verify "refs/tags/$tag^{commit}").Trim()
+            if ($tagHead -ne $head) {
+              throw "Manual release tag $tag resolves to $tagHead but checkout HEAD is $head"
+            }
+          } elseif ($env:GITHUB_SHA -ne $head) {
+            throw "Tag-push GITHUB_SHA $env:GITHUB_SHA does not match checkout HEAD $head"
+          }
+
+          "SKY_EXPECTED_BUILD_COMMIT=$head" | Add-Content $env:GITHUB_ENV -Encoding ASCII
+          Write-Host "Release source provenance bound to $head"
+
       - name: Set up Python environment
         uses: ./.github/actions/python-environment
         with:


### PR DESCRIPTION
## Why

The first `workflow_dispatch` recovery run for `v3.4.3` checked out the correct tag commit (`1565b759...`) but GitHub kept `GITHUB_SHA` bound to the dispatcher ref on `main` (`3b959821...`). The native wheel gate correctly rejected that mismatch.

## Change

- verify the checked-out release ref before any build work
- for normal tag pushes, continue requiring `GITHUB_SHA == HEAD`
- for manual dispatch, require the explicit tag to resolve to checkout `HEAD`
- export the already-supported `SKY_EXPECTED_BUILD_COMMIT=HEAD` only after that verification

No runtime/application code changes and no provenance checks are disabled.