### PR TITLE
fix(release): bind app build to verified tag provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
       - name: Build unsigned native app and smoke tests
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
+          SKY_EXPECTED_BUILD_COMMIT: ${{ steps.source.outputs.build_commit }}
         run: uv run --env-file .env python -m build_app
 
       - name: Generate unsigned-byte manifest


### PR DESCRIPTION
## Why

The manual `v3.4.3` release run now passes source binding, native wheel, full pytest, version lock, and source PyInstaller bootloader, but `build_app` internally invokes `scripts/build_rust_wheel.py` again. Without a scoped expected source SHA, that nested precheck falls back to workflow-dispatch `GITHUB_SHA` (the main dispatcher commit) instead of the checked-out tag commit.

## Change

Pass the already-verified `${{ steps.source.outputs.build_commit }}` only to the `Build unsigned native app and smoke tests` step.

This keeps full pytest isolated, keeps provenance fail-closed, and does not change runtime/application code. `--manifest-only` does not invoke the native-wheel precheck and is left unchanged.