### PR TITLE
test: isolate synthetic updater polling share race

### DIFF
--- a/tests/test_windows_updater_harness.py
+++ b/tests/test_windows_updater_harness.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
+import pathlib
 import subprocess
 
 import pytest
@@ -13,7 +13,7 @@ _SYNTHETIC_SHARING_VIOLATION = "being used by another process"
 _MAX_SELF_TEST_ATTEMPTS = 3
 
 
-def _run_result_polling_self_test(script: Path) -> subprocess.CompletedProcess[str]:
+def _run_result_polling_self_test(script: pathlib.Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             "pwsh",
@@ -45,7 +45,7 @@ def test_result_polling_ignores_intermediate_success() -> None:
     if os.name != "nt":
         pytest.skip("requires Windows PowerShell")
 
-    script = Path(__file__).parents[1] / "scripts" / "test_windows_updater_e2e.ps1"
+    script = pathlib.Path(__file__).parents[1] / "scripts" / "test_windows_updater_e2e.ps1"
     completed: subprocess.CompletedProcess[str] | None = None
     for _ in range(_MAX_SELF_TEST_ATTEMPTS):
         completed = _run_result_polling_self_test(script)

--- a/tests/test_windows_updater_harness.py
+++ b/tests/test_windows_updater_harness.py
@@ -7,7 +7,6 @@ import subprocess
 
 import pytest
 
-
 _SYNTHETIC_SHARING_VIOLATION = "being used by another process"
 _MAX_SELF_TEST_ATTEMPTS = 3
 

--- a/tests/test_windows_updater_harness.py
+++ b/tests/test_windows_updater_harness.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from pathlib import Path
+import subprocess
 
 import pytest
 

--- a/tests/test_windows_updater_harness.py
+++ b/tests/test_windows_updater_harness.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import pathlib
 import subprocess
 
 import pytest
@@ -13,7 +12,8 @@ _SYNTHETIC_SHARING_VIOLATION = "being used by another process"
 _MAX_SELF_TEST_ATTEMPTS = 3
 
 
-def _run_result_polling_self_test(script: pathlib.Path) -> subprocess.CompletedProcess[str]:
+def _run_result_polling_self_test(script: str) -> subprocess.CompletedProcess[str]:
+    script_parent = os.path.dirname(script)
     return subprocess.run(
         [
             "pwsh",
@@ -23,11 +23,11 @@ def _run_result_polling_self_test(script: pathlib.Path) -> subprocess.CompletedP
             "-ExecutionPolicy",
             "Bypass",
             "-File",
-            str(script),
+            script,
             "-FromPackage",
-            str(script.parent / "unused-from.zip"),
+            os.path.join(script_parent, "unused-from.zip"),
             "-ToPackage",
-            str(script.parent / "unused-to.zip"),
+            os.path.join(script_parent, "unused-to.zip"),
             "-SelfTestResultPolling",
         ],
         capture_output=True,
@@ -45,7 +45,8 @@ def test_result_polling_ignores_intermediate_success() -> None:
     if os.name != "nt":
         pytest.skip("requires Windows PowerShell")
 
-    script = pathlib.Path(__file__).parents[1] / "scripts" / "test_windows_updater_e2e.ps1"
+    repo_root = os.path.dirname(os.path.dirname(__file__))
+    script = os.path.join(repo_root, "scripts", "test_windows_updater_e2e.ps1")
     completed: subprocess.CompletedProcess[str] | None = None
     for _ in range(_MAX_SELF_TEST_ATTEMPTS):
         completed = _run_result_polling_self_test(script)

--- a/tests/test_windows_updater_harness.py
+++ b/tests/test_windows_updater_harness.py
@@ -9,13 +9,12 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.windows
-def test_result_polling_ignores_intermediate_success() -> None:
-    if os.name != "nt":
-        pytest.skip("requires Windows PowerShell")
+_SYNTHETIC_SHARING_VIOLATION = "being used by another process"
+_MAX_SELF_TEST_ATTEMPTS = 3
 
-    script = Path(__file__).parents[1] / "scripts" / "test_windows_updater_e2e.ps1"
-    completed = subprocess.run(
+
+def _run_result_polling_self_test(script: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         [
             "pwsh",
             "-NoLogo",
@@ -39,4 +38,22 @@ def test_result_polling_ignores_intermediate_success() -> None:
         timeout=45,
         check=False,
     )
+
+
+@pytest.mark.windows
+def test_result_polling_ignores_intermediate_success() -> None:
+    if os.name != "nt":
+        pytest.skip("requires Windows PowerShell")
+
+    script = Path(__file__).parents[1] / "scripts" / "test_windows_updater_e2e.ps1"
+    completed: subprocess.CompletedProcess[str] | None = None
+    for _ in range(_MAX_SELF_TEST_ATTEMPTS):
+        completed = _run_result_polling_self_test(script)
+        if completed.returncode == 0:
+            return
+        output = f"{completed.stderr}\n{completed.stdout}".casefold()
+        if _SYNTHETIC_SHARING_VIOLATION not in output:
+            break
+
+    assert completed is not None
     assert completed.returncode == 0, completed.stderr or completed.stdout


### PR DESCRIPTION
Fixes the Windows CI flake in `test_result_polling_ignores_intermediate_success` without changing updater or dispatch production behavior.

The PowerShell self-test uses a synthetic `Copy-Item -Force` writer and can collide with its own reader, producing the specific Windows sharing-violation message `being used by another process`. The Python contract test now retries the self-test at most three times only for that exact synthetic collision. Any other failure still fails immediately; the PowerShell polling deadline remains five seconds and the outer process guard remains 45 seconds.

This does not change scheduler/timing policy, updater production code, or acceptance semantics.