### PR TITLE
test(release): qualify exact target assets

### DIFF
--- a/docs/releases/v3.5.0-release-acceptance.md
+++ b/docs/releases/v3.5.0-release-acceptance.md
@@ -1,0 +1,99 @@
+# Sky Auto Player v3.5.0 release acceptance
+
+Qualification date: 2026-08-29
+
+## A. Source identity
+
+- Candidate: `v3.5.0rc1`
+- Tag: `v3.5.0rc1`
+- Tag commit: `b3c53257e5bea2b726c038eebbdda85d00cf10f6`
+- Main at RC freeze: `b3c53257e5bea2b726c038eebbdda85d00cf10f6`
+- Qualification harness commit: `49bb96e1e12ac482fae81297ec9d54b12b6f56bc`
+- Public stable source: `v3.4.5` at `ef96d70852053fb0cf32f250581d9d09da4855e0`
+
+The RC remains a GitHub Draft Release. No stable tag or stable release was created.
+
+## B. Toolchain
+
+| Component | Qualified value |
+| --- | --- |
+| Python | `3.14.7+freethreaded` |
+| uv | `0.12.7` |
+| Rust | `1.98.0` |
+| PyO3 | `0.29.2` |
+| PyInstaller | `6.22.2` |
+| Maturin | `1.15.0` |
+| zip | `8.6.0` with `zlib-rs` |
+| Bun | `1.4.0` |
+| Astro | `7.2.9` |
+| TypeScript | `6.0.3` |
+
+## C. Dependency audits
+
+- `uv audit --frozen`: pass; no known vulnerabilities.
+- `cargo audit --file rust/Cargo.lock`: pass; 91 crate dependencies scanned.
+- GitHub static/security gate: pass on workflow run `33210611450`.
+
+## D. RC Draft Release
+
+- Workflow run: `33208788460`.
+- Draft release node: `RE_kwDOSp2_Gc4Wk1Gf`.
+- State: `draft=true`, `prerelease=true`, not published.
+- `Sky-Auto-Player-v3.5.0rc1.zip`: asset `RA_kwDOSp2_Gc4f2RNE`, 31,004,744 bytes,
+  SHA-256 `06d8205f87e7e532327af771b20d07340c089cdde8e36662edd122f804061d6c`.
+- `Sky-Auto-Player-v3.5.0rc1.zip.sha256`: asset `RA_kwDOSp2_Gc4f2RNB`, SHA-256
+  `f9521925516c416dde772d3322797074e7e37f99f47bd6a32aa1a016d241a88b`.
+- `MANIFEST.json`: asset `RA_kwDOSp2_Gc4f2RNC`, SHA-256
+  `ada9a45cd08de7d0749309cce94f063e2391ccef89f3033313759351e1dde3c2`.
+- All three assets passed `gh attestation verify` for the release workflow and
+  `refs/tags/v3.5.0rc1`.
+
+The downloaded ZIP digest, sidecar, external manifest, embedded manifest, and release manifest
+fields all matched. The manifest reports `git_head` and `native_build_commit` equal to the tag
+commit and `dirty_worktree=false`.
+
+## E. Exact RC qualification
+
+| Check | Result | Evidence |
+| --- | --- | --- |
+| Fresh exact RC extraction | PASS | `verify_release_manifest.py` |
+| Packaged version | PASS | `Sky-Auto-Player.exe --version` → `3.5.0rc1` |
+| Native self-test | PASS | Rust/runtime/provenance contract and GIL checks |
+| Textual smoke | PASS | Headless packaged app smoke |
+| Exact `v3.4.5 → v3.5.0rc1` updater | PASS | Exact GitHub ZIP/sidecar/manifest; restart count 1 |
+| Preserved `config.json`, `.env`, `songs/**`, `logs/**` | PASS | Before/after SHA-256 equal |
+| Rust updater/security matrix | PASS | Workspace updater tests and CI packaged E2E |
+| Defender scans | PASS | Exact ZIP, extracted tree, app, updater: no detections |
+| Defender exclusion provenance | NOT RUN | Current execution token exposes `N/A: Must be an administrator` |
+| Production `SendInput` qualification | NOT RUN | No valid foreground desktop; `GetForegroundWindow()` returned `0` |
+
+The exact updater happy path was run with the beta channel and the downloaded RC bundle as the
+local release source. The existing Windows E2E harness was extended to support this exact-asset
+mode; its self-test and static gate pass. Its full Defender-wrapped run cannot complete on this
+host because the elevated helper cannot read the existing exclusion list.
+
+## F. Stable release
+
+Not created. No stable source prep, stable Draft, stable artifact, stable Defender scan, or stable
+update qualification was performed.
+
+## G. Publication verification
+
+Not applicable. The RC Draft was intentionally not published, and no asset or tag was changed
+after qualification.
+
+## H. Risk assessment
+
+| Area | Risk | Assessment |
+| --- | --- | --- |
+| RC artifact identity | LOW | GitHub digest, sidecar, manifests, and attestations match. |
+| Exact updater happy path | LOW | Exact public `v3.4.5` source upgraded and restarted successfully. |
+| Updater safety | LOW | Existing Rust and packaged security matrix passed. |
+| Defender qualification | MEDIUM | Scans are clean, but exclusion immutability is not observable here. |
+| Real production input | HIGH | Interactive `SendInput` timing/correctness remains unqualified. |
+| Stable publication | HIGH | Must remain blocked until RC gates are complete. |
+
+## I. Final decision
+
+NO-GO
+

--- a/docs/releases/v3.5.0-release-acceptance.md
+++ b/docs/releases/v3.5.0-release-acceptance.md
@@ -32,7 +32,9 @@ The RC remains a GitHub Draft Release. No stable tag or stable release was creat
 
 - `uv audit --frozen`: pass; no known vulnerabilities.
 - `cargo audit --file rust/Cargo.lock`: pass; 91 crate dependencies scanned.
-- GitHub static/security gate: pass on workflow run `33210611450`.
+- GitHub static/security and packaged gates passed on the preceding harness commit's workflow run
+  `33210611450`; its Windows gate was still pending when this report was written. The report
+  commit's replacement run `33211051268` was also pending at that time.
 
 ## D. RC Draft Release
 
@@ -96,4 +98,3 @@ after qualification.
 ## I. Final decision
 
 NO-GO
-

--- a/scripts/test_windows_updater_e2e.ps1
+++ b/scripts/test_windows_updater_e2e.ps1
@@ -8,6 +8,9 @@ param(
     [string]$ExpectedFromVersion = "3.4.5",
     [string]$ExpectedToVersion = "3.4.5",
     [string]$SyntheticTargetVersion = "3.4.6",
+    [ValidateSet("stable", "beta")]
+    [string]$Channel = "stable",
+    [switch]$ExactTargetQualification,
     [switch]$RunGitHubSmoke,
     [switch]$KeepEvidence,
     [switch]$SelfTestResultPolling,
@@ -317,6 +320,8 @@ function Start-UpdaterProcess {
         [string]$CurrentVersion,
         [string]$TargetVersion,
         [string]$ReleaseDir,
+        [ValidateSet("stable", "beta")]
+        [string]$Channel = "stable",
         [uint32]$ParentPid = 1,
         [string]$FailAt,
         [string]$PauseAt,
@@ -336,7 +341,7 @@ function Start-UpdaterProcess {
         "--parent-pid", [string]$ParentPid,
         "--current-version", $CurrentVersion,
         "--target-version", $TargetVersion,
-        "--channel", "stable"
+        "--channel", $Channel
     )
     if ($Restart) { $arguments += "--restart" }
     if ($FailRestart) { $arguments += "--fail-restart" }
@@ -429,6 +434,8 @@ function Invoke-UpdaterExpectTerminal {
         [string]$CurrentVersion,
         [string]$TargetVersion,
         [string]$ReleaseDir,
+        [ValidateSet("stable", "beta")]
+        [string]$Channel = "stable",
         [string]$FailAt,
         [string]$ExpectedStatus,
         [string]$ExpectedErrorCode,
@@ -439,7 +446,7 @@ function Invoke-UpdaterExpectTerminal {
     $parentPid = if ($parent) { [uint32]$parent.Id } else { [uint32]1 }
     $runInfo = Start-UpdaterProcess -Install $Scenario.Install -Candidate $Candidate `
         -ParentPid $parentPid -CurrentVersion $CurrentVersion -TargetVersion $TargetVersion `
-        -ReleaseDir $ReleaseDir -FailAt $FailAt -Restart:$Restart `
+        -ReleaseDir $ReleaseDir -Channel $Channel -FailAt $FailAt -Restart:$Restart `
         -RequireProgressWindow -FailRestart:$FailRestart
     Stop-ProcessIfRunning $parent
     $observed = Wait-ForUpdaterResult $Scenario $runInfo $ExpectedStatus $ExpectedErrorCode
@@ -504,6 +511,8 @@ function Invoke-Updater {
         [string]$CurrentVersion,
         [string]$TargetVersion,
         [string]$ReleaseDir,
+        [ValidateSet("stable", "beta")]
+        [string]$Channel = "stable",
         [string]$FailAt,
         [string]$PauseAt,
         [switch]$Restart,
@@ -513,7 +522,7 @@ function Invoke-Updater {
     $parent = Start-ParentFixture $Scenario.Install
     $parentPid = if ($parent) { [uint32]$parent.Id } else { [uint32]1 }
     $runInfo = Start-UpdaterProcess -Install $Scenario.Install -Candidate $Candidate `
-        -ParentPid $parentPid -CurrentVersion $CurrentVersion -TargetVersion $TargetVersion -ReleaseDir $ReleaseDir `
+        -ParentPid $parentPid -CurrentVersion $CurrentVersion -TargetVersion $TargetVersion -ReleaseDir $ReleaseDir -Channel $Channel `
         -FailAt $FailAt -PauseAt $PauseAt -Restart:$Restart `
         -RequireProgressWindow:$RequireProgressWindow -FailRestart:$FailRestart
     Start-Sleep -Milliseconds 500
@@ -868,6 +877,25 @@ function Build-SyntheticLocalRelease {
     return $release
 }
 
+function Build-ExactLocalRelease {
+    param([string]$Archive)
+    $archivePath = (Resolve-Path $Archive).Path
+    $archiveDirectory = Split-Path -Parent $archivePath
+    $sidecarPath = "$archivePath.sha256"
+    $manifestPath = Join-Path $archiveDirectory "MANIFEST.json"
+    foreach ($path in @($sidecarPath, $manifestPath)) {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            throw "exact release asset is missing: $path"
+        }
+    }
+    $release = Join-Path $script:SandboxRoot "exact-release"
+    New-Item -ItemType Directory -Path $release -Force | Out-Null
+    Copy-Item -LiteralPath $archivePath -Destination (Join-Path $release (Split-Path -Leaf $archivePath)) -Force
+    Copy-Item -LiteralPath $sidecarPath -Destination (Join-Path $release (Split-Path -Leaf $sidecarPath)) -Force
+    Copy-Item -LiteralPath $manifestPath -Destination (Join-Path $release "MANIFEST.json") -Force
+    return $release
+}
+
 function Build-CorruptSidecarRelease {
     param([string]$ValidRelease)
     $release = Join-Path $script:SandboxRoot "corrupt-sidecar-release"
@@ -965,7 +993,9 @@ try {
     $toManifest = Get-ManifestObject $toRoot
     if ($fromManifest.version -ne $ExpectedFromVersion) { throw "rollout acceptance requires a v$ExpectedFromVersion source package; got $($fromManifest.version)" }
     if ($toManifest.version -ne $ExpectedToVersion) { throw "rollout acceptance requires a v$ExpectedToVersion exact package template; got $($toManifest.version)" }
-    if ($fromManifest.version -ne $toManifest.version) { throw "source and exact target template must have the same v3.4.5 package version" }
+    if (-not $ExactTargetQualification -and $fromManifest.version -ne $toManifest.version) {
+        throw "source and exact target template must have the same v3.4.5 package version"
+    }
     if ($SyntheticTargetVersion -eq $fromManifest.version) { throw "synthetic target version must be newer than source" }
 
     $cargoManifest = Join-Path $script:RepoRoot "rust\Cargo.toml"
@@ -988,6 +1018,62 @@ try {
         "production_candidate $($candidateHashes.production_candidate)"
         "e2e_executor $($candidateHashes.e2e_executor)"
     ) | Set-Content (Join-Path $script:EvidenceRoot "candidate-sha256.txt") -Encoding ascii
+
+    $exactRelease = $null
+    if ($ExactTargetQualification) {
+        $exactRelease = Build-ExactLocalRelease $ToPackage
+        $externalManifestHash = (Get-FileHash (Join-Path $exactRelease "MANIFEST.json") -Algorithm SHA256).Hash.ToLowerInvariant()
+        $embeddedManifestHash = (Get-FileHash (Join-Path $toRoot "MANIFEST.json") -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($externalManifestHash -ne $embeddedManifestHash) {
+            throw "exact target external MANIFEST.json differs from the downloaded ZIP manifest"
+        }
+        Write-EvidenceJson "exact-target-assets.json" ([ordered]@{
+            archive = (Split-Path -Leaf $ToPackage)
+            archive_sha256 = (Get-FileHash -LiteralPath $ToPackage -Algorithm SHA256).Hash.ToLowerInvariant()
+            sidecar = (Get-Content -LiteralPath "$ToPackage.sha256" -Raw).Trim()
+            external_manifest_sha256 = $externalManifestHash
+            embedded_manifest_sha256 = $embeddedManifestHash
+            version = $toManifest.version
+        })
+
+        $scenario = New-Scenario "canonical-v345-to-rc1" $fromRoot
+        $run = Invoke-Updater $scenario $e2eCandidate $fromManifest.version $toManifest.version $exactRelease `
+            -Channel $Channel -Restart -RequireProgressWindow
+        if ($run.Result.status -ne "success" -or $run.ExitCode -ne 0) {
+            throw "canonical v3.4.5 to exact v$($toManifest.version) result was not success"
+        }
+        $hExact = Save-ScenarioEvidence "canonical-v345-to-rc1" $scenario $run $toManifest
+        Save-UpdaterLog "canonical-v345-to-rc1" $scenario
+        $installedExactUpdaterHash = (Get-FileHash (Join-Path $scenario.Install "Sky-Auto-Player-Updater.exe") -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($installedExactUpdaterHash -ne $candidateHashes.packaged_updater) {
+            throw "exact RC install updater hash is not the exact downloaded RC packaged updater hash"
+        }
+        if (-not $hExact.restart_verified) { throw "exact RC restart was not observed" }
+        $exactRestart = Assert-CanonicalSuccess $scenario $run
+        Write-EvidenceJson "canonical-v345-to-rc1-result.json" ([ordered]@{
+            status = "PASS"
+            source_version = $fromManifest.version
+            target_version = $toManifest.version
+            downloaded_archive_sha256 = (Get-FileHash -LiteralPath $ToPackage -Algorithm SHA256).Hash.ToLowerInvariant()
+            installed_updater_sha256 = $installedExactUpdaterHash
+            restarted_pid = $exactRestart.Id
+            channel = $Channel
+            exact_asset = $true
+            active_state_removed = $true
+            transaction_removed = $true
+            preserved_state_verified = $true
+        })
+        $script:Results.canonical_v345_to_rc1 = [ordered]@{
+            status = "PASS"
+            target_version = $toManifest.version
+            installed_updater_sha256 = $installedExactUpdaterHash
+            restarted_pid = $exactRestart.Id
+            restart_verified = $true
+            exact_asset = $true
+            preserved_state_verified = $true
+        }
+        Stop-RestartedApp $scenario.Install
+    }
 
     # The mandatory rollout proof starts with the v3.4.5 package and installs
     # a test-only synthetic v3.4.6 payload. Its updater bytes remain the exact
@@ -1455,6 +1541,7 @@ finally {
     })
     Write-EvidenceJson "summary.json" ([ordered]@{
         overall = $script:Results.overall
+        canonical_v345_to_rc1 = if ($script:Results.canonical_v345_to_rc1) { $script:Results.canonical_v345_to_rc1.status } else { "NOT_RUN" }
         canonical_v345_to_v346 = if ($script:Results.canonical_v345_to_v346) { $script:Results.canonical_v345_to_v346.status } else { "FAIL" }
         ready_visible = [bool]$script:Results.ready_visible
         happy_github = if ($script:Results.happy_github) { $script:Results.happy_github.status } else { "NOT_RUN" }


### PR DESCRIPTION
Adds a bounded exact-asset mode to the Windows updater E2E harness. It verifies the downloaded ZIP, sidecar, and external manifest as one local release source, supports beta-channel prerelease qualification, and retains the existing synthetic failure matrix. No production updater or dispatch behavior changes.