### PR TITLE
chore(release): prepare v3.5.0rc1

### DIFF
--- a/docs/releases/v3.5.0rc1-release-notes.md
+++ b/docs/releases/v3.5.0rc1-release-notes.md
@@ -1,0 +1,23 @@
+# Sky Auto Player v3.5.0rc1
+
+This release candidate is published for beta-channel qualification before the
+v3.5.0 stable release.
+
+## Highlights
+
+- Improves native updater validation and extraction performance on the
+  qualified release workload.
+- Hardens native transport-fault telemetry and terminal-state reporting.
+- Refreshes the Windows packaging and dependency-security toolchain while
+  preserving the existing portable release format.
+- Preserves user configuration, songs, and logs across supported updates.
+
+## Qualification
+
+This is an unsigned Windows portable package. It is intended for bounded beta
+testing of the exact release artifact and the supported update path from
+v3.4.5. Do not treat the candidate as the stable release.
+
+The updater continues to verify the release ZIP SHA256, manifest, archive
+paths, and native provenance before changing managed files. Code signing is
+not included in this release candidate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sky-auto-player"
-version = "3.4.5"
+version = "3.5.0rc1"
 description = "Sky Auto Player - Auto Music Sheet Player"
 readme = "README.md"
 # Production scheduling and SendInput dispatch live in the Rust native extension. Python remains

--- a/scripts/audit_free_threaded_wheels.py
+++ b/scripts/audit_free_threaded_wheels.py
@@ -29,7 +29,7 @@ NAME: str = "Sky Auto Player"
 # (PEP 440 specifier) are checked at runtime.
 RUNTIME_MIN_VERSION: dict[str, str] = {
     "rapidfuzz": ">=3.14.5",
-    "textual": ">=8.2.7",
+    "textual": ">=8.2.8",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -435,7 +435,7 @@ wheels = [
 
 [[package]]
 name = "sky-auto-player"
-version = "3.4.5"
+version = "3.5.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },


### PR DESCRIPTION
## Summary\n- prepare version metadata for v3.5.0rc1\n- add RC release notes\n- align free-threaded runtime audit with Textual 8.2.8\n\n## Qualification\n- uv audit: no known vulnerabilities\n- cargo audit: 91 dependencies, no findings\n- free-threaded wheel audit passed (cp314t, GIL disabled)\n- static checks passed\n- full Python suite: 959 passed, 1 skipped, 1 xfailed\n- Rust workspace, zero-allocation, updater and E2E suites passed\n- site frozen install/check/lint/format/build/dist/SEO passed\n- Playwright functional suite: 58 passed\n\nVersion is intentionally prepared as a separate release commit; no Rust dispatch timing changes.