### PR TITLE
Fix strict scheduling qualification and Windows CI harness

### DIFF
--- a/docs/perf-baselines/2026-08-native-dispatch-followup-errata.md
+++ b/docs/perf-baselines/2026-08-native-dispatch-followup-errata.md
@@ -1,0 +1,62 @@
+# Native dispatch follow-up errata
+
+This note narrows two provenance/qualification statements in
+`2026-08-native-dispatch-followup.md`. It does not change runtime timing policy.
+
+## Production waiter wording
+
+The phrase **"production behavior remains frozen"** in the production-equivalent
+scheduling section is too broad if read as covering every public diagnostic
+profile.
+
+The normal `DispatchProfile::Production` authored timing and safety contract is
+unchanged: authored timestamps, the 500 us Down grace, hold/release policy,
+focus/target/lease gates, future authorization, one-wait architecture,
+SendInput attempt policy, and real-time allocation behavior were not retuned.
+
+`DispatchProfile::StrictTimingDiagnostic` is a production-backend diagnostic
+profile. Production backends intentionally use the production waiter constructor
+and production startup calibration regardless of whether telemetry is the normal
+production profile or strict timing diagnostics. This lets real-SendInput
+diagnostics observe the production waiter rather than substituting a test wait
+policy. Compared with older baselines where the calibration condition was tied
+more narrowly to the production profile, this is therefore an intentional
+diagnostic-profile waiter/calibration behavior change, not an authored timing or
+safety-policy change.
+
+No calibration constants or runtime adaptation are authorized by this erratum.
+
+## Production-equivalent priority qualification
+
+A production-calibrated test-support run is scheduling-qualified only when all
+of the following are true:
+
+- requested priority policy is `auto`;
+- the acquired policy is one of the actual production Auto ladder outcomes:
+  `mmcss:Games` or `thread:highest`;
+- startup calibration provenance is valid;
+- sender cutoff, waiter, dispatch and hard correctness dimensions are clean;
+- the required physical-boundary sample floor is met.
+
+`Auto -> off` remains **INCONCLUSIVE**. Forced `highest`, `time_critical`, or
+`mmcss` test-support runs are not production-equivalent evidence even if they
+are active and otherwise clean.
+
+## Historical raw-artifact hashes
+
+The following historical local artifacts were not committed and their SHA256
+values were not recorded in the committed report:
+
+- `.benchmarks/production-equivalent-auto-cold-p1-final7c.json`
+- `.benchmarks/production-equivalent-auto-hot-p1-final7c.json`
+- `.benchmarks/production-equivalent-auto-hot-p15-final7c.json`
+- `.benchmarks/production-equivalent-real-wait-core-10k.json`
+- associated failed-run JSON artifacts
+
+Their source SHA, commands, host fingerprint and wheel provenance remain useful,
+but the raw JSON byte identity is **not independently source-verifiable** from
+GitHub. No SHA256 is reconstructed or inferred here.
+
+Any future qualification rerun that keeps benchmark JSON outside Git must record
+at minimum the exact artifact path, SHA256, source/native commit, and exact
+command line before the evidence is considered provenance-complete.

--- a/rust/crates/sky_player_rs/src/python/test_session.rs
+++ b/rust/crates/sky_player_rs/src/python/test_session.rs
@@ -108,6 +108,13 @@ impl TestDispatchSessionPy {
                 ));
             }
         };
+        if matches!(test_wait_policy, TestWaitPolicy::ProductionCalibrated)
+            && priority_mode != PriorityMode::Auto
+        {
+            return Err(PyValueError::new_err(
+                "production_calibrated wait_policy requires rt_priority_mode=auto",
+            ));
+        }
         let fault_script = match fault_mode {
             "none" => FaultInjectionScript::none(),
             "zero_progress" => FaultInjectionScript::zero_progress_down_once(),

--- a/scripts/bench_native_acceptance.py
+++ b/scripts/bench_native_acceptance.py
@@ -69,6 +69,7 @@ PRODUCTION_DOWN_LATE_GRACE_US = 500
 PRODUCTION_MIN_SPIN_THRESHOLD_US = 250
 PRODUCTION_MAX_SPIN_THRESHOLD_US = 1_000
 PRODUCTION_CALIBRATION_SAMPLES = 6
+PRODUCTION_AUTO_ACQUIRED_PRIORITIES = frozenset(("mmcss:Games", "thread:highest"))
 
 PRODUCTION_CORRECTNESS_COUNTERS = (
     "production_release_gap_below_policy_count",
@@ -1371,10 +1372,21 @@ def _aggregate_runtime_provenance(runs: list[dict[str, Any]]) -> dict[str, Any]:
     calibration_sample_counts = _unique_run_values(
         runs, "startup_calibration_sample_count"
     )
-    return {
-        "requested_rt_priority_mode": scalar_values["requested_rt_priority_mode"][0]
+    requested_priority: Any = (
+        scalar_values["requested_rt_priority_mode"][0]
         if len(scalar_values["requested_rt_priority_mode"]) == 1
-        else scalar_values["requested_rt_priority_mode"],
+        else scalar_values["requested_rt_priority_mode"]
+    )
+    production_priority_valid = (
+        requested_priority == "auto"
+        and bool(acquired_priorities)
+        and all(
+            priority in PRODUCTION_AUTO_ACQUIRED_PRIORITIES
+            for priority in acquired_priorities
+        )
+    )
+    return {
+        "requested_rt_priority_mode": requested_priority,
         "acquired_priority": acquired_priorities[0]
         if len(acquired_priorities) == 1
         else "mixed",
@@ -1413,6 +1425,7 @@ def _aggregate_runtime_provenance(runs: list[dict[str, Any]]) -> dict[str, Any]:
         if len(scalar_values["spin_threshold_source"]) == 1
         else scalar_values["spin_threshold_source"],
         "priority_active": all(run["acquired_priority"] != "off" for run in runs),
+        "production_priority_valid": production_priority_valid,
         "calibration_provenance_valid": all(
             bool(run["runtime_provenance"]["calibration_provenance_valid"])
             for run in runs
@@ -1447,11 +1460,16 @@ def _scheduling_qualification(
     )
     effective_wait_policy = provenance["effective_wait_policy"]
     production_mode = effective_wait_policy == "production_calibrated"
+    production_priority_valid = bool(provenance["production_priority_valid"])
     status = "qualified"
     if not production_mode:
         status = "legacy_test_support_only"
+    elif provenance["requested_rt_priority_mode"] != "auto":
+        status = "inconclusive_nonproduction_priority_request"
     elif not provenance["priority_active"]:
         status = "inconclusive_priority_fallback"
+    elif not production_priority_valid:
+        status = "inconclusive_nonproduction_priority_acquisition"
     elif not provenance["calibration_provenance_valid"]:
         status = "inconclusive_calibration_fallback"
     elif not sender_cutoff_clean:
@@ -1466,7 +1484,7 @@ def _scheduling_qualification(
         "waiter_timing_clean": waiter_timing_clean,
         "dispatch_path_clean": dispatch_path_clean,
         "sender_cutoff_clean": sender_cutoff_clean,
-        "priority_qualification": provenance["priority_active"],
+        "priority_qualification": production_priority_valid,
         "calibration_provenance_valid": provenance["calibration_provenance_valid"],
         "statistics_eligible": (
             status == "qualified"
@@ -1751,6 +1769,10 @@ def _runtime_provenance(
         and source == "legacy_test_wide_spin"
         and threshold_us == 20_000
     )
+    production_priority_valid = (
+        requested_priority == "auto"
+        and acquired_priority in PRODUCTION_AUTO_ACQUIRED_PRIORITIES
+    )
     return {
         "requested_rt_priority_mode": requested_priority,
         "acquired_priority": acquired_priority,
@@ -1762,12 +1784,13 @@ def _runtime_provenance(
         "effective_spin_threshold_us": threshold_us,
         "spin_threshold_source": source,
         "priority_active": acquired_priority != "off",
+        "production_priority_valid": production_priority_valid,
         "calibration_provenance_valid": calibration_provenance_valid,
         "legacy_provenance_valid": legacy_provenance_valid,
         "production_wait_qualification": (
             expected_wait_policy == "production_calibrated"
             and calibration_provenance_valid
-            and acquired_priority != "off"
+            and production_priority_valid
         ),
         "expected_wait_policy": expected_wait_policy,
     }
@@ -3025,6 +3048,10 @@ def main() -> int:
         raise SystemExit("--budget-seconds must be between 1 and 600 seconds")
     if args.backend == "sendinput" and not args.allow_real_input:
         raise SystemExit("--backend sendinput requires --allow-real-input")
+    if args.wait_policy == "production_calibrated" and args.rt_priority_mode != "auto":
+        raise SystemExit(
+            "--wait-policy production_calibrated requires --rt-priority-mode auto"
+        )
     mock_base_latency_us, mock_per_key_latency_us = _resolve_mock_latency_values(
         backend=args.backend,
         mock_base_latency_us=args.mock_base_latency_us,
@@ -3852,16 +3879,20 @@ def main() -> int:
     acceptance_failure_reasons = _acceptance_failure_reasons(report)
     report["acceptance_clean"] = not acceptance_failure_reasons
     report["acceptance_failure_reasons"] = acceptance_failure_reasons
-    report["statistics_eligible"] = report[
-        "acceptance_clean"
-    ] and _qualification_boundary_gate(
-        backend=args.backend, measured_boundaries=physical_boundaries
-    )
-    report["scheduling_qualification"] = _scheduling_qualification(
+    scheduling_qualification = _scheduling_qualification(
         dispatch_runs,
         backend=args.backend,
         acceptance_clean=report["acceptance_clean"],
         physical_boundaries=physical_boundaries,
+    )
+    report["scheduling_qualification"] = scheduling_qualification
+    report["statistics_eligible"] = (
+        scheduling_qualification["statistics_eligible"]
+        if benchmark_config["effective_wait_policy"] == "production_calibrated"
+        else report["acceptance_clean"]
+        and _qualification_boundary_gate(
+            backend=args.backend, measured_boundaries=physical_boundaries
+        )
     )
     encoded = json.dumps(report, indent=2)
     print(encoded)

--- a/tests/test_native_production_wait_contract.py
+++ b/tests/test_native_production_wait_contract.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+import sky_player_rs  # type: ignore[import-not-found,import-untyped]
+
+
+@pytest.mark.parametrize("priority_mode", ["off", "mmcss", "highest", "time_critical"])
+def test_production_calibrated_test_session_rejects_non_auto_priority(
+    priority_mode: str,
+) -> None:
+    test_session = getattr(sky_player_rs, "TestDispatchSession", None)
+    if not callable(test_session):
+        pytest.skip("requires the test-support native wheel")
+
+    scan_code = int(sky_player_rs.instrument_scan_codes()[0])
+    actions = [
+        (0, "down", 100_000, [scan_code], "contract-down"),
+        (1, "up", 200_000, [scan_code], "contract-up"),
+    ]
+    with pytest.raises(ValueError, match="requires rt_priority_mode=auto"):
+        test_session(
+            actions,
+            [scan_code],
+            min_hold_us=100,
+            min_release_gap_us=16_667,
+            game_fps=60,
+            rt_priority_mode=priority_mode,
+            wait_policy="production_calibrated",
+        )
+
+
+def test_production_calibrated_test_session_accepts_auto_priority() -> None:
+    test_session = getattr(sky_player_rs, "TestDispatchSession", None)
+    if not callable(test_session):
+        pytest.skip("requires the test-support native wheel")
+
+    scan_code = int(sky_player_rs.instrument_scan_codes()[0])
+    actions = [
+        (0, "down", 100_000, [scan_code], "contract-down"),
+        (1, "up", 200_000, [scan_code], "contract-up"),
+    ]
+    session = test_session(
+        actions,
+        [scan_code],
+        min_hold_us=100,
+        min_release_gap_us=16_667,
+        game_fps=60,
+        rt_priority_mode="auto",
+        wait_policy="production_calibrated",
+    )
+    assert session is not None

--- a/tests/test_native_scheduling_qualification_contract.py
+++ b/tests/test_native_scheduling_qualification_contract.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+def _load_acceptance_module() -> ModuleType:
+    path = Path(__file__).parents[1] / "scripts" / "bench_native_acceptance.py"
+    spec = importlib.util.spec_from_file_location(
+        "native_scheduling_qualification_under_test", path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ACCEPTANCE = _load_acceptance_module()
+
+
+def _run(*, requested: str, acquired: str) -> dict[str, Any]:
+    return {
+        "requested_rt_priority_mode": requested,
+        "acquired_priority": acquired,
+        "requested_wait_policy": "production_calibrated",
+        "effective_wait_policy": "production_calibrated",
+        "spin_threshold_source": "production_startup_calibration",
+        "startup_calibration_executed": True,
+        "startup_calibration_sample_count": 6,
+        "startup_wake_error_p50_us": 100,
+        "startup_wake_error_p95_us": 200,
+        "startup_wake_error_p99_us": 300,
+        "startup_wake_error_max_us": 350,
+        "startup_wake_error_robust_us": 400,
+        "effective_spin_threshold_us": 450,
+        "runtime_provenance": {
+            "calibration_provenance_valid": True,
+            "legacy_provenance_valid": False,
+        },
+        "correctness": {},
+        "missed_down_boundaries": 0,
+        "pre_call_hold_shrink_over_grace_count": 0,
+        "_metric_rows": {"pre_call_lateness_us": [("down", 0)]},
+    }
+
+
+def _qualification(*, requested: str, acquired: str) -> dict[str, Any]:
+    return ACCEPTANCE._scheduling_qualification(
+        [_run(requested=requested, acquired=acquired)],
+        backend="mock",
+        acceptance_clean=True,
+        physical_boundaries=10_000,
+    )
+
+
+def test_auto_mmcss_games_is_production_priority_qualified() -> None:
+    result = _qualification(requested="auto", acquired="mmcss:Games")
+    assert result["status"] == "qualified"
+    assert result["priority_qualification"] is True
+    assert result["statistics_eligible"] is True
+
+
+def test_auto_highest_fallback_is_production_priority_qualified() -> None:
+    result = _qualification(requested="auto", acquired="thread:highest")
+    assert result["status"] == "qualified"
+    assert result["priority_qualification"] is True
+    assert result["statistics_eligible"] is True
+
+
+def test_auto_off_remains_inconclusive() -> None:
+    result = _qualification(requested="auto", acquired="off")
+    assert result["status"] == "inconclusive_priority_fallback"
+    assert result["priority_qualification"] is False
+    assert result["statistics_eligible"] is False
+
+
+def test_forced_highest_cannot_be_relabelled_as_production_equivalent() -> None:
+    result = _qualification(requested="highest", acquired="thread:highest")
+    assert result["status"] == "inconclusive_nonproduction_priority_request"
+    assert result["priority_qualification"] is False
+    assert result["statistics_eligible"] is False
+
+
+def test_forced_time_critical_cannot_be_relabelled_as_production_equivalent() -> None:
+    result = _qualification(
+        requested="time_critical", acquired="thread:time_critical"
+    )
+    assert result["status"] == "inconclusive_nonproduction_priority_request"
+    assert result["priority_qualification"] is False
+    assert result["statistics_eligible"] is False
+
+
+def test_unexpected_active_auto_acquisition_is_not_production_qualified() -> None:
+    result = _qualification(requested="auto", acquired="thread:time_critical")
+    assert result["status"] == "inconclusive_nonproduction_priority_acquisition"
+    assert result["priority_qualification"] is False
+    assert result["statistics_eligible"] is False
+
+
+def test_runtime_provenance_requires_auto_ladder_for_production_wait() -> None:
+    snapshot = {
+        "requested_rt_priority_mode": "highest",
+        "rt_priority_acquired": "thread:highest",
+        "requested_wait_policy": "production_calibrated",
+        "effective_wait_policy": "production_calibrated",
+        "startup_calibration_executed": True,
+        "startup_calibration_sample_count": 6,
+        "startup_wake_error_p50_us": 100,
+        "startup_wake_error_p95_us": 200,
+        "startup_wake_error_p99_us": 300,
+        "startup_wake_error_max_us": 350,
+        "startup_wake_error_robust_us": 400,
+        "effective_spin_threshold_us": 450,
+        "spin_threshold_source": "production_startup_calibration",
+    }
+    provenance = ACCEPTANCE._runtime_provenance(
+        snapshot,
+        backend="mock",
+        requested_wait_policy="production_calibrated",
+    )
+    assert provenance["priority_active"] is True
+    assert provenance["production_priority_valid"] is False
+    assert provenance["production_wait_qualification"] is False

--- a/tests/test_windows_updater_harness.py
+++ b/tests/test_windows_updater_harness.py
@@ -18,7 +18,9 @@ def test_result_polling_ignores_intermediate_success() -> None:
     completed = subprocess.run(
         [
             "pwsh",
+            "-NoLogo",
             "-NoProfile",
+            "-NonInteractive",
             "-ExecutionPolicy",
             "Bypass",
             "-File",
@@ -31,7 +33,10 @@ def test_result_polling_ignores_intermediate_success() -> None:
         ],
         capture_output=True,
         text=True,
-        timeout=20,
+        # The PowerShell self-test has its own five-second polling deadline.
+        # This outer guard only covers cold pwsh/Add-Type startup on hosted
+        # Windows runners and must not be used to stretch the polling contract.
+        timeout=45,
         check=False,
     )
     assert completed.returncode == 0, completed.stderr or completed.stdout


### PR DESCRIPTION
Surgical follow-up to the native-dispatch acceptance audit.

Scope:
- keep production authored timing, 500 us Down grace, hold/release policy, focus/target/lease gates, waiter architecture, and SendInput path unchanged;
- require production-calibrated test-support sessions to request the production Auto priority policy;
- qualify only actual Auto ladder acquisitions (`mmcss:Games` or `thread:highest`), never forced priority modes;
- tie production-calibrated top-level statistics eligibility to scheduling qualification;
- add deterministic qualification truth-table tests;
- widen only the outer Windows PowerShell process guard for the updater polling self-test while preserving its internal five-second polling deadline;
- add provenance errata for StrictTimingDiagnostic waiter behavior and historical unhashed local JSON artifacts.

This PR does not retune calibration or timing constants.