### PR TITLE
feat(core): add bounded desktop IPC worker

### DIFF
--- a/src/core_main.py
+++ b/src/core_main.py
@@ -1,0 +1,8 @@
+"""Frozen/source entrypoint for ``Sky-Auto-Player-Core.exe``."""
+
+from __future__ import annotations
+
+from sky_music.cli.desktop_core import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sky_music/cli/desktop_core.py
+++ b/src/sky_music/cli/desktop_core.py
@@ -1,0 +1,117 @@
+"""Entrypoint for the bounded Python Desktop Core worker."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from sky_music.config import load_config
+from sky_music.infrastructure.desktop_ipc.protocol import (
+    bounded_text,
+    event,
+    write_frame,
+)
+from sky_music.infrastructure.desktop_ipc.server import DesktopCoreServer
+from sky_music.infrastructure.realtime import assert_free_threaded_runtime
+from sky_music.orchestration.catalog_service import CatalogService
+from sky_music.orchestration.native_admission import require_rust_core
+from sky_music.orchestration.settings_service import SettingsService
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--desktop-worker", action="store_true")
+    parser.add_argument("--parent-pid")
+    parser.add_argument("--install-root")
+    return parser
+
+
+def _positive_pid(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    try:
+        value = int(raw, 10)
+    except ValueError as exc:
+        raise ValueError("--parent-pid must be a positive integer") from exc
+    if value <= 0:
+        raise ValueError("--parent-pid must be a positive integer")
+    return value
+
+
+def _install_root(raw: str | None) -> Path | None:
+    if raw is None:
+        return None
+    if not raw or "\x00" in raw or len(raw) > 4096:
+        raise ValueError("--install-root is invalid")
+    path = Path(raw)
+    if not path.is_absolute():
+        raise ValueError("--install-root must be an absolute path")
+    return path.resolve(strict=False)
+
+
+def _fatal(stdout: Any, stderr: Any, code: str, message: object) -> None:
+    print(f"desktop Core fatal: {message}", file=stderr)
+    try:
+        write_frame(
+            stdout,
+            event("core.fatal", {"code": bounded_text(code), "message": bounded_text(message)}),
+        )
+    except Exception as exc:
+        print(f"desktop Core could not emit fatal event: {exc}", file=stderr)
+
+
+def run_desktop_core(
+    argv: list[str] | None = None,
+    *,
+    stdin: Any = None,
+    stdout: Any = None,
+    stderr: Any = None,
+    runtime_guard: Callable[[], None] | None = None,
+    native_admission: Callable[[], Any] | None = None,
+) -> int:
+    """Validate startup, admit the native core, then serve bounded requests."""
+    input_stream = stdin if stdin is not None else sys.stdin.buffer
+    output_stream = stdout if stdout is not None else sys.stdout.buffer
+    error_stream = stderr if stderr is not None else sys.stderr
+    try:
+        args = _parser().parse_args(argv)
+        if not args.desktop_worker:
+            raise ValueError("--desktop-worker is required")
+        parent_pid = _positive_pid(args.parent_pid)
+        install_root = _install_root(args.install_root)
+        if install_root is not None:
+            if not install_root.is_dir():
+                raise ValueError("--install-root must name an existing directory")
+            import os
+
+            os.chdir(install_root)
+        (runtime_guard or assert_free_threaded_runtime)()
+        cfg = load_config()
+        native_info = (native_admission or require_rust_core)()
+        settings = SettingsService(cfg)
+        catalog = CatalogService(settings.snapshot().songs_dir)
+        server = DesktopCoreServer(
+            settings_service=settings,
+            catalog_service=catalog,
+            native_build_info=native_info,
+            parent_pid=parent_pid,
+        )
+    except SystemExit as exc:
+        code = exc.code if isinstance(exc.code, int) else 2
+        _fatal(output_stream, error_stream, "startup_failed", "invalid Core arguments")
+        return code or 2
+    except Exception as exc:
+        print(f"desktop Core startup failure: {exc}", file=error_stream)
+        _fatal(output_stream, error_stream, "startup_failed", "Core startup admission failed")
+        return 2
+    return server.serve(input_stream, output_stream, stderr=error_stream)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_desktop_core(argv)
+
+
+__all__ = ["main", "run_desktop_core"]

--- a/src/sky_music/infrastructure/desktop_ipc/__init__.py
+++ b/src/sky_music/infrastructure/desktop_ipc/__init__.py
@@ -1,0 +1,19 @@
+"""Versioned bounded stdin/stdout protocol for the Python desktop Core."""
+
+from sky_music.infrastructure.desktop_ipc.protocol import (
+    DESKTOP_PROTOCOL_VERSION,
+    MAX_ERROR_MESSAGE_BYTES,
+    MAX_INBOUND_FRAME_BYTES,
+    MAX_OUTBOUND_FRAME_BYTES,
+    MAX_REQUEST_FRAME_BYTES,
+    MAX_RESPONSE_FRAME_BYTES,
+)
+
+__all__ = [
+    "DESKTOP_PROTOCOL_VERSION",
+    "MAX_ERROR_MESSAGE_BYTES",
+    "MAX_INBOUND_FRAME_BYTES",
+    "MAX_OUTBOUND_FRAME_BYTES",
+    "MAX_REQUEST_FRAME_BYTES",
+    "MAX_RESPONSE_FRAME_BYTES",
+]

--- a/src/sky_music/infrastructure/desktop_ipc/protocol.py
+++ b/src/sky_music/infrastructure/desktop_ipc/protocol.py
@@ -1,0 +1,229 @@
+"""Strict, bounded NDJSON primitives for the desktop Core boundary."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+DESKTOP_PROTOCOL_VERSION = 1
+MAX_INBOUND_FRAME_BYTES = 64 * 1024
+MAX_OUTBOUND_FRAME_BYTES = 1 * 1024 * 1024
+# Descriptive aliases used by callers that name limits by protocol direction.
+MAX_REQUEST_FRAME_BYTES = MAX_INBOUND_FRAME_BYTES
+MAX_RESPONSE_FRAME_BYTES = MAX_OUTBOUND_FRAME_BYTES
+MAX_ERROR_MESSAGE_BYTES = 4 * 1024
+MAX_METHOD_BYTES = 128
+MAX_REQUEST_ID = 2**53 - 1
+_READ_CHUNK_BYTES = 4096
+_REQUEST_KEYS = frozenset({"v", "id", "type", "method", "params"})
+
+
+class ProtocolError(ValueError):
+    """A malformed or unsupported protocol frame."""
+
+    def __init__(self, code: str, message: str, *, request_id: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.request_id = request_id
+
+
+def _reject_constant(value: str) -> object:
+    raise ProtocolError("invalid_json", f"non-finite JSON constant is not allowed: {value}")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ProtocolError("invalid_json", f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _as_bytes(frame: bytes | bytearray | memoryview | str) -> bytes:
+    if isinstance(frame, str):
+        return frame.encode("utf-8")
+    return bytes(frame)
+
+
+def _request_id(value: Mapping[str, object]) -> int | None:
+    candidate = value.get("id")
+    if type(candidate) is int and 0 <= candidate <= MAX_REQUEST_ID:
+        return candidate
+    return None
+
+
+def validate_request_object(value: object) -> dict[str, object]:
+    """Validate an already-decoded request object without coercion."""
+    if not isinstance(value, dict):
+        raise ProtocolError("invalid_request", "request must be a JSON object")
+    request_id = _request_id(value)
+    if any(not isinstance(key, str) for key in value):
+        raise ProtocolError("invalid_request", "request keys must be strings")
+    keys = frozenset(value)
+    if keys != _REQUEST_KEYS:
+        missing = sorted(_REQUEST_KEYS - keys)
+        unknown = sorted(keys - _REQUEST_KEYS)
+        details = []
+        if missing:
+            details.append(f"missing fields: {', '.join(missing)}")
+        if unknown:
+            details.append(f"unknown fields: {', '.join(unknown)}")
+        raise ProtocolError("invalid_request", "; ".join(details), request_id=request_id)
+    version = value["v"]
+    if type(version) is not int or version != DESKTOP_PROTOCOL_VERSION:
+        raise ProtocolError(
+            "unsupported_version",
+            f"unsupported protocol version: {version!r}",
+            request_id=request_id,
+        )
+    if type(value["id"]) is not int or not 0 <= value["id"] <= MAX_REQUEST_ID:
+        raise ProtocolError("invalid_id", "request id must be an integer in the safe JSON range")
+    if value["type"] != "request":
+        raise ProtocolError("invalid_type", "message type must be request", request_id=request_id)
+    method = value["method"]
+    if not isinstance(method, str) or not method or len(method.encode("utf-8")) > MAX_METHOD_BYTES:
+        raise ProtocolError("invalid_method", "method must be a bounded non-empty string", request_id=request_id)
+    if any(char not in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-" for char in method):
+        raise ProtocolError("invalid_method", "method contains unsupported characters", request_id=request_id)
+    if not isinstance(value["params"], dict):
+        raise ProtocolError("invalid_params", "params must be an object", request_id=request_id)
+    return value
+
+
+def parse_request_frame(frame: bytes | bytearray | memoryview | str) -> dict[str, object]:
+    """Decode and strictly validate one bounded NDJSON request frame."""
+    raw = _as_bytes(frame)
+    if raw.endswith(b"\n"):
+        raw = raw[:-1]
+    if raw.endswith(b"\r"):
+        raw = raw[:-1]
+    if len(raw) > MAX_INBOUND_FRAME_BYTES:
+        raise ProtocolError("frame_too_large", "request frame exceeds 64 KiB")
+    try:
+        text = raw.decode("utf-8")
+        decoded = json.loads(
+            text,
+            parse_constant=_reject_constant,
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except ProtocolError:
+        raise
+    except (RecursionError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolError("invalid_json", "request is not valid UTF-8 JSON") from exc
+    return validate_request_object(decoded)
+
+
+def _bounded_text(value: object) -> str:
+    text = str(value).replace("\x00", "")
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= MAX_ERROR_MESSAGE_BYTES:
+        return text
+    return encoded[: MAX_ERROR_MESSAGE_BYTES - 3].decode("utf-8", errors="ignore") + "..."
+
+
+def bounded_text(value: object) -> str:
+    """Return text safe for a bounded user-facing protocol field."""
+    return _bounded_text(value)
+
+
+def encode_frame(message: Mapping[str, object]) -> bytes:
+    """Serialize one protocol message and enforce the outbound frame limit."""
+    try:
+        encoded = json.dumps(
+            dict(message),
+            ensure_ascii=False,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8") + b"\n"
+    except (TypeError, ValueError) as exc:
+        raise ProtocolError("invalid_response", "response contains unsupported JSON values") from exc
+    if len(encoded) > MAX_OUTBOUND_FRAME_BYTES:
+        raise ProtocolError("frame_too_large", "response frame exceeds 1 MiB")
+    return encoded
+
+
+def response_ok(request_id: int, result: Mapping[str, object]) -> dict[str, object]:
+    return {"v": DESKTOP_PROTOCOL_VERSION, "id": request_id, "type": "response", "ok": True, "result": dict(result)}
+
+
+def response_error(request_id: int, code: str, message: object) -> dict[str, object]:
+    return {
+        "v": DESKTOP_PROTOCOL_VERSION,
+        "id": request_id,
+        "type": "response",
+        "ok": False,
+        "error": {"code": _bounded_text(code), "message": _bounded_text(message)},
+    }
+
+
+def event(name: str, payload: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "v": DESKTOP_PROTOCOL_VERSION,
+        "type": "event",
+        "name": name,
+        "payload": dict(payload),
+    }
+
+
+def iter_bounded_frames(stream: Any) -> Iterable[bytes]:
+    """Yield newline-delimited frames without calling unbounded ``readline``."""
+    pending = bytearray()
+    while True:
+        chunk = stream.read(_READ_CHUNK_BYTES)
+        if chunk in (b"", ""):
+            break
+        if isinstance(chunk, str):
+            chunk = chunk.encode("utf-8")
+        if not isinstance(chunk, bytes):
+            raise ProtocolError("stream_error", "stdin returned a non-byte chunk")
+        pending.extend(chunk)
+        while True:
+            newline = pending.find(b"\n")
+            if newline < 0:
+                break
+            line = bytes(pending[:newline])
+            del pending[: newline + 1]
+            if len(line) > MAX_INBOUND_FRAME_BYTES:
+                raise ProtocolError("frame_too_large", "request frame exceeds 64 KiB")
+            yield line
+        if len(pending) > MAX_INBOUND_FRAME_BYTES:
+            raise ProtocolError("frame_too_large", "request frame exceeds 64 KiB")
+    if pending:
+        if len(pending) > MAX_INBOUND_FRAME_BYTES:
+            raise ProtocolError("frame_too_large", "request frame exceeds 64 KiB")
+        yield bytes(pending)
+
+
+def write_frame(stream: Any, message: Mapping[str, object]) -> None:
+    encoded = encode_frame(message)
+    try:
+        stream.write(encoded)
+    except TypeError:
+        stream.write(encoded.decode("utf-8"))
+    flush = getattr(stream, "flush", None)
+    if callable(flush):
+        flush()
+
+
+__all__ = [
+    "DESKTOP_PROTOCOL_VERSION",
+    "MAX_ERROR_MESSAGE_BYTES",
+    "MAX_INBOUND_FRAME_BYTES",
+    "MAX_OUTBOUND_FRAME_BYTES",
+    "MAX_REQUEST_FRAME_BYTES",
+    "MAX_REQUEST_ID",
+    "MAX_RESPONSE_FRAME_BYTES",
+    "ProtocolError",
+    "bounded_text",
+    "encode_frame",
+    "event",
+    "iter_bounded_frames",
+    "parse_request_frame",
+    "response_error",
+    "response_ok",
+    "validate_request_object",
+    "write_frame",
+]

--- a/src/sky_music/infrastructure/desktop_ipc/server.py
+++ b/src/sky_music/infrastructure/desktop_ipc/server.py
@@ -1,0 +1,547 @@
+"""Application service adapter and bounded stdin/stdout server for Desktop Core."""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import traceback
+from collections.abc import Mapping
+from dataclasses import asdict
+from queue import Empty, Queue
+from typing import Any
+
+from sky_music import __version__
+from sky_music.config import VALID_FPS
+from sky_music.domain.session_context import PlaybackSessionContext
+from sky_music.infrastructure.desktop_ipc.protocol import (
+    DESKTOP_PROTOCOL_VERSION,
+    ProtocolError,
+    bounded_text,
+    event,
+    iter_bounded_frames,
+    parse_request_frame,
+    response_error,
+    response_ok,
+    write_frame,
+)
+from sky_music.orchestration.catalog_service import (
+    CatalogError,
+    CatalogGenerationError,
+    CatalogLookupError,
+    CatalogService,
+)
+from sky_music.orchestration.desktop_models import (
+    BootstrapDto,
+    NativeBuildDto,
+    PlaybackConfigDto,
+    PlaybackOptionSetsDto,
+    PlaybackRecommendationDto,
+    RiskSummaryDto,
+    SongDetailDto,
+    UpdatePreferencesDto,
+)
+from sky_music.orchestration.native_admission import RustBuildInfo
+from sky_music.orchestration.settings_service import (
+    HOLD_FRAME_OPTIONS,
+    TEMPO_SCALE_OPTIONS,
+    SettingsService,
+)
+from sky_music.orchestration.song_metadata_service import get_song_ui_metadata
+
+MAX_OFFSET = 1_000_000_000
+MAX_VIEWPORT_SPAN = 2_000
+PATCH_FIELDS = frozenset({"theme", "telemetry_enabled", "verbose_hud", "playback_defaults"})
+PLAYBACK_PATCH_FIELDS = frozenset({"hold_frames", "tempo_scale", "fps"})
+SUPPORTED_METHODS = frozenset(
+    {
+        "app.bootstrap",
+        "app.shutdown",
+        "catalog.search",
+        "catalog.detail",
+        "catalog.reload",
+        "catalog.set_viewport",
+        "settings.get",
+        "settings.patch",
+    }
+)
+
+
+class CoreRequestError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def parent_process_alive(pid: int) -> bool:
+    """Return whether the supervising process still exists without touching it."""
+    if type(pid) is not int or pid <= 0:
+        return False
+    if sys.platform == "win32":
+        from sky_music.platform.win32.process_state import query_process_image
+
+        return query_process_image(pid).alive
+    try:
+        os.kill(pid, 0)
+    except PermissionError:
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+def _object_params(raw_params: object, allowed: frozenset[str]) -> dict[str, object]:
+    params = raw_params
+    if not isinstance(params, dict):
+        raise CoreRequestError("invalid_params", "params must be an object")
+    unknown = set(params) - allowed
+    if unknown:
+        raise CoreRequestError("invalid_params", f"unknown params: {', '.join(sorted(unknown))}")
+    return params
+
+
+def _required_text(params: Mapping[str, object], name: str, *, max_bytes: int = 1024) -> str:
+    value = params.get(name)
+    if not isinstance(value, str) or not value or len(value.encode("utf-8")) > max_bytes:
+        raise CoreRequestError("invalid_params", f"{name} must be a bounded non-empty string")
+    return value
+
+
+def _optional_generation(params: Mapping[str, object]) -> int | None:
+    value = params.get("generation")
+    if value is None:
+        return None
+    if type(value) is not int or value < 0:
+        raise CoreRequestError("invalid_params", "generation must be a non-negative integer")
+    return value
+
+
+def _required_int(params: Mapping[str, object], name: str, *, minimum: int = 0) -> int:
+    value = params.get(name)
+    if type(value) is not int or value < minimum:
+        raise CoreRequestError("invalid_params", f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _native_build_dto(info: RustBuildInfo) -> NativeBuildDto:
+    return NativeBuildDto(
+        native_build_commit=info.native_build_commit,
+        native_version=info.native_version,
+        schema_version=info.schema_version,
+        native_abi=info.native_abi,
+        rustc_version=info.rustc_version,
+        win32_backend=info.win32_backend,
+    )
+
+
+def _native_build_dict(info: RustBuildInfo) -> dict[str, object]:
+    return asdict(_native_build_dto(info))
+
+
+def _settings_dict(service: SettingsService) -> dict[str, object]:
+    settings = service.snapshot()
+    return {
+        "theme": settings.theme,
+        "ui_background_mode": settings.ui_background_mode,
+        "playback_defaults": asdict(
+            PlaybackConfigDto(
+                hold_frames=settings.default_hold_frames,
+                tempo_scale=settings.default_tempo_scale,
+                fps=settings.game_fps,
+                dry_run=False,
+            )
+        ),
+        "telemetry_enabled": settings.telemetry_enabled,
+        "verbose_hud": settings.verbose_hud,
+        "update_preferences": asdict(
+            UpdatePreferencesDto(
+                auto_check=settings.update_preferences.auto_check,
+                channel=settings.update_preferences.channel,  # type: ignore[arg-type]
+                skip_version=settings.update_preferences.skip_version,
+            )
+        ),
+    }
+
+
+def _bootstrap_dict(
+    dto: BootstrapDto,
+) -> dict[str, object]:
+    return asdict(dto)
+
+
+class DesktopCoreServer:
+    """Single-threaded request dispatcher with a bounded I/O shell."""
+
+    def __init__(
+        self,
+        *,
+        settings_service: SettingsService,
+        catalog_service: CatalogService,
+        native_build_info: RustBuildInfo,
+        app_version: str = __version__,
+        parent_pid: int | None = None,
+    ) -> None:
+        self.settings_service = settings_service
+        self.catalog_service = catalog_service
+        self.native_build_info = native_build_info
+        self.app_version = app_version
+        self.parent_pid = parent_pid
+        self._catalog_initialized = catalog_service.generation > 0
+        self._shutdown_requested = False
+        self._events: list[dict[str, object]] = []
+        self._viewport: dict[str, object] | None = None
+        self._stop_event = threading.Event()
+
+    def ready_event(self) -> dict[str, object]:
+        return event(
+            "core.ready",
+            {
+                "app_version": self.app_version,
+                "protocol_version": DESKTOP_PROTOCOL_VERSION,
+                "native_build": _native_build_dict(self.native_build_info),
+            },
+        )
+
+    def drain_events(self) -> tuple[dict[str, object], ...]:
+        events = tuple(self._events)
+        self._events.clear()
+        return events
+
+    def handle_request(self, request: Mapping[str, object]) -> dict[str, object]:
+        """Dispatch a validated request and return exactly one response."""
+        request_id = request.get("id")
+        if type(request_id) is not int:
+            raise ProtocolError("invalid_id", "request id must be an integer")
+        try:
+            result = self._dispatch(request["method"], request["params"])
+        except CoreRequestError as exc:
+            return response_error(request_id, exc.code, exc.message)
+        except CatalogGenerationError:
+            return response_error(request_id, "stale_generation", "catalog generation is stale")
+        except CatalogLookupError:
+            return response_error(request_id, "not_found", "song was not found in the catalog")
+        except CatalogError:
+            return response_error(request_id, "catalog_error", "catalog operation failed")
+        except ValueError as exc:
+            return response_error(request_id, "invalid_params", str(exc))
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            return response_error(request_id, "internal_error", "internal Core error")
+        return response_ok(request_id, result)
+
+    def _dispatch(self, method: object, raw_params: object) -> dict[str, object]:
+        if not isinstance(method, str) or method not in SUPPORTED_METHODS:
+            raise CoreRequestError("unknown_method", "unknown desktop Core method")
+        if not isinstance(raw_params, dict):
+            raise CoreRequestError("invalid_params", "params must be an object")
+        params = raw_params
+        if method == "app.bootstrap":
+            return self._bootstrap(_object_params(params, frozenset()))
+        if method == "app.shutdown":
+            _object_params(params, frozenset())
+            self._shutdown_requested = True
+            self._stop_event.set()
+            return {"shutdown": True}
+        if method == "catalog.search":
+            return self._search(_object_params(params, frozenset({"query", "offset", "limit", "generation"})))
+        if method == "catalog.detail":
+            return self._detail(_object_params(params, frozenset({"song_id", "generation"})))
+        if method == "catalog.reload":
+            return self._reload(_object_params(params, frozenset()))
+        if method == "catalog.set_viewport":
+            return self._set_viewport(
+                _object_params(
+                    params,
+                    frozenset({"generation", "first_index", "last_index", "selected_song_id"}),
+                )
+            )
+        if method == "settings.get":
+            _object_params(params, frozenset())
+            return _settings_dict(self.settings_service)
+        if method == "settings.patch":
+            return self._patch_settings(params)
+        raise CoreRequestError("unknown_method", "unknown desktop Core method")
+
+    def _ensure_catalog(self) -> None:
+        if not self._catalog_initialized:
+            self.catalog_service.scan()
+            self._catalog_initialized = True
+
+    def _bootstrap(self, _params: Mapping[str, object]) -> dict[str, object]:
+        self._ensure_catalog()
+        settings = self.settings_service.snapshot()
+        dto = BootstrapDto(
+            app_version=self.app_version,
+            protocol_version=DESKTOP_PROTOCOL_VERSION,
+            native_build=_native_build_dto(self.native_build_info),
+            playback_defaults=PlaybackConfigDto(
+                hold_frames=settings.default_hold_frames,
+                tempo_scale=settings.default_tempo_scale,
+                fps=settings.game_fps,
+                dry_run=False,
+            ),
+            option_sets=PlaybackOptionSetsDto(
+                hold_frames=HOLD_FRAME_OPTIONS,
+                tempo_scales=TEMPO_SCALE_OPTIONS,
+                fps=VALID_FPS,
+            ),
+            theme=settings.theme,
+            telemetry_enabled=settings.telemetry_enabled,
+            update_preferences=UpdatePreferencesDto(
+                auto_check=settings.update_preferences.auto_check,
+                channel=settings.update_preferences.channel,  # type: ignore[arg-type]
+                skip_version=settings.update_preferences.skip_version,
+            ),
+            catalog_generation=self.catalog_service.generation,
+        )
+        return _bootstrap_dict(dto)
+
+    def _search(self, params: Mapping[str, object]) -> dict[str, object]:
+        self._ensure_catalog()
+        query = params.get("query", "")
+        if not isinstance(query, str) or len(query.encode("utf-8")) > 4 * 1024:
+            raise CoreRequestError("invalid_params", "query must be bounded text")
+        offset = params.get("offset", 0)
+        limit = params.get("limit", 100)
+        if type(offset) is not int or not 0 <= offset <= MAX_OFFSET:
+            raise CoreRequestError("invalid_params", "offset is outside the supported range")
+        if type(limit) is not int or not 1 <= limit <= 200:
+            raise CoreRequestError("invalid_params", "limit must be between 1 and 200")
+        page = self.catalog_service.search_window(
+            query,
+            offset=offset,
+            limit=limit,
+            generation=_optional_generation(params),
+        )
+        return {
+            "items": [
+                {
+                    "song_id": row.song_id,
+                    "title": row.title,
+                    "duration_us": None,
+                    "note_count": None,
+                    "risk_level": "unknown",
+                    "metadata_state": "pending",
+                }
+                for row in page.items
+            ],
+            "offset": page.offset,
+            "limit": page.limit,
+            "total": page.total,
+            "generation": page.generation,
+        }
+
+    def _detail(self, params: Mapping[str, object]) -> dict[str, object]:
+        self._ensure_catalog()
+        song_id = _required_text(params, "song_id", max_bytes=64)
+        path = self.catalog_service.path_for_song_id(
+            song_id,
+            generation=_optional_generation(params),
+        )
+        settings = self.settings_service.snapshot()
+        session = PlaybackSessionContext.default(
+            hold_frames=settings.default_hold_frames,
+            tempo_scale=settings.default_tempo_scale,
+            fps=settings.game_fps,
+        )
+        metadata = get_song_ui_metadata(path, session, self.settings_service.config_snapshot())
+        risk_level = metadata.risk if metadata.risk in {"low", "medium", "high"} else "unknown"
+        recommendations = tuple(metadata.warnings) if risk_level != "unknown" else ()
+        reasons = () if risk_level == "low" else recommendations
+        risk = RiskSummaryDto(
+            level=risk_level,  # type: ignore[arg-type]
+            headline={
+                "low": "Low timing risk",
+                "medium": "Medium timing risk",
+                "high": "High timing risk",
+                "unknown": "Risk unavailable",
+            }[risk_level],
+            reasons=reasons,
+            recommendations=recommendations,
+        )
+        recommendation = None
+        if risk_level != "unknown":
+            recommendation = PlaybackRecommendationDto(
+                recommended_hold_frames=metadata.recommended_hold_frames,
+                recommended_tempo_scale=metadata.recommended_tempo_scale,
+                summary=(recommendations[0] if recommendations else "Keep the selected settings."),
+            )
+        dto = SongDetailDto(
+            song_id=song_id,
+            title=path.stem,
+            duration_us=round(metadata.duration_seconds * 1_000_000),
+            note_count=metadata.note_count,
+            format_label=path.suffix.lower().lstrip(".").upper(),
+            risk=risk,
+            recommendation=recommendation,
+        )
+        return asdict(dto)
+
+    def _reload(self, _params: Mapping[str, object]) -> dict[str, object]:
+        snapshot = self.catalog_service.scan()
+        self._catalog_initialized = True
+        self._events.append(
+            event(
+                "catalog.changed",
+                {"generation": snapshot.generation, "total": snapshot.total},
+            )
+        )
+        return {"generation": snapshot.generation, "total": snapshot.total}
+
+    def _set_viewport(self, params: Mapping[str, object]) -> dict[str, object]:
+        self._ensure_catalog()
+        generation = _required_int(params, "generation")
+        first_index = _required_int(params, "first_index")
+        last_index = _required_int(params, "last_index")
+        if last_index < first_index or last_index - first_index + 1 > MAX_VIEWPORT_SPAN:
+            raise CoreRequestError("invalid_params", "viewport range is invalid or too large")
+        selected = params.get("selected_song_id")
+        if selected is not None and (
+            not isinstance(selected, str)
+            or len(selected) != 32
+            or any(char not in "0123456789abcdef" for char in selected)
+        ):
+            raise CoreRequestError("invalid_params", "selected_song_id must be an opaque song ID or null")
+        self.catalog_service.entries(generation=generation)
+        self._viewport = {
+            "generation": generation,
+            "first_index": first_index,
+            "last_index": last_index,
+            "selected_song_id": selected,
+        }
+        return {
+            "accepted": True,
+            "generation": generation,
+            "first_index": first_index,
+            "last_index": last_index,
+            "selected_song_id": selected,
+        }
+
+    def _patch_settings(self, params: Mapping[str, object]) -> dict[str, object]:
+        unknown = set(params) - PATCH_FIELDS
+        if unknown:
+            raise CoreRequestError("invalid_params", f"unsupported settings: {', '.join(sorted(unknown))}")
+        translated: dict[str, object] = {}
+        for field in ("theme", "telemetry_enabled", "verbose_hud"):
+            if field in params:
+                translated[field] = params[field]
+        if "playback_defaults" in params:
+            playback = params["playback_defaults"]
+            if not isinstance(playback, dict):
+                raise CoreRequestError("invalid_params", "playback_defaults must be an object")
+            unknown_playback = set(playback) - PLAYBACK_PATCH_FIELDS
+            if unknown_playback:
+                raise CoreRequestError(
+                    "invalid_params",
+                    f"unsupported playback settings: {', '.join(sorted(unknown_playback))}",
+                )
+            field_map = {
+                "hold_frames": "default_hold_frames",
+                "tempo_scale": "default_tempo_scale",
+                "fps": "game_fps",
+            }
+            translated.update({field_map[key]: value for key, value in playback.items()})
+        try:
+            self.settings_service.patch(translated)
+            return _settings_dict(self.settings_service)
+        except (TypeError, ValueError) as exc:
+            raise CoreRequestError("invalid_params", str(exc)) from exc
+
+    def serve(self, stdin: Any, stdout: Any, *, stderr: Any = None) -> int:
+        """Run until shutdown, EOF, parent loss, or a fatal protocol violation."""
+        error_stream = stderr or sys.stderr
+        try:
+            write_frame(stdout, self.ready_event())
+        except (OSError, ProtocolError) as exc:
+            print(f"desktop Core could not emit ready: {exc}", file=error_stream)
+            return 2
+
+        queue: Queue[bytes | ProtocolError | None] = Queue()
+
+        def read_worker() -> None:
+            try:
+                for frame in iter_bounded_frames(stdin):
+                    queue.put(frame)
+            except ProtocolError as exc:
+                queue.put(exc)
+            finally:
+                queue.put(None)
+
+        reader = threading.Thread(target=read_worker, name="desktop-core-reader", daemon=True)
+        reader.start()
+
+        parent_watch_stop = threading.Event()
+
+        def parent_worker() -> None:
+            if self.parent_pid is None:
+                return
+            while not parent_watch_stop.wait(0.25):
+                if not parent_process_alive(self.parent_pid):
+                    self._stop_event.set()
+                    queue.put(None)
+                    return
+
+        parent_thread = threading.Thread(target=parent_worker, name="desktop-core-parent-watch", daemon=True)
+        parent_thread.start()
+
+        exit_code = 0
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    item = queue.get(timeout=0.25)
+                except Empty:
+                    continue
+                if item is None:
+                    break
+                if isinstance(item, ProtocolError):
+                    print(f"desktop Core protocol error: {item.message}", file=error_stream)
+                    write_frame(
+                        stdout,
+                        event(
+                            "core.fatal",
+                            {"code": bounded_text(item.code), "message": bounded_text(item.message)},
+                        ),
+                    )
+                    exit_code = 2
+                    break
+                try:
+                    request = parse_request_frame(item)
+                except ProtocolError as exc:
+                    if exc.request_id is not None:
+                        write_frame(stdout, response_error(exc.request_id, exc.code, exc.message))
+                        continue
+                    print(f"desktop Core protocol error: {exc.message}", file=error_stream)
+                    write_frame(
+                        stdout,
+                        event(
+                            "core.fatal",
+                            {"code": bounded_text(exc.code), "message": bounded_text(exc.message)},
+                        ),
+                    )
+                    exit_code = 2
+                    break
+                response = self.handle_request(request)
+                write_frame(stdout, response)
+                for notification in self.drain_events():
+                    write_frame(stdout, notification)
+                if self._shutdown_requested:
+                    break
+        except (OSError, ProtocolError) as exc:
+            print(f"desktop Core output failure: {exc}", file=error_stream)
+            exit_code = 2
+        finally:
+            parent_watch_stop.set()
+            self._stop_event.set()
+        return exit_code
+
+
+__all__ = [
+    "MAX_OFFSET",
+    "MAX_VIEWPORT_SPAN",
+    "PATCH_FIELDS",
+    "PLAYBACK_PATCH_FIELDS",
+    "SUPPORTED_METHODS",
+    "DesktopCoreServer",
+    "parent_process_alive",
+]

--- a/src/sky_music/orchestration/catalog_service.py
+++ b/src/sky_music/orchestration/catalog_service.py
@@ -74,6 +74,17 @@ class CatalogPage:
 
 
 @dataclass(frozen=True, slots=True)
+class CatalogWindow:
+    """An offset/limit window from one immutable catalog generation."""
+
+    items: tuple[CatalogRow, ...]
+    offset: int
+    limit: int
+    total: int
+    generation: int
+
+
+@dataclass(frozen=True, slots=True)
 class CatalogSnapshot:
     """The complete path-free catalog view after one successful scan."""
 
@@ -231,6 +242,31 @@ class CatalogService:
         items = tuple(CatalogRow(entry.song_id, entry.title) for entry in entries[start : start + page_size])
         return CatalogPage(items, page, page_size, len(entries), catalog_generation)
 
+    def search_window(
+        self,
+        query: str = "",
+        *,
+        offset: int = 0,
+        limit: int = DEFAULT_PAGE_SIZE,
+        generation: int | None = None,
+    ) -> CatalogWindow:
+        """Return an arbitrary offset/limit window from one catalog snapshot."""
+        if type(offset) is not int or offset < 0:
+            raise CatalogError("catalog offset must be a non-negative integer")
+        _validate_page(0, limit)
+        normalized = _validate_query(query)
+        catalog_generation, entries = self._entries_snapshot(generation)
+        if normalized:
+            ranked_indices = self.rank_search_keys(
+                [entry.search_key for entry in entries],
+                normalized,
+                score_cutoff=FUZZY_SCORE_CUTOFF,
+            )
+            entries = tuple(entries[index] for index in ranked_indices)
+        window = entries[offset : offset + limit]
+        items = tuple(CatalogRow(entry.song_id, entry.title) for entry in window)
+        return CatalogWindow(items, offset, limit, len(entries), catalog_generation)
+
     def search_entries(
         self,
         query: str = "",
@@ -325,6 +361,7 @@ __all__ = [
     "CatalogRow",
     "CatalogService",
     "CatalogSnapshot",
+    "CatalogWindow",
     "canonical_path",
     "normalize_search_text",
     "normalized_canonical_path",

--- a/src/sky_music/orchestration/settings_service.py
+++ b/src/sky_music/orchestration/settings_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +24,18 @@ from sky_music.domain.hold_timing import (
 
 THEME_IDS: frozenset[str] = frozenset({"aurora", "minimalist", "slate", "cyberpunk", "classic"})
 BACKGROUND_MODES: frozenset[str] = frozenset({"transparent", "painted"})
+HOLD_FRAME_OPTIONS: tuple[float, ...] = (1.0, 1.25, 1.5)
+TEMPO_SCALE_OPTIONS: tuple[float, ...] = (0.90, 0.95, 1.00, 1.05, 1.10)
+PATCHABLE_SETTINGS: frozenset[str] = frozenset(
+    {
+        "default_hold_frames",
+        "default_tempo_scale",
+        "game_fps",
+        "theme",
+        "telemetry_enabled",
+        "verbose_hud",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -203,6 +216,12 @@ class SettingsService:
     def snapshot(self) -> ApplicationSettings:
         return normalize_application_settings(self._cfg)
 
+    def config_snapshot(self) -> AppConfig:
+        """Return a detached config for trusted read-only orchestration work."""
+        from copy import deepcopy
+
+        return deepcopy(self._cfg)
+
     def reload(self) -> ApplicationSettings:
         self._cfg = load_config(force_reload=True)
         return self.snapshot()
@@ -265,9 +284,61 @@ class SettingsService:
         save_config(self._cfg)
         return self.snapshot()
 
+    def patch(self, values: Mapping[str, object]) -> ApplicationSettings:
+        """Atomically validate and persist the supported application settings."""
+        if not isinstance(values, Mapping):
+            raise ValueError("settings patch must be an object")
+        unknown = [
+            key for key in values if not isinstance(key, str) or key not in PATCHABLE_SETTINGS
+        ]
+        if unknown:
+            labels = ", ".join(sorted(str(key) for key in unknown))
+            raise ValueError(f"unsupported settings: {labels}")
+
+        normalized: dict[str, object] = {}
+        if "default_hold_frames" in values:
+            normalized["default_hold_frames"] = _validate_write_hold_frames(
+                values["default_hold_frames"]
+            )
+        if "default_tempo_scale" in values:
+            normalized["default_tempo_scale"] = _validate_write_tempo(
+                values["default_tempo_scale"]
+            )
+        if "game_fps" in values:
+            normalized["game_fps"] = _validate_write_fps(values["game_fps"])
+        if "theme" in values:
+            normalized["theme"] = _validate_write_theme(values["theme"])
+        if "telemetry_enabled" in values:
+            normalized["telemetry_enabled"] = _validate_write_bool(
+                values["telemetry_enabled"], "telemetry_enabled"
+            )
+        if "verbose_hud" in values:
+            normalized["verbose_hud"] = _validate_write_bool(
+                values["verbose_hud"], "verbose_hud"
+            )
+
+        if "default_hold_frames" in normalized:
+            self._cfg.default_hold_frames = normalized["default_hold_frames"]  # type: ignore[assignment]
+        if "default_tempo_scale" in normalized:
+            self._cfg.default_tempo_scale = normalized["default_tempo_scale"]  # type: ignore[assignment]
+        if "game_fps" in normalized:
+            self._cfg.game_fps = normalized["game_fps"]  # type: ignore[assignment]
+        if "theme" in normalized:
+            self._cfg.theme = normalized["theme"]  # type: ignore[assignment]
+        if "telemetry_enabled" in normalized:
+            self._cfg.telemetry_enabled_by_default = normalized["telemetry_enabled"]  # type: ignore[assignment]
+        if "verbose_hud" in normalized:
+            self._cfg.verbose_hud = normalized["verbose_hud"]  # type: ignore[assignment]
+        if normalized:
+            save_config(self._cfg)
+        return self.snapshot()
+
 
 __all__ = [
     "BACKGROUND_MODES",
+    "HOLD_FRAME_OPTIONS",
+    "PATCHABLE_SETTINGS",
+    "TEMPO_SCALE_OPTIONS",
     "THEME_IDS",
     "ApplicationSettings",
     "HotkeySettings",

--- a/tests/test_background_worker_static_guard.py
+++ b/tests/test_background_worker_static_guard.py
@@ -20,6 +20,7 @@ def test_static_drift_guard() -> None:
     
     allowed_threading_thread = {
         "sky_music/orchestration/engine.py",
+        "sky_music/infrastructure/desktop_ipc/server.py",
         "sky_music/platform/win32/global_hotkeys.py",
     }
 

--- a/tests/test_desktop_ipc.py
+++ b/tests/test_desktop_ipc.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from sky_music.config import AppConfig
+from sky_music.infrastructure import desktop_ipc as desktop_ipc_package
+from sky_music.infrastructure.desktop_ipc import protocol
+from sky_music.infrastructure.desktop_ipc.server import DesktopCoreServer
+from sky_music.orchestration import settings_service as settings_module
+from sky_music.orchestration.catalog_service import CatalogService, song_id_for_path
+from sky_music.orchestration.native_admission import RustBuildInfo
+from sky_music.orchestration.settings_service import SettingsService
+
+NATIVE_INFO = RustBuildInfo(
+    native_build_commit="a" * 40,
+    schema_version=10,
+    native_abi="cp314t-win_amd64",
+    native_version="3.5.0",
+    rustc_version="1.98.0",
+    module_path="sky_player_rs.pyd",
+    win32_backend=True,
+)
+
+
+def _request(method: str, params: dict[str, object] | None = None, request_id: int = 1) -> dict[str, object]:
+    return {
+        "v": 1,
+        "id": request_id,
+        "type": "request",
+        "method": method,
+        "params": params or {},
+    }
+
+
+def _server(tmp_path: Path) -> DesktopCoreServer:
+    return DesktopCoreServer(
+        settings_service=SettingsService(AppConfig(songs_dir=str(tmp_path))),
+        catalog_service=CatalogService(tmp_path),
+        native_build_info=NATIVE_INFO,
+        app_version="3.5.0-test",
+    )
+
+
+def _call(server: DesktopCoreServer, request: dict[str, object]) -> dict[str, object]:
+    return server.handle_request(protocol.parse_request_frame(protocol.encode_frame(request)))
+
+
+def _output_messages(output: io.BytesIO) -> list[dict[str, object]]:
+    return [json.loads(line) for line in output.getvalue().splitlines()]
+
+
+def test_protocol_constants_and_package_exports() -> None:
+    assert protocol.DESKTOP_PROTOCOL_VERSION == 1
+    assert protocol.MAX_REQUEST_FRAME_BYTES == 64 * 1024
+    assert protocol.MAX_RESPONSE_FRAME_BYTES == 1024 * 1024
+    assert desktop_ipc_package.MAX_INBOUND_FRAME_BYTES == 64 * 1024
+
+
+def test_protocol_rejects_bad_version_unknown_fields_duplicates_and_nonfinite() -> None:
+    with pytest.raises(protocol.ProtocolError, match="unsupported protocol version"):
+        protocol.parse_request_frame(protocol.encode_frame({**_request("settings.get"), "v": 2}))
+    with pytest.raises(protocol.ProtocolError, match="unknown fields"):
+        protocol.parse_request_frame(protocol.encode_frame({**_request("settings.get"), "extra": True}))
+    with pytest.raises(protocol.ProtocolError, match="duplicate JSON key"):
+        protocol.parse_request_frame(
+            b'{"v":1,"id":1,"type":"request","method":"settings.get","params":{},"params":{}}\n'
+        )
+    with pytest.raises(protocol.ProtocolError, match="non-finite"):
+        protocol.parse_request_frame(
+            b'{"v":1,"id":1,"type":"request","method":"settings.patch","params":{"default_tempo_scale":NaN}}\n'
+        )
+
+
+def test_protocol_rejects_oversized_frames_without_readline() -> None:
+    class ChunkStream:
+        def __init__(self, value: bytes) -> None:
+            self._value = value
+
+        def read(self, size: int) -> bytes:
+            chunk, self._value = self._value[:size], self._value[size:]
+            return chunk
+
+        def readline(self) -> bytes:
+            raise AssertionError("bounded reader must not call readline")
+
+    with pytest.raises(protocol.ProtocolError, match="64 KiB"):
+        list(protocol.iter_bounded_frames(ChunkStream(b"x" * (64 * 1024 + 1))))
+
+    with pytest.raises(protocol.ProtocolError, match="1 MiB"):
+        protocol.encode_frame({"payload": "x" * (1024 * 1024)})
+
+
+def test_protocol_rejects_bad_envelope_types() -> None:
+    bad_requests = (
+        {**_request("settings.get"), "id": True},
+        {**_request("settings.get"), "type": "event"},
+        {**_request("settings.get"), "method": "settings get"},
+        {**_request("settings.get"), "params": []},
+    )
+    for request in bad_requests:
+        with pytest.raises(protocol.ProtocolError):
+            protocol.parse_request_frame(protocol.encode_frame(request))
+
+
+def test_bootstrap_is_lazy_but_publishes_catalog_snapshot(tmp_path: Path) -> None:
+    (tmp_path / "Alpha.json").write_text(
+        '{"name":"ignored","songNotes":[{"time":0,"key":"Key0"}]}',
+        encoding="utf-8",
+    )
+    server = _server(tmp_path)
+
+    response = _call(server, _request("app.bootstrap"))
+
+    assert response["ok"] is True
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert result["protocol_version"] == 1
+    assert result["catalog_generation"] == 1
+    assert result["native_build"]["native_build_commit"] == "a" * 40  # type: ignore[index]
+    assert result["option_sets"]["fps"]  # type: ignore[index]
+    assert str(tmp_path) not in json.dumps(response)
+
+
+def test_catalog_search_is_path_free_and_supports_offset_limit(tmp_path: Path) -> None:
+    for title in ("Bravo", "Alpha", "Charlie"):
+        (tmp_path / f"{title}.txt").write_text("", encoding="utf-8")
+    server = _server(tmp_path)
+
+    response = _call(server, _request("catalog.search", {"query": "", "offset": 1, "limit": 1}))
+
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert result["total"] == 3
+    assert result["offset"] == 1
+    assert result["generation"] == 1
+    assert result["items"] == [
+        {
+            "song_id": song_id_for_path(tmp_path / "Bravo.txt"),
+            "title": "Bravo",
+            "duration_us": None,
+            "note_count": None,
+            "risk_level": "unknown",
+            "metadata_state": "pending",
+        }
+    ]
+    assert str(tmp_path) not in json.dumps(response)
+
+
+def test_catalog_detail_is_structured_and_does_not_leak_path(tmp_path: Path) -> None:
+    song_path = tmp_path / "Detail.json"
+    song_path.write_text(
+        '{"name":"ignored","songNotes":[{"time":0,"key":"Key0"},{"time":200,"key":"Key1"}]}',
+        encoding="utf-8",
+    )
+    server = _server(tmp_path)
+    _call(server, _request("catalog.search"))
+
+    response = _call(server, _request("catalog.detail", {"song_id": song_id_for_path(song_path)}))
+
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert result["title"] == "Detail"
+    assert result["format_label"] == "JSON"
+    assert isinstance(result["risk"], dict)
+    assert isinstance(result["recommendation"], dict)
+    assert str(tmp_path) not in json.dumps(response)
+
+
+def test_catalog_reload_returns_response_then_changed_event(tmp_path: Path) -> None:
+    server = _server(tmp_path)
+    output = io.BytesIO()
+    requests = b"".join(
+        protocol.encode_frame(request)
+        for request in (_request("catalog.reload"), _request("app.shutdown", request_id=2))
+    )
+
+    assert server.serve(io.BytesIO(requests), output, stderr=io.StringIO()) == 0
+    messages = _output_messages(output)
+    assert messages[0]["name"] == "core.ready"
+    assert messages[1]["type"] == "response"
+    assert messages[2]["name"] == "catalog.changed"
+    assert messages[3]["result"] == {"shutdown": True}
+
+
+def test_catalog_generation_is_checked_for_viewport_and_search(tmp_path: Path) -> None:
+    server = _server(tmp_path)
+    bootstrap = _call(server, _request("app.bootstrap"))
+    generation = bootstrap["result"]["catalog_generation"]  # type: ignore[index]
+
+    accepted = _call(
+        server,
+        _request(
+            "catalog.set_viewport",
+            {
+                "generation": generation,
+                "first_index": 0,
+                "last_index": 10,
+                "selected_song_id": None,
+            },
+        ),
+    )
+    stale = _call(server, _request("catalog.search", {"generation": generation + 1}))
+
+    assert accepted["ok"] is True
+    assert stale["ok"] is False
+    assert stale["error"]["code"] == "stale_generation"  # type: ignore[index]
+
+
+def test_settings_patch_uses_service_and_is_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    writes: list[AppConfig] = []
+    monkeypatch.setattr(settings_module, "save_config", lambda cfg: writes.append(cfg))
+    server = _server(tmp_path)
+
+    response = _call(
+        server,
+        _request(
+            "settings.patch",
+            {
+                "theme": "slate",
+                "playback_defaults": {"tempo_scale": 0.95, "fps": 120},
+                "telemetry_enabled": True,
+            },
+        ),
+    )
+    result = response["result"]
+    assert isinstance(result, dict)
+    assert result["theme"] == "slate"
+    assert result["playback_defaults"]["tempo_scale"] == 0.95  # type: ignore[index]
+    assert writes
+
+    before = server.settings_service.snapshot()
+    invalid = _call(
+        server,
+        _request("settings.patch", {"playback_defaults": {"tempo_scale": 0.9, "fps": True}}),
+    )
+
+    assert invalid["ok"] is False
+    assert invalid["error"]["code"] == "invalid_params"  # type: ignore[index]
+    assert server.settings_service.snapshot() == before
+    assert len(writes) == 1
+
+
+def test_unknown_method_and_invalid_params_are_responses() -> None:
+    server = _server(Path("songs"))
+    unknown = _call(server, _request("catalog.nope"))
+    invalid = _call(server, _request("catalog.search", {"limit": 201}))
+
+    assert unknown["error"]["code"] == "unknown_method"  # type: ignore[index]
+    assert invalid["error"]["code"] == "invalid_params"  # type: ignore[index]
+
+
+def test_server_eof_is_graceful_and_stdout_contains_protocol_only(tmp_path: Path) -> None:
+    server = _server(tmp_path)
+    output = io.BytesIO()
+    errors = io.StringIO()
+
+    assert server.serve(io.BytesIO(), output, stderr=errors) == 0
+    messages = _output_messages(output)
+    assert messages[0]["name"] == "core.ready"
+    assert errors.getvalue() == ""
+
+
+def test_server_malformed_frame_emits_bounded_fatal_on_stdout(tmp_path: Path) -> None:
+    server = _server(tmp_path)
+    output = io.BytesIO()
+    errors = io.StringIO()
+
+    assert server.serve(io.BytesIO(b"not-json\n"), output, stderr=errors) == 2
+    messages = _output_messages(output)
+    assert messages[0]["name"] == "core.ready"
+    assert messages[1]["name"] == "core.fatal"
+    assert len(json.dumps(messages[1]["payload"]["message"]).encode()) <= 4096  # type: ignore[index]
+    assert errors.getvalue()
+
+
+def test_parent_loss_stops_reader_without_waiting_for_stdin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class BlockingStream:
+        def read(self, _size: int) -> bytes:
+            threading.Event().wait(10)
+            return b""
+
+    monkeypatch.setattr("sky_music.infrastructure.desktop_ipc.server.parent_process_alive", lambda _pid: False)
+    server = DesktopCoreServer(
+        settings_service=SettingsService(AppConfig(songs_dir=str(tmp_path))),
+        catalog_service=CatalogService(tmp_path),
+        native_build_info=NATIVE_INFO,
+        parent_pid=12345,
+    )
+    output = io.BytesIO()
+
+    assert server.serve(BlockingStream(), output, stderr=io.StringIO()) == 0
+    assert _output_messages(output)[0]["name"] == "core.ready"
+
+
+def test_run_desktop_core_admits_runtime_before_services(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from sky_music.cli import desktop_core
+
+    calls: list[str] = []
+    monkeypatch.setattr(desktop_core, "load_config", lambda: AppConfig(songs_dir=str(tmp_path)))
+
+    def runtime_guard() -> None:
+        calls.append("runtime")
+
+    def native_admission() -> RustBuildInfo:
+        calls.append("native")
+        return NATIVE_INFO
+
+    output = io.BytesIO()
+    request = protocol.encode_frame(_request("app.shutdown"))
+    result = desktop_core.run_desktop_core(
+        ["--desktop-worker"],
+        stdin=io.BytesIO(request),
+        stdout=output,
+        stderr=io.StringIO(),
+        runtime_guard=runtime_guard,
+        native_admission=native_admission,
+    )
+
+    assert result == 0
+    assert calls == ["runtime", "native"]
+    assert _output_messages(output)[-1]["result"] == {"shutdown": True}
+
+
+def test_run_desktop_core_startup_failure_is_protocol_fatal(tmp_path: Path) -> None:
+    from sky_music.cli.desktop_core import run_desktop_core
+
+    output = io.BytesIO()
+    errors = io.StringIO()
+
+    result = run_desktop_core(
+        ["--desktop-worker"],
+        stdin=io.BytesIO(),
+        stdout=output,
+        stderr=errors,
+        runtime_guard=lambda: (_ for _ in ()).throw(RuntimeError("runtime rejected")),
+    )
+
+    assert result == 2
+    assert _output_messages(output)[0]["name"] == "core.fatal"
+    assert errors.getvalue()
+
+
+def test_desktop_core_subprocess_round_trip(tmp_path: Path) -> None:
+    source_root = Path(__file__).parents[1] / "src"
+    script = """
+import sys
+from sky_music.config import AppConfig
+from sky_music.infrastructure.desktop_ipc.server import DesktopCoreServer
+from sky_music.orchestration.catalog_service import CatalogService
+from sky_music.orchestration.native_admission import RustBuildInfo
+from sky_music.orchestration.settings_service import SettingsService
+
+root = sys.argv[1]
+info = RustBuildInfo(
+    native_build_commit="a" * 40,
+    schema_version=10,
+    native_abi="cp314t-win_amd64",
+    native_version="3.5.0",
+    rustc_version="1.98.0",
+    module_path="sky_player_rs.pyd",
+    win32_backend=True,
+)
+server = DesktopCoreServer(
+    settings_service=SettingsService(AppConfig(songs_dir=root)),
+    catalog_service=CatalogService(root),
+    native_build_info=info,
+)
+raise SystemExit(server.serve(sys.stdin.buffer, sys.stdout.buffer, stderr=sys.stderr))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(source_root), env.get("PYTHONPATH", "")]))
+    input_data = protocol.encode_frame(_request("app.shutdown"))
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(tmp_path)],
+        input=input_data,
+        capture_output=True,
+        env=env,
+        cwd=source_root.parent,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+    messages = [json.loads(line) for line in completed.stdout.splitlines()]
+    assert messages[0]["name"] == "core.ready"
+    assert messages[-1]["result"] == {"shutdown": True}
+    assert completed.stderr == b""


### PR DESCRIPTION
Phase 2 only — Python Desktop Core protocol. Implements bounded NDJSON stdin/stdout, strict protocol validation, runtime/native admission, core lifecycle, catalog search/detail/reload/viewport, settings get/patch, EOF/parent-loss handling, and direct/subprocess tests. No Tauri, React, Vite, playback IPC, diagnostics streaming, calibration UI, updater UI, packaging, or Rust changes.