### PR TITLE
docs(maintenance): record post-push acceptance

### DIFF
--- a/docs/releases/2026-08-modernization-acceptance.md
+++ b/docs/releases/2026-08-modernization-acceptance.md
@@ -1,15 +1,18 @@
 # Dependency, Toolchain, Packaging & Release Modernization Acceptance
 
-Date: 2026-08-28
+Qualification date: 2026-08-28
+Post-push follow-up: 2026-08-29
 
 ## A. Baseline and final state
 
 - Requested baseline: `cf6fb3de97f5e3290c46c7bd7532c90733bbfe9b`.
-- Final implementation tip before this report-only commit: `d1afa3d1c16a8adb2dbc4b39ef6fa593a1955cc9`.
+- Accepted implementation tip: `e545bd62bd8329daa3eb52b2dd848066e16efe03`.
 - Branch: `main`.
-- `origin/main` was fetched before finalization and remains at the requested baseline; no newer
-  remote changes were overwritten. The local branch is ahead and has not been pushed.
-- The nine local commits after the baseline remain purpose-separated by workstream.
+- `origin/main` was verified at the accepted implementation tip after push; no newer remote changes
+  were overwritten. This documentation follow-up is intentionally separate from that implementation
+  tip and may be one local commit ahead until it is pushed.
+- The nine implementation commits after the baseline remain purpose-separated by workstream; the
+  previous acceptance report was the tenth commit.
 
 Environment used for qualification:
 
@@ -56,6 +59,24 @@ Evidence:
 The canonical `scripts/check.py tests` command still encounters `PermissionError: [WinError 5]`
 when pytest removes the pre-existing locked root `.pytest_tmp` directory. This is a host filesystem
 condition; the same tests pass with an isolated `.tmp` basetemp.
+
+Post-push verification on the accepted implementation tip is complete:
+
+- GitHub [CI run #391 / `33192063876`](https://github.com/pumni/Sky-Auto-Player/actions/runs/33192063876)
+  checked out `e545bd6` and completed successfully.
+- Static/security, Windows compatibility and unit tests, packaged frozen unsigned app smoke, and
+  the required CI gate all completed successfully.
+- The matching [GitHub Pages deployment](https://github.com/pumni/Sky-Auto-Player/actions/runs/33192063793)
+  also completed successfully.
+
+Repository policy follow-up is also complete:
+
+- `main` is now protected by active ruleset `Require CI before main updates` (ruleset ID
+  `21750194`).
+- The ruleset strictly requires the GitHub Actions check `Sky Auto Player — required CI gate`
+  from integration `15368`.
+- No bypass actors, pull-request review requirements, or unrelated branch policy requirements were
+  added.
 
 ## C. Changes committed locally
 
@@ -146,20 +167,22 @@ reproducibility/current-support, not a runtime performance claim. Both Bun versi
 | ZIP 8 migration | MEDIUM | Major dependency/API and decompression backend change; archive, security, rollback, and user-state tests pass. |
 | Site/Astro/Bun updates | LOW | Frozen install, check, lint, format, build, dist/SEO, and 58 E2E pass. |
 | ZIP byte reproducibility | MEDIUM | Current `Compress-Archive` output is not deterministic; root cause remains unqualified. |
-| Final GitHub CI | MEDIUM | Required final commit run is pending because local commits were not pushed. |
+| Final GitHub CI | LOW | Accepted implementation tip `e545bd6` passed CI run `33192063876`; the report-only follow-up is not a production code change. |
+| Main branch policy | LOW | Active ruleset `21750194` strictly requires the accepted CI gate; no bypass actors are configured. |
 | Real production SendInput qualification | HIGH/OPEN | This program did not run the interactive desktop production sink matrix; no timing retune is recommended. |
 
 ## H. Final recommendations
 
-### MERGE AFTER CI FIX
+### ACCEPTED
 
 - `cf1a82e` P0 terminal counter fix.
 - Exact Python/uv pins and allowed tooling/attestation updates.
 - Source bootloader provenance check.
 - `zip 8.6.0 + zlib-rs` updater migration.
 - Site patch/minor updates, Astro `7.2.9`, Bun `1.4.0`, and Dependabot grouping.
+- Post-push acceptance documentation and the `main` required-CI ruleset.
 
-All have local evidence, but the required GitHub CI gate must be run on the final pushed commits.
+All passed the required GitHub CI gate on the pushed implementation tip `e545bd6`.
 
 ### KEEP CURRENT
 

--- a/docs/tuning-presets.md
+++ b/docs/tuning-presets.md
@@ -56,8 +56,9 @@ AV risk themselves.
 Sky Auto Player is pinned to the free-threaded CPython 3.14 build by the
 **interpreter pair invariant** — `.python-version` (`3.14.7+freethreaded`) and
 `pyproject.toml`'s `requires-python` (`>=3.14,<3.15`) move together. The
-project deliberately makes the no-GIL runtime a hard requirement (the dispatch
-loop and the Textual UI thread must not contend on the GIL).
+project deliberately makes the no-GIL runtime a hard requirement so Python-side
+orchestration, telemetry, support timing helpers, and the Textual UI can progress
+alongside the native Rust worker without GIL contention.
 The `--no-switch-interval-tuning` flag is therefore a no-op in practice — the
 runtime skips `setswitchinterval` automatically when `sys._is_gil_enabled()`
 returns `False`.
@@ -74,10 +75,10 @@ guard raises `FreeThreadedRuntimeError` if **either** of the following fails:
   or the probe is missing on an interpreter older than 3.13).
 
 `main()` prints a banner that names the failed condition and exits with code 2
-(via `_wait_key_and_exit(2)`). The app never proceeds into the dispatch loop
-on a non-free-threaded interpreter — silently installing a stock 3.14 build
-under the app would otherwise deadlock the UI thread against the dispatch
-spin.
+(via `_wait_key_and_exit(2)`). The app never proceeds into native-worker
+orchestration on a non-free-threaded interpreter — silently installing a stock
+3.14 build would otherwise reintroduce GIL contention between the UI and
+Python-side background work.
 
 ### Building a `python3.14t` binary
 
@@ -93,8 +94,9 @@ and is left as a fork exercise.
 `.python-version = "3.14.7+freethreaded"` (the interpreter-pair invariant
 documented in `AGENTS.md` and enforced at runtime by
 `assert_free_threaded_runtime()` — see above). The free-threaded build of
-3.14 is mandatory: the dispatch loop and the Textual UI thread must not
-contend on the GIL. The `getattr(sys, "_is_gil_enabled", None)` probe in
+3.14 is mandatory so Python-side orchestration, telemetry, support timing
+helpers, and the Textual UI can progress alongside the native Rust worker
+without GIL contention. The `getattr(sys, "_is_gil_enabled", None)` probe in
 `realtime.py` is used only to detect whether the runtime GIL is still active
 in a build that *advertises* free-threadedness (e.g. a forker who flipped
 `PYTHON_GIL=1` on a `3.14t` build); it is not a backward-compat path for

--- a/scripts/audit_free_threaded_wheels.py
+++ b/scripts/audit_free_threaded_wheels.py
@@ -6,12 +6,13 @@ failure so it can be used as a CI gate.
 
 Why this matters
 ----------------
-Sky Auto Player pins ``.python-version`` to ``3.14.7+freethreaded`` so the dispatch
-spinner and the Textual UI thread run truly in parallel. Native deps must
-ship ``cp314t`` wheels — a standard ``cp314`` wheel will fail to import under
-a free-threaded interpreter (different ABI), so the runtime import check is
-the load-bearing verification for native packages. For pure-python packages
-we only enforce the minimum version listed in this file (mirrors pyproject).
+Sky Auto Player pins ``.python-version`` to ``3.14.7+freethreaded`` so Python-side
+orchestration, telemetry, support timing helpers, and the Textual UI can progress
+alongside the native Rust worker without GIL contention. Native deps must ship
+``cp314t`` wheels — a standard ``cp314`` wheel will fail to import under a
+free-threaded interpreter (different ABI), so the runtime import check is the
+load-bearing verification for native packages. For pure-python packages we only
+enforce the minimum version listed in this file (mirrors pyproject).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Post-push acceptance follow-up for e545bd6. Updates the acceptance report with CI #391 and Pages success, corrects stale free-threaded Python wording, and records the active main required-CI ruleset. Targeted free-threaded audit and static/security checks pass. No production dispatch or dependency behavior changes.