### PR TITLE
docs(release): correct v3.5.0rc1 release notes and acceptance

### DIFF
--- a/docs/releases/v3.5.0rc1-acceptance.md
+++ b/docs/releases/v3.5.0rc1-acceptance.md
@@ -1,199 +1,82 @@
 # Sky Auto Player v3.5.0rc1 Acceptance
 
-Acceptance review date: 2026-08-29
+## Decision
 
-Overall status: **BLOCKED FOR PUBLICATION**
+NO-GO
 
-This record distinguishes release-pipeline evidence that is already complete
-from exact-artifact and interactive Windows checks that still require direct
-access to the Draft Release assets or a controlled Windows desktop sink.
+## Source identity
 
-## 1. Release identity
+- Version: 3.5.0rc1
+- Tag: v3.5.0rc1
+- Tag target: b3c53257e5bea2b726c038eebbdda85d00cf10f6
+- Tag object: f0b845298bc456c84897fc3bfe79df16ed96011b
+- Release workflow: 33208788460
+- Draft Release ID: 378753439
 
-- Release candidate: `v3.5.0rc1`.
-- Source commit: `b3c53257e5bea2b726c038eebbdda85d00cf10f6`.
-- Annotated tag object: `f0b845298bc456c84897fc3bfe79df16ed96011b`.
-- The annotated tag resolves to the exact source commit above.
-- Version-tag protection is active for `refs/tags/v*`; tag update and deletion
-  are blocked and no bypass actors are configured.
+## Exact assets
 
-Verdict: **PASS**.
+- ZIP asset ID: 534319940
+- ZIP SHA256: 06d8205f87e7e532327af771b20d07340c089cdde8e36662edd122f804061d6c
+- MANIFEST asset ID: 534319938
+- SHA sidecar asset ID: 534319937
+- Asset identity unchanged after qualification: PASS
 
-## 2. Exact tagged release workflow
+## Artifact integrity
 
-GitHub Actions Release run `33208788460` (`Release` run #32) executed on
-`v3.5.0rc1` / `b3c53257e5bea2b726c038eebbdda85d00cf10f6` and completed successfully.
+- GitHub digest == sidecar == independent SHA256: PASS
+- Manifest exact-file-set verification: PASS
+- Version/provenance verification: PASS
+- Frozen selftests: PASS
+- Fresh interactive launch: FAIL
 
-The Windows release job passed all of the following release-owned steps:
+The exact downloaded RC passed `--version`, `--selftest-rust`,
+`--selftest-textual`, and `--selftest-optimize`. Interactive launch was not
+qualified because this host has no valid interactive desktop/foreground window.
 
-- Python environment setup;
-- repository static verification;
-- pinned Rust toolchain verification;
-- full Rust repository verification;
-- native wheel build;
-- full Python tests;
-- tag/version consistency assertion;
-- source-built matching PyInstaller bootloader;
-- unsigned frozen application build and smoke tests;
-- unsigned-byte manifest generation;
-- exact release-tree and manifest verification;
-- release asset staging and existence checks;
-- build provenance attestation;
-- Draft GitHub Release creation.
+## Update qualification
 
-Verdict: **PASS**.
+- Exact public v3.4.5 source artifact used: YES
+- v3.4.5 → v3.5.0rc1 updater harness: PASS
+- User-owned paths preserved: PASS
+- Transaction/rollback/security matrix: PASS
 
-## 3. Draft Release metadata
+The update qualification used the official v3.4.5 artifact and exact RC
+ZIP/sidecar/MANIFEST bytes. The existing updater security matrix and exact
+update harness passed; the RC was not published.
 
-Draft Release ID `378753439` is still unpublished and is marked as a
-prerelease.
+## Native input qualification
 
-Observed canonical assets:
+- Controlled SendInput sink: FAIL
+- Singles/chords/holds/rapid sequences: FAIL
+- Focus/target/control invalidation: FAIL
+- Cleanup/all-up: FAIL
+- Stuck keys observed: NO
+- Partial sends: not measured
+- Zero-progress sends: not measured
+- Timing regression: NO (not assessable without an interactive sink)
 
-| Asset | Size | GitHub digest |
-| --- | ---: | --- |
-| `MANIFEST.json` | 43,097 bytes | `sha256:ada9a45cd08de7d0749309cce94f063e2391ccef89f3033313759351e1dde3c2` |
-| `Sky-Auto-Player-v3.5.0rc1.zip` | 31,004,744 bytes | `sha256:06d8205f87e7e532327af771b20d07340c089cdde8e36662edd122f804061d6c` |
-| `Sky-Auto-Player-v3.5.0rc1.zip.sha256` | 97 bytes | `sha256:f9521925516c416dde772d3322797074e7e37f99f47bd6a32aa1a016d241a88b` |
+The controlled sink could not provide a valid foreground HWND on this host, so
+no production SendInput observations were made. No stuck key was observed
+because no qualifying input run occurred.
 
-The release workflow generated, verified, staged, attested, and uploaded these
-assets in one successful tagged run.
+## Defender
 
-Verdict: **PASS for release-pipeline metadata**.
+- Exact RC ZIP scan: PASS
+- Extracted RC scan: PASS
+- Main executable scan: PASS
+- Updater executable scan: PASS
+- Defender state/exclusion provenance: FAIL (exclusion list was not readable without an elevated admin token)
 
-### Remaining exact-byte check
+Exact RC bytes produced no Defender detections. Real-time protection was
+enabled; the host could not provide complete exclusion provenance.
 
-The connected GitHub interface available during this review exposes Draft
-Release metadata but does not provide authenticated download of the unpublished
-asset bytes. Therefore the independent post-upload check
+## Release-note verification
 
-`downloaded ZIP SHA256 == sidecar value == GitHub ZIP digest`
+- Draft body updated to approved exact text: PASS
+- Draft remained unpublished during qualification: PASS
+- Asset IDs unchanged: PASS
+- Asset digests unchanged: PASS
 
-has **not** been rerun against a separately downloaded Draft asset in this
-review.
+## Final decision
 
-Verdict: **PENDING**. Do not infer a post-upload byte comparison from the
-successful pre-upload release-tree verification.
-
-## 4. Release-note acceptance
-
-The release note originally described the candidate mainly as updater/toolchain
-maintenance and stated that the candidate "is published" even though the
-GitHub Release is still a Draft.
-
-The corrected canonical note now:
-
-- describes the v3.4.5 -> v3.5.0rc1 delta;
-- makes the native timing handoff and final dispatch-boundary safety changes the
-  primary user-visible highlights;
-- scopes the updater performance claim to the qualified ZIP workload only;
-- keeps dependency/security work under release quality rather than presenting it
-  as the main product feature;
-- explicitly states that sender-side timing evidence is not game-side latency
-  evidence;
-- describes the candidate as prepared for beta qualification rather than
-  already published.
-
-The canonical source correction was merged into `main` as
-`cd95882252260ffe874d43278be0d9cf5989439b` after the required CI gate passed.
-
-The current GitHub Draft Release body was generated from the tagged source before
-this documentation correction. The connected GitHub interface used for this
-review does not expose a Release-body update operation, so the Draft body still
-requires synchronization before publication. The tag and binary assets must not
-be changed for that prose-only correction.
-
-Verdict: **SOURCE PASS / DRAFT BODY BLOCKED**.
-
-## 5. v3.4.5 -> v3.5.0rc1 update qualification
-
-The normal release workflow includes packaged updater E2E and exact managed-tree
-verification, and the updater security matrix was previously qualified for the
-modernized updater stack.
-
-However, this acceptance review has not executed a separate end-to-end update
-starting from the already-published `v3.4.5` package and consuming the exact
-unpublished RC1 Draft assets.
-
-Required final evidence:
-
-- start from the official public `v3.4.5` portable package;
-- invoke the supported native Update and Restart flow;
-- consume the exact `v3.5.0rc1` Draft ZIP, sidecar, and manifest;
-- verify download, hash/manifest validation, transactional replacement, restart,
-  installed version, and preserved `config.json`, `.env`, `songs/`, and `logs/`;
-- retain rollback/recovery evidence if an injected failure case is repeated.
-
-Verdict: **PENDING**.
-
-## 6. Production SendInput qualification
-
-The native timing/handoff work has extensive project-owned benchmark,
-no-allocation, fault, and acceptance evidence. The modernization acceptance also
-records that the interactive production SendInput sink matrix remained an open
-release-quality item.
-
-This review environment cannot operate an interactive Windows desktop or a
-controlled foreground input sink. Therefore it has not independently qualified
-the exact RC binary for:
-
-- single notes and chords;
-- holds and rapid same-key repeats;
-- focus loss around the final admission boundary;
-- stop/cancel and all-up cleanup;
-- stuck-key absence;
-- partial/zero-progress transport behavior under a real Windows sink.
-
-Verdict: **PENDING / HIGH-IMPORTANCE RELEASE GATE**.
-
-## 7. Performance-claim scope
-
-The qualified updater ZIP experiment used the real v3.4.5 release tree with
-235 files and 30,835,159 input bytes, 10 warmups, and 30 measured iterations.
-For `zip 8.6.0 + zlib-rs` versus the previous `zip 2.4.2` backend, the recorded
-across-run median improved by about 7.4% and p95 by about 10.0%.
-
-Those measurements qualify updater archive validation/extraction work. They are
-not evidence for a percentage improvement in playback latency, Windows input
-delivery, or game-side sampling.
-
-Verdict: **PASS** for the narrowed release-note claim.
-
-## 8. Changelog follow-up
-
-`CHANGELOG.md` currently stops at `3.4.2`, while public release notes exist for
-later releases including `v3.4.4` and `v3.4.5`. This does not change RC1 binary
-qualification, but the changelog must be reconciled from canonical release notes
-before `v3.5.0` stable is tagged.
-
-Verdict: **DEFER TO STABLE PREP; DO NOT INVENT HISTORY FROM COMMIT LOGS**.
-
-## 9. Publication decision
-
-### PASS
-
-- immutable RC tag identity;
-- exact tagged release workflow;
-- Rust/Python/package verification performed by that workflow;
-- source-built PyInstaller bootloader and frozen smoke tests;
-- release tree / manifest verification before upload;
-- provenance attestation;
-- Draft Release creation and canonical asset metadata;
-- corrected canonical release-note wording.
-
-### BLOCKED / PENDING
-
-- synchronize the corrected release note into Draft Release ID `378753439`
-  without rebuilding or retagging;
-- independently download the exact Draft assets and compare ZIP SHA256 with the
-  sidecar and GitHub digest;
-- run the official `v3.4.5 -> v3.5.0rc1` update path against those exact Draft
-  assets;
-- run the controlled interactive Windows production SendInput qualification.
-
-Final decision: **DO NOT PUBLISH `v3.5.0rc1` YET**.
-
-Do not move the tag, rebuild the ZIP, replace `MANIFEST.json`, or create RC2 for
-release-note prose alone. If the remaining exact-artifact and Windows gates
-pass, publish the existing Draft Release and preserve the existing asset
-identity.
+NO-GO

--- a/docs/releases/v3.5.0rc1-release-notes.md
+++ b/docs/releases/v3.5.0rc1-release-notes.md
@@ -1,57 +1,20 @@
 # Sky Auto Player v3.5.0rc1
 
-This is the first release candidate for Sky Auto Player v3.5.0. Compared with
-v3.4.5, it focuses on native playback timing and dispatch safety together with
-updater and release hardening.
-
-It is prepared for beta-channel qualification and is not the stable v3.5.0
-release.
+This is the first release candidate for Sky Auto Player v3.5.0. Compared with v3.4.5, it focuses on native playback timing, input-boundary safety, and updater reliability.
 
 ## Highlights
 
-- Reworks the native timing handoff around one interruptible high-resolution
-  wait to the authored physical target followed by a bounded, session-calibrated
-  QPC spin. Calibration changes waiting cost only; it does not shift authored
-  note targets or introduce adaptive dispatch lead.
-- Strengthens the final input boundary by preparing each physical packet before
-  the target wait, revalidating control, target, and focus state before sending,
-  and keeping each physical boundary to one packetized Windows `SendInput` call.
-- Hardens fail-closed handling for late key-downs, invalid packets, and partial
-  or zero-progress transport results. Ambiguous physical transitions are not
-  blindly retried.
-- Improves the native updater ZIP validation and extraction path. On the
-  project's qualified v3.4.5 release workload, the new ZIP backend reduced
-  across-run median wall time by about 7.4% and p95 by about 10% versus the
-  previous backend. These measurements are qualification evidence, not a
-  guaranteed tail bound.
-
-## Reliability and release quality
-
-- Improves terminal-state and transport diagnostics so completed and failed
-  native sessions expose consistent final telemetry.
-- Refreshes the frozen Windows packaging toolchain and verifies provenance for
-  the source-built PyInstaller bootloader.
-- Adds automated Python and Rust dependency vulnerability checks while
-  retaining the existing portable ZIP distribution model.
+- Reworks the native timing handoff around one interruptible wait to the authored physical target followed by a bounded, session-calibrated QPC spin, without shifting authored note timing.
+- Strengthens the final input boundary with immutable packet preparation, final control/target/focus revalidation, and fail-closed handling for invalid, partial, or zero-progress sends.
+- Improves native updater ZIP validation and extraction. On the qualified release-archive workload, validate-and-extract staging wall time improved by about 7.4% at the median and 10.0% at p95 versus the previous ZIP backend.
+- Refreshes Windows packaging and dependency-security checks while keeping the existing portable ZIP distribution model.
 
 ## Updating from v3.4.5
 
-This candidate is intended to qualify the supported v3.4.5 -> v3.5.0rc1 native
-update path.
+This candidate is intended to qualify the v3.4.5 → v3.5.0rc1 update path. The native updater continues to preserve `config.json`, `.env`, `songs/`, and `logs/` while verifying release integrity before replacing managed application files.
 
-The native updater continues to preserve user-owned `config.json`, `.env`,
-`songs/`, and `logs/`. Before changing managed application files, it verifies
-the release ZIP SHA256, `MANIFEST.json`, archive paths, staged file hashes, and
-release provenance, and retains transactional rollback and recovery behavior.
+## Release candidate
 
-## Qualification scope
+This is an unsigned Windows portable beta build, not the stable v3.5.0 release. Windows SmartScreen may display an unrecognized-app warning.
 
-The native timing evidence for this release qualifies Sky Auto Player's own
-scheduling and `SendInput` boundary behavior. It is not a claim that Windows or
-the game has zero input-delivery latency.
-
-This remains an unsigned Windows portable package, so Windows SmartScreen may
-display an unrecognized-app warning. Download releases only from the official
-Sky Auto Player GitHub Releases page.
-
-This is a beta release candidate. Do not treat it as the stable v3.5.0 release.
+Download Sky Auto Player only from the official GitHub Releases page.


### PR DESCRIPTION
Updates the canonical v3.5.0rc1 release notes to the approved Draft body and records the exact-artifact qualification result. This is docs-only; the existing RC Draft remains unpublished because this host cannot provide the required interactive SendInput qualification.