### PR TITLE
docs(release): finalize rc1 acceptance follow-up

### DIFF
--- a/docs/releases/v3.5.0rc1-acceptance.md
+++ b/docs/releases/v3.5.0rc1-acceptance.md
@@ -94,7 +94,8 @@ The corrected canonical note now:
 - describes the candidate as prepared for beta qualification rather than
   already published.
 
-The source correction is on branch `codex/fix-v3.5.0rc1-release-notes`.
+The canonical source correction was merged into `main` as
+`cd95882252260ffe874d43278be0d9cf5989439b` after the required CI gate passed.
 
 The current GitHub Draft Release body was generated from the tagged source before
 this documentation correction. The connected GitHub interface used for this
@@ -158,7 +159,16 @@ delivery, or game-side sampling.
 
 Verdict: **PASS** for the narrowed release-note claim.
 
-## 8. Publication decision
+## 8. Changelog follow-up
+
+`CHANGELOG.md` currently stops at `3.4.2`, while public release notes exist for
+later releases including `v3.4.4` and `v3.4.5`. This does not change RC1 binary
+qualification, but the changelog must be reconciled from canonical release notes
+before `v3.5.0` stable is tagged.
+
+Verdict: **DEFER TO STABLE PREP; DO NOT INVENT HISTORY FROM COMMIT LOGS**.
+
+## 9. Publication decision
 
 ### PASS
 


### PR DESCRIPTION
Follow up the merged RC1 release-note correction so the acceptance record reflects the actual merged `main` commit and explicitly tracks the stale `CHANGELOG.md` as a stable-prep documentation item.

No tag, release asset, runtime, packaging, or updater behavior changes.