### PR TITLE
feat(release): package and qualify exact v4 portable artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
                 relevant=true
                 break
                 ;;
-              pyproject.toml|uv.lock|.python-version|.env.example|Sky-Auto-Player.spec)
+              pyproject.toml|uv.lock|.python-version|.env.example|Sky-Auto-Player.spec|Sky-Auto-Player-Core.spec)
                 relevant=true
                 break
                 ;;
@@ -187,7 +187,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.relevant == 'true'
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout
@@ -223,22 +223,33 @@ jobs:
           "SKY_SOURCE_BOOTLOADER_DIR=$bootloader" | Add-Content $env:GITHUB_ENV -Encoding ASCII
           "SKY_REQUIRE_SOURCE_BOOTLOADER=1" | Add-Content $env:GITHUB_ENV -Encoding ASCII
 
-      - name: Build packaged unsigned app
+      - name: Set up Bun for production frontend build
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Build and qualify exact Phase 8 portable artifact
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
           SKY_EXPECTED_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: uv run --env-file .env python -m build_app --manifest
+        run: |
+          $output = Join-Path $env:RUNNER_TEMP "Sky Auto Player Phase8"
+          uv run --env-file .env python scripts/build_phase8.py --output-root $output
+          "SKY_PHASE8_OUTPUT=$output" | Add-Content $env:GITHUB_ENV -Encoding UTF8
 
       - name: Verify packaged release tree
         run: |
           $version = uv run python -c "import tomllib,pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
           uv run --env-file .env python scripts/verify_release_manifest.py `
-            --release-dir "dist\Sky-Auto-Player-v$version" --version $version
+            --release-dir (Join-Path $env:SKY_PHASE8_OUTPUT "Sky-Auto-Player-v$version") --version $version
 
-      - name: Native updater security E2E
-        env:
-          RUSTUP_TOOLCHAIN: 1.98.0
-        run: cargo test --manifest-path rust/Cargo.toml -p sky_updater --test packaged_update_e2e --all-features --locked
+      - name: Upload exact Phase 8 release candidate
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sky-auto-player-phase8-portable-v${{ hashFiles('pyproject.toml') }}
+          path: ${{ runner.temp }}/Sky Auto Player Phase8
+          if-no-files-found: error
+          retention-days: 14
 
   status:
     name: Sky Auto Player — required CI gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,21 @@ jobs:
           uv run --env-file .env python scripts/verify_release_manifest.py `
             --release-dir (Join-Path $env:SKY_PHASE8_OUTPUT "Sky-Auto-Player-v$version") --version $version
 
+      - name: Report exact Phase 8 artifact identity
+        shell: pwsh
+        run: |
+          $summary = Get-Content (Join-Path $env:SKY_PHASE8_OUTPUT "PHASE8_ARTIFACT_SUMMARY.json") -Raw | ConvertFrom-Json
+          @"
+          ## Phase 8 exact artifact
+          - repo head: ``$($summary.repo_head)``
+          - ZIP: ``$($summary.artifact_name)`` ($($summary.artifact_size) bytes)
+          - ZIP SHA-256: ``$($summary.artifact_sha256)``
+          - MANIFEST SHA-256: ``$($summary.manifest_sha256)``
+          - portable files: $($summary.portable_file_count)
+          - managed entries: $($summary.managed_entry_count)
+          "@ | Add-Content $env:GITHUB_STEP_SUMMARY -Encoding UTF8
+          Get-Content (Join-Path $env:SKY_PHASE8_OUTPUT "PROVENANCE.json")
+
       - name: Upload exact Phase 8 release candidate
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
   release:
     name: Build + attest + draft
     runs-on: windows-latest
-    timeout-minutes: 40
+    timeout-minutes: 100
 
     steps:
       - name: Checkout
@@ -99,20 +99,26 @@ jobs:
           "SKY_SOURCE_BOOTLOADER_DIR=$bootloader" | Add-Content $env:GITHUB_ENV -Encoding ASCII
           "SKY_REQUIRE_SOURCE_BOOTLOADER=1" | Add-Content $env:GITHUB_ENV -Encoding ASCII
 
-      - name: Build unsigned native app and smoke tests
+      - name: Set up Bun for production frontend build
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Build and qualify exact portable release candidate
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
-        run: uv run --env-file .env python -m build_app
-
-      - name: Generate unsigned-byte manifest
-        run: uv run --env-file .env python -m build_app --manifest-only
+        run: |
+          $output = Join-Path $env:RUNNER_TEMP "Sky Auto Player Phase8"
+          uv run --env-file .env python scripts/build_phase8.py --output-root $output
+          "SKY_PHASE8_OUTPUT=$output" | Add-Content $env:GITHUB_ENV -Encoding UTF8
 
       - name: Verify exact release tree and manifest
         run: |
           $ver = "${{ steps.verlock.outputs.version }}"
+          $rel = Join-Path $env:SKY_PHASE8_OUTPUT "Sky-Auto-Player-v$ver"
           uv run --env-file .env python scripts/verify_release_manifest.py `
-            --release-dir "dist\Sky-Auto-Player-v$ver" --version $ver
-          $e2e = Get-ChildItem "dist\Sky-Auto-Player-v$ver" -Recurse -File -ErrorAction SilentlyContinue |
+            --release-dir $rel --version $ver
+          $e2e = Get-ChildItem $rel -Recurse -File -ErrorAction SilentlyContinue |
             Where-Object { $_.Name -like "sky_updater_e2e*" }
           if ($e2e) { throw "E2E updater artifacts must never enter the public release tree: $($e2e.FullName -join ', ')" }
 
@@ -120,14 +126,17 @@ jobs:
         id: stage
         run: |
           $ver = "${{ steps.verlock.outputs.version }}"
-          $rel = "dist\Sky-Auto-Player-v$ver"
-          if (-not (Test-Path $rel)) { throw "Missing release dir: $rel" }
-
-          # Canonical
-          Compress-Archive -Path (Join-Path $rel '*') -DestinationPath "$env:RUNNER_TEMP\Sky-Auto-Player-v$ver.zip" -Force
-          $h = (Get-FileHash -Algorithm SHA256 "$env:RUNNER_TEMP\Sky-Auto-Player-v$ver.zip").Hash
-          "$h  Sky-Auto-Player-v$ver.zip" | Set-Content "$env:RUNNER_TEMP\Sky-Auto-Player-v$ver.zip.sha256" -Encoding ASCII
-          Copy-Item "$rel\MANIFEST.json" "$env:RUNNER_TEMP\MANIFEST.json"
+          $artifact = Join-Path $env:SKY_PHASE8_OUTPUT "Sky-Auto-Player-v$ver.zip"
+          $sidecar = "$artifact.sha256"
+          $manifest = Join-Path $env:SKY_PHASE8_OUTPUT "MANIFEST.json"
+          $provenance = Join-Path $env:SKY_PHASE8_OUTPUT "PROVENANCE.json"
+          foreach ($path in @($artifact, $sidecar, $manifest, $provenance)) {
+            if (-not (Test-Path $path)) { throw "Missing exact Phase 8 release asset: $path" }
+          }
+          Copy-Item $artifact "$env:RUNNER_TEMP\Sky-Auto-Player-v$ver.zip"
+          Copy-Item $sidecar "$env:RUNNER_TEMP\Sky-Auto-Player-v$ver.zip.sha256"
+          Copy-Item $manifest "$env:RUNNER_TEMP\MANIFEST.json"
+          Copy-Item $provenance "$env:RUNNER_TEMP\PROVENANCE.json"
 
           "version=$ver" | Set-Content $env:GITHUB_OUTPUT -Encoding ASCII
 
@@ -137,7 +146,8 @@ jobs:
           $required = @(
             "Sky-Auto-Player-v$ver.zip",
             "Sky-Auto-Player-v$ver.zip.sha256",
-            "MANIFEST.json"
+            "MANIFEST.json",
+            "PROVENANCE.json"
           )
           foreach ($file in $required) {
             if (-not (Test-Path "$env:RUNNER_TEMP\$file")) {
@@ -153,6 +163,7 @@ jobs:
             ${{ runner.temp }}/Sky-Auto-Player-v${{ steps.stage.outputs.version }}.zip
             ${{ runner.temp }}/Sky-Auto-Player-v${{ steps.stage.outputs.version }}.zip.sha256
             ${{ runner.temp }}/MANIFEST.json
+            ${{ runner.temp }}/PROVENANCE.json
 
       - name: Create draft GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -161,6 +172,7 @@ jobs:
             ${{ runner.temp }}/Sky-Auto-Player-v${{ steps.stage.outputs.version }}.zip
             ${{ runner.temp }}/Sky-Auto-Player-v${{ steps.stage.outputs.version }}.zip.sha256
             ${{ runner.temp }}/MANIFEST.json
+            ${{ runner.temp }}/PROVENANCE.json
           body_path: docs/releases/v${{ steps.stage.outputs.version }}-release-notes.md
           generate_release_notes: false
           # Every release starts as a draft. Publish only the exact artifact that

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ build/
 dist/
 *.spec
 !Sky-Auto-Player.spec
+!Sky-Auto-Player-Core.spec
 windows_version_info.txt
 
 # Packaging Metadata

--- a/Sky-Auto-Player-Core.spec
+++ b/Sky-Auto-Player-Core.spec
@@ -1,0 +1,115 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""The single free-threaded Python runtime used by the v4 portable package."""
+
+from importlib.util import find_spec
+from pathlib import Path
+
+ROOT = Path(SPECPATH).resolve()
+app_name = "Sky-Auto-Player-Core"
+entry_point = str(ROOT / "src" / "core_main.py")
+
+datas = []
+binaries = []
+hiddenimports = [
+    "main",
+    "sky_music._native_build",
+    "sky_music._version",
+    "sky_music.platform.win32",
+    "sky_music.platform.win32.global_hotkeys",
+    "sky_music.orchestration.native_admission",
+    "sky_music.orchestration.engine",
+    "sky_music.orchestration.calibration",
+    "sky_music.orchestration.telemetry",
+    "sky_music.infrastructure.background",
+    "sky_music.infrastructure.desktop_ipc",
+    "sky_music.infrastructure.desktop_ipc.protocol",
+    "sky_music.infrastructure.desktop_ipc.server",
+    "sky_music.infrastructure.hotkeys",
+    "sky_music.infrastructure.doctor",
+    "sky_music.infrastructure.focus",
+    "sky_music.infrastructure.realtime",
+    "sky_music.infrastructure.timing",
+    "sky_music.cli.calibration_command",
+    "sky_music.cli.console_playback",
+    "sky_music.cli.doctor_command",
+    "sky_music.ui.hud",
+    "sky_music.ui.picker",
+    "sky_music.ui.picker_helpers",
+    "sky_music.ui.textual_app",
+    "sky_music.ui.textual_app.styles",
+    "textual.drivers.windows_driver",
+    "rich.markdown",
+]
+
+stylesheet = ROOT / "src" / "sky_music" / "ui" / "textual_app" / "styles" / "base.tcss"
+if not stylesheet.is_file():
+    raise RuntimeError(f"required Textual stylesheet is missing: {stylesheet}")
+datas.append((str(stylesheet), "sky_music/ui/textual_app/styles"))
+
+native_module = find_spec("sky_player_rs.sky_player_rs")
+if native_module is None or native_module.origin is None:
+    raise RuntimeError(
+        "sky_player_rs is required; run scripts/build_rust_wheel.py before packaging"
+    )
+binaries.append((native_module.origin, "sky_player_rs"))
+hiddenimports.extend(["sky_player_rs", "sky_player_rs.sky_player_rs"])
+
+block_cipher = None
+
+a = Analysis(
+    [entry_point],
+    pathex=[str(ROOT / "src")],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        "pyinstaller",
+        "pyright",
+        "ruff",
+        "soundcard",
+        "pytest",
+        "_pytest",
+        "xmlrpc",
+        "pydoc",
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+    optimize=1,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=app_name,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    version=str(ROOT / "windows_version_info.txt"),
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name=app_name,
+)

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -11,6 +11,7 @@ struct AppStateInner {
     core: Mutex<CoreState>,
     settings_writes: Mutex<()>,
     closing: AtomicBool,
+    gui_smoke_exit: AtomicBool,
 }
 
 enum CoreState {
@@ -27,6 +28,7 @@ impl Default for AppState {
                 core: Mutex::new(CoreState::Idle),
                 settings_writes: Mutex::new(()),
                 closing: AtomicBool::new(false),
+                gui_smoke_exit: AtomicBool::new(false),
             }),
         }
     }
@@ -117,6 +119,14 @@ impl AppState {
 
     pub fn begin_close(&self) -> bool {
         !self.inner.closing.swap(true, Ordering::AcqRel)
+    }
+
+    pub fn set_gui_smoke_exit(&self, enabled: bool) {
+        self.inner.gui_smoke_exit.store(enabled, Ordering::Release);
+    }
+
+    pub fn should_exit_after_close(&self) -> bool {
+        self.inner.gui_smoke_exit.load(Ordering::Acquire)
     }
 
     fn is_closing(&self) -> bool {

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -12,6 +12,7 @@ struct AppStateInner {
     settings_writes: Mutex<()>,
     closing: AtomicBool,
     gui_smoke_exit: AtomicBool,
+    gui_smoke_failed: AtomicBool,
 }
 
 enum CoreState {
@@ -29,6 +30,7 @@ impl Default for AppState {
                 settings_writes: Mutex::new(()),
                 closing: AtomicBool::new(false),
                 gui_smoke_exit: AtomicBool::new(false),
+                gui_smoke_failed: AtomicBool::new(false),
             }),
         }
     }
@@ -127,6 +129,18 @@ impl AppState {
 
     pub fn should_exit_after_close(&self) -> bool {
         self.inner.gui_smoke_exit.load(Ordering::Acquire)
+    }
+
+    pub fn set_gui_smoke_failed(&self) {
+        self.inner.gui_smoke_failed.store(true, Ordering::Release);
+    }
+
+    pub fn gui_smoke_exit_code(&self) -> i32 {
+        if self.inner.gui_smoke_failed.load(Ordering::Acquire) {
+            1
+        } else {
+            0
+        }
     }
 
     fn is_closing(&self) -> bool {

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -865,14 +865,24 @@ pub async fn subscribe_ui_events(
 #[tauri::command]
 pub async fn shutdown(
     window: tauri::WebviewWindow<super::ShellRuntime>,
-    _state: State<'_, AppState>,
+    state: State<'_, AppState>,
+    params: Option<ShutdownRequest>,
 ) -> Result<(), String> {
     // This command is used only after an authoritative update handoff. Keep
     // shell exit under the same prevent-close -> bounded Core cleanup ->
     // destroy lifecycle as a user-initiated close; React never destroys the
     // native window directly.
+    if params.is_some_and(|request| request.failed) {
+        state.inner().set_gui_smoke_failed();
+    }
     crate::lifecycle::close_window(window.as_ref().window());
     Ok(())
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ShutdownRequest {
+    pub failed: bool,
 }
 
 #[cfg(test)]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -31,6 +31,12 @@ pub fn run_gui_smoke() {
 fn run_inner(gui_smoke: bool) {
     if let Err(error) = core::check_startup_update_guard() {
         eprintln!("Sky Auto Player startup refused: {error}");
+        if gui_smoke {
+            // The packaging smoke is a process-level gate. A startup guard
+            // rejection must be observable as a failing child, rather than
+            // looking like a clean return before Tauri's event loop starts.
+            std::process::exit(2);
+        }
         return;
     }
     let app_state = app_state::AppState::default();
@@ -115,6 +121,9 @@ pub fn selftest_packaged_shell() -> i32 {
     let result = match bootstrap {
         Ok(value) if value.get("native_build").is_some() => {
             supervisor.shutdown();
+            if let Some(marker) = std::env::var_os("SKY_PHASE8_RESTART_MARKER") {
+                let _ = std::fs::write(marker, b"bootstrap-ready\n");
+            }
             0
         }
         Ok(_) => {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -56,6 +56,48 @@ pub fn run() {
         .expect("error while running Sky Auto Player desktop shell");
 }
 
+/// Validate the release shell/Core pairing without constructing a WebView.
+///
+/// This hidden, packaging-only entrypoint is used by the exact portable
+/// artifact gate. It still uses the production launch command and
+/// ``CoreSupervisor``; it merely replaces the interactive window with a
+/// bounded bootstrap/shutdown assertion so CI never needs to synthesize a
+/// physical input session.
+pub fn selftest_packaged_shell() -> i32 {
+    if let Err(error) = core::check_startup_update_guard() {
+        eprintln!("packaged shell selftest startup guard failed: {error}");
+        return 2;
+    }
+    let supervisor = match core::CoreSupervisor::spawn() {
+        Ok(supervisor) => supervisor,
+        Err(error) => {
+            eprintln!("packaged shell selftest could not start Core: {error}");
+            return 2;
+        }
+    };
+    let bootstrap = supervisor.request("app.bootstrap", serde_json::json!({}));
+    let result = match bootstrap {
+        Ok(value) if value.get("native_build").is_some() => {
+            supervisor.shutdown();
+            0
+        }
+        Ok(_) => {
+            eprintln!("packaged shell selftest bootstrap omitted native_build");
+            supervisor.shutdown();
+            1
+        }
+        Err(error) => {
+            eprintln!("packaged shell selftest bootstrap failed: {error}");
+            supervisor.shutdown();
+            1
+        }
+    };
+    if result == 0 {
+        println!("Packaged Tauri/Core selftest: PASS");
+    }
+    result
+}
+
 // The mock runtime is intentionally exercised in a no-default-features test
 // build. Keeping the production Wry runtime out of that test binary avoids
 // loading the native desktop webview during command-decoder unit tests.

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -33,9 +33,21 @@ fn run_inner(gui_smoke: bool) {
         eprintln!("Sky Auto Player startup refused: {error}");
         return;
     }
+    let app_state = app_state::AppState::default();
+    app_state.set_gui_smoke_exit(gui_smoke);
     let mut builder = tauri::Builder::<ShellRuntime>::default()
-        .manage(app_state::AppState::default())
-        .setup(|_| Ok(()));
+        .manage(app_state)
+        .setup(move |app| {
+            if gui_smoke {
+                let app_handle = app.handle().clone();
+                std::thread::spawn(move || {
+                    std::thread::sleep(std::time::Duration::from_secs(45));
+                    eprintln!("packaged GUI smoke watchdog expired");
+                    app_handle.exit(1);
+                });
+            }
+            Ok(())
+        });
     if gui_smoke {
         builder = builder.on_page_load(|webview, payload| {
             if payload.event() == tauri::webview::PageLoadEvent::Finished {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -15,13 +15,37 @@ type ShellRuntime = tauri::test::MockRuntime;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    run_inner(false);
+}
+
+/// Run the production shell with a packaging-only WebView smoke hook.
+///
+/// The hook is selected only by the hidden release self-test argument. It
+/// dispatches a DOM event after the real frontend has loaded; React then
+/// exercises the production bridge and closes through the normal controlled
+/// lifecycle. No test command or alternate runtime is exposed to the user.
+pub fn run_gui_smoke() {
+    run_inner(true);
+}
+
+fn run_inner(gui_smoke: bool) {
     if let Err(error) = core::check_startup_update_guard() {
         eprintln!("Sky Auto Player startup refused: {error}");
         return;
     }
-    tauri::Builder::<ShellRuntime>::default()
+    let mut builder = tauri::Builder::<ShellRuntime>::default()
         .manage(app_state::AppState::default())
-        .setup(|_| Ok(()))
+        .setup(|_| Ok(()));
+    if gui_smoke {
+        builder = builder.on_page_load(|webview, payload| {
+            if payload.event() == tauri::webview::PageLoadEvent::Finished {
+                let _ = webview.eval(
+                    "window.__SKY_PHASE8_GUI_SMOKE__ = true; window.dispatchEvent(new Event('sky-phase8-gui-smoke'));",
+                );
+            }
+        });
+    }
+    builder
         .invoke_handler(tauri::generate_handler![
             commands::bootstrap,
             commands::search_songs,

--- a/desktop/src-tauri/src/lifecycle.rs
+++ b/desktop/src-tauri/src/lifecycle.rs
@@ -4,6 +4,7 @@ use tauri::{Manager, Runtime, Window};
 pub fn close_window<R: Runtime + 'static>(window: Window<R>) {
     let app_handle = window.app_handle().clone();
     let state = app_handle.state::<AppState>().inner().clone();
+    let exit_after_close = state.should_exit_after_close();
     if !state.begin_close() {
         return;
     }
@@ -15,6 +16,9 @@ pub fn close_window<R: Runtime + 'static>(window: Window<R>) {
         // `destroy` does not emit another CloseRequested event, so the
         // bounded shutdown path cannot recurse through this callback.
         let _ = window.destroy();
+        if exit_after_close {
+            app_handle.exit(0);
+        }
     });
 }
 

--- a/desktop/src-tauri/src/lifecycle.rs
+++ b/desktop/src-tauri/src/lifecycle.rs
@@ -5,6 +5,7 @@ pub fn close_window<R: Runtime + 'static>(window: Window<R>) {
     let app_handle = window.app_handle().clone();
     let state = app_handle.state::<AppState>().inner().clone();
     let exit_after_close = state.should_exit_after_close();
+    let exit_code = state.gui_smoke_exit_code();
     if !state.begin_close() {
         return;
     }
@@ -17,7 +18,7 @@ pub fn close_window<R: Runtime + 'static>(window: Window<R>) {
         // bounded shutdown path cannot recurse through this callback.
         let _ = window.destroy();
         if exit_after_close {
-            app_handle.exit(0);
+            app_handle.exit(exit_code);
         }
     });
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,11 +1,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    if std::env::args()
-        .skip(1)
-        .any(|arg| arg == "--selftest-desktop-shell")
-    {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|arg| arg == "--selftest-desktop-shell") {
         std::process::exit(sky_desktop_shell_lib::selftest_packaged_shell());
+    }
+    if args.iter().any(|arg| arg == "--selftest-desktop-gui") {
+        sky_desktop_shell_lib::run_gui_smoke();
+        return;
     }
     sky_desktop_shell_lib::run();
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,5 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if std::env::args()
+        .skip(1)
+        .any(|arg| arg == "--selftest-desktop-shell")
+    {
+        std::process::exit(sky_desktop_shell_lib::selftest_packaged_shell());
+    }
     sky_desktop_shell_lib::run();
 }

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -2,6 +2,16 @@
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    if std::env::var_os("SKY_PHASE8_RESTART_SELFTEST").is_some() {
+        std::process::exit(sky_desktop_shell_lib::selftest_packaged_shell());
+    }
+    if args.iter().any(|arg| arg == "--selftest-desktop-parent") {
+        // This is used only by the exact-package updater harness. The
+        // process is still the real packaged Tauri executable, so the native
+        // updater verifies the canonical parent image rather than a helper.
+        std::thread::sleep(std::time::Duration::from_secs(120));
+        return;
+    }
     if args.iter().any(|arg| arg == "--selftest-desktop-shell") {
         std::process::exit(sky_desktop_shell_lib::selftest_packaged_shell());
     }

--- a/desktop/src-tauri/tests/fixtures/fake_core.py
+++ b/desktop/src-tauri/tests/fixtures/fake_core.py
@@ -220,6 +220,10 @@ def serve(mode: str) -> None:
         raw(b"{not valid json}\n")
         time.sleep(30)
         return
+    if mode == "non_utf8":
+        raw(b"\xff\xfe\n")
+        time.sleep(30)
+        return
     if mode == "duplicate_output":
         raw(b'{"v":1,"type":"event","name":"core.ready","name":"again","payload":{}}\n')
         time.sleep(30)

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -72,7 +72,10 @@ export function App({ bridge }: AppProps) {
       await state.patchSettings({ theme: state.bootstrap?.theme ?? 'aurora' });
       await state.setDiagnosticsEnabled(true);
       await state.setDiagnosticsEnabled(false);
-      await bridge.shutdown();
+      // The controlled-close command destroys this WebView after starting
+      // bounded Core cleanup. Do not wait for an invoke response from a
+      // window that is intentionally being destroyed.
+      void bridge.shutdown();
     };
 
     const onSmokeEvent = () => {

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -46,6 +46,45 @@ export function App({ bridge }: AppProps) {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [settingsOpen, useStore]);
 
+  useEffect(() => {
+    let completed = false;
+    const runPackagedSmoke = async () => {
+      if (completed) return;
+      completed = true;
+      const waitForReady = async () => {
+        for (let attempt = 0; attempt < 300; attempt += 1) {
+          const state = useStore.getState();
+          if (state.bootstrapState === 'ready' && state.settings) return;
+          if (state.bootstrapState === 'fatal') {
+            throw new Error(state.fatal ?? 'packaged GUI bootstrap failed');
+          }
+          await new Promise((resolve) => window.setTimeout(resolve, 100));
+        }
+        throw new Error('packaged GUI bootstrap timed out');
+      };
+
+      await waitForReady();
+      const state = useStore.getState();
+      if (!document.querySelector('.app-shell')) {
+        throw new Error('packaged GUI shell did not render');
+      }
+      await state.search('');
+      await state.patchSettings({ theme: state.bootstrap?.theme ?? 'aurora' });
+      await state.setDiagnosticsEnabled(true);
+      await state.setDiagnosticsEnabled(false);
+      await bridge.shutdown();
+    };
+
+    const onSmokeEvent = () => {
+      void runPackagedSmoke();
+    };
+    window.addEventListener('sky-phase8-gui-smoke', onSmokeEvent);
+    if ((window as Window & { __SKY_PHASE8_GUI_SMOKE__?: boolean }).__SKY_PHASE8_GUI_SMOKE__) {
+      void runPackagedSmoke();
+    }
+    return () => window.removeEventListener('sky-phase8-gui-smoke', onSmokeEvent);
+  }, [bridge, useStore]);
+
   return (
     <BootstrapGate useStore={useStore}>
       {bootstrap && (

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import type { DesktopBridge } from '../bridge/DesktopBridge';
+import type { DesktopBridge, UiEvent } from '../bridge/DesktopBridge';
 import { BootstrapGate } from './BootstrapGate';
 import { LibraryPanel } from '../components/library/LibraryPanel';
 import { SettingsPanel } from '../components/settings/SettingsPanel';
@@ -62,16 +62,134 @@ export function App({ bridge }: AppProps) {
         }
         throw new Error('packaged GUI bootstrap timed out');
       };
+      const waitForStore = async (predicate: () => boolean, description: string): Promise<void> => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (predicate()) return;
+          await new Promise((resolve) => window.setTimeout(resolve, 50));
+        }
+        throw new Error(`packaged GUI ${description} state timed out`);
+      };
 
       await waitForReady();
       const state = useStore.getState();
       if (!document.querySelector('.app-shell')) {
         throw new Error('packaged GUI shell did not render');
       }
-      await state.search('');
-      await state.patchSettings({ theme: state.bootstrap?.theme ?? 'aurora' });
-      await state.setDiagnosticsEnabled(true);
-      await state.setDiagnosticsEnabled(false);
+      const generation = state.library.generation;
+      const search = await bridge.searchSongs({
+        query: '',
+        offset: 0,
+        limit: 200,
+        ...(generation > 0 ? { generation } : {}),
+      });
+      if (
+        !Number.isInteger(search.generation) ||
+        search.generation < 0 ||
+        !Number.isInteger(search.total) ||
+        search.total < 0 ||
+        !Array.isArray(search.items) ||
+        search.items.length > search.limit
+      ) {
+        throw new Error('packaged GUI search postcondition failed');
+      }
+      await waitForStore(() => {
+        const current = useStore.getState();
+        return !current.library.loading && current.library.error === null;
+      }, 'library');
+      const afterSearch = useStore.getState();
+      if (
+        afterSearch.bootstrapState !== 'ready' ||
+        afterSearch.library.loading ||
+        afterSearch.library.error !== null ||
+        afterSearch.fatal !== null
+      ) {
+        throw new Error('packaged GUI library store postcondition failed');
+      }
+      const expectedTheme = state.bootstrap?.theme ?? 'aurora';
+      const smokeTheme = expectedTheme === 'aurora' ? 'slate' : 'aurora';
+      const patched = await bridge.patchSettings({ theme: smokeTheme });
+      if (patched.theme !== smokeTheme) {
+        throw new Error('packaged GUI settings mutation postcondition failed');
+      }
+      const reread = await bridge.getSettings();
+      if (reread.theme !== smokeTheme) {
+        throw new Error('packaged GUI settings round-trip postcondition failed');
+      }
+      const restored = await bridge.patchSettings({ theme: expectedTheme });
+      if (restored.theme !== expectedTheme) {
+        throw new Error('packaged GUI settings restore postcondition failed');
+      }
+      const restoredRead = await bridge.getSettings();
+      if (restoredRead.theme !== expectedTheme) {
+        throw new Error('packaged GUI settings restore round-trip failed');
+      }
+      const afterSettings = useStore.getState();
+      if (afterSettings.settingsState !== 'ready' || afterSettings.fatal !== null) {
+        throw new Error('packaged GUI settings store postcondition failed');
+      }
+      const enabled = await bridge.setDiagnosticsEnabled({ enabled: true });
+      if (enabled.enabled !== true) {
+        throw new Error('packaged GUI diagnostics enable postcondition failed');
+      }
+      const disabled = await bridge.setDiagnosticsEnabled({ enabled: false });
+      if (disabled.enabled !== false) {
+        throw new Error('packaged GUI diagnostics disable postcondition failed');
+      }
+
+      let calibrationOperationId: string | null = null;
+      let calibrationFinished: Extract<UiEvent, { name: 'calibration.finished' }> | null = null;
+      const earlyCalibrationFinished: Extract<UiEvent, { name: 'calibration.finished' }>[] = [];
+      let resolveCalibration!: (event: Extract<UiEvent, { name: 'calibration.finished' }>) => void;
+      const calibrationDone = new Promise<Extract<UiEvent, { name: 'calibration.finished' }>>(
+        (resolve) => {
+          resolveCalibration = resolve;
+        },
+      );
+      const unsubscribe = await bridge.subscribeUiEvents((event) => {
+        if (
+          event.name === 'calibration.finished' &&
+          calibrationOperationId !== null &&
+          event.payload.operation_id === calibrationOperationId
+        ) {
+          resolveCalibration(event);
+        } else if (event.name === 'calibration.finished') {
+          earlyCalibrationFinished.push(event);
+        }
+      });
+      try {
+        const calibration = await bridge.startCalibration({
+          mode: 'quick',
+          className: null,
+          polyphony: null,
+          samples: null,
+          timeoutSeconds: null,
+        });
+        if (calibration.state !== 'running') {
+          throw new Error('packaged GUI calibration did not start');
+        }
+        calibrationOperationId = calibration.operation_id;
+        const early = earlyCalibrationFinished.find(
+          (event) => event.payload.operation_id === calibrationOperationId,
+        );
+        if (early) resolveCalibration(early);
+        calibrationFinished = await Promise.race([
+          calibrationDone,
+          new Promise<never>((_, reject) =>
+            window.setTimeout(
+              () => reject(new Error('packaged GUI calibration timed out')),
+              10_000,
+            ),
+          ),
+        ]);
+      } finally {
+        unsubscribe();
+      }
+      if (
+        !calibrationFinished ||
+        !['succeeded', 'cancelled'].includes(calibrationFinished.payload.outcome)
+      ) {
+        throw new Error('packaged GUI calibration terminal postcondition failed');
+      }
       // The controlled-close command destroys this WebView after starting
       // bounded Core cleanup. Do not wait for an invoke response from a
       // window that is intentionally being destroyed.
@@ -79,11 +197,21 @@ export function App({ bridge }: AppProps) {
     };
 
     const onSmokeEvent = () => {
-      void runPackagedSmoke();
+      void runPackagedSmoke().catch((error: unknown) => {
+        console.error('packaged GUI smoke failed', error);
+        void bridge.shutdown(true).catch((shutdownError: unknown) => {
+          console.error('packaged GUI failure shutdown failed', shutdownError);
+        });
+      });
     };
     window.addEventListener('sky-phase8-gui-smoke', onSmokeEvent);
     if ((window as Window & { __SKY_PHASE8_GUI_SMOKE__?: boolean }).__SKY_PHASE8_GUI_SMOKE__) {
-      void runPackagedSmoke();
+      void runPackagedSmoke().catch((error: unknown) => {
+        console.error('packaged GUI smoke failed', error);
+        void bridge.shutdown(true).catch((shutdownError: unknown) => {
+          console.error('packaged GUI failure shutdown failed', shutdownError);
+        });
+      });
     }
     return () => window.removeEventListener('sky-phase8-gui-smoke', onSmokeEvent);
   }, [bridge, useStore]);

--- a/desktop/src/bridge/DesktopBridge.ts
+++ b/desktop/src/bridge/DesktopBridge.ts
@@ -162,5 +162,5 @@ export interface DesktopBridge {
   startCalibration(request: CalibrationStart): Promise<CalibrationStartAck>;
   cancelCalibration(request: CalibrationCancel): Promise<CalibrationCancelAck>;
   subscribeUiEvents(listener: (event: UiEvent) => void): Promise<Unsubscribe>;
-  shutdown(): Promise<void>;
+  shutdown(failed?: boolean): Promise<void>;
 }

--- a/desktop/src/bridge/mockBridge.ts
+++ b/desktop/src/bridge/mockBridge.ts
@@ -526,7 +526,7 @@ export function createMockBridge(): DesktopBridge {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
-    async shutdown() {
+    async shutdown(_failed = false) {
       if (diagnosticsTimer !== null) clearInterval(diagnosticsTimer);
       if (calibrationTimer !== null) clearTimeout(calibrationTimer);
       diagnosticsTimer = null;

--- a/desktop/src/bridge/tauriBridge.ts
+++ b/desktop/src/bridge/tauriBridge.ts
@@ -85,7 +85,11 @@ export function createTauriBridge(): DesktopBridge {
         channel.onmessage = () => undefined;
       };
     },
-    shutdown: async () => {
+    shutdown: async (failed = false) => {
+      if (failed) {
+        await invoke('shutdown', { params: { failed: true } });
+        return;
+      }
       await invoke('shutdown');
     },
   };

--- a/docs/evidence/desktop-phase8/README.md
+++ b/docs/evidence/desktop-phase8/README.md
@@ -43,8 +43,9 @@ release check.
 
 Previous-stable qualification is `3.4.5 → 3.5.0` and exercises the native
 updater's ZIP/sidecar/manifest checks, staged verification, managed-file
-transition, preserved user paths, transaction installation, and interrupted
-transaction recovery against the actual Phase 8 ZIP. The feature-gated
+transition, preserved user paths, transaction installation, injected apply
+failure rollback, and interrupted transaction recovery against the actual
+Phase 8 ZIP. The feature-gated
 `sky_updater_e2e` runner supplies only the deterministic local-release
 transport used by the offline exact-artifact handoff/restart harness; the
 shipped `Sky-Auto-Player-Updater.exe` remains the default GitHub/HTTPS

--- a/docs/evidence/desktop-phase8/README.md
+++ b/docs/evidence/desktop-phase8/README.md
@@ -28,10 +28,13 @@ Sky-Auto-Player-v3.5.0/
 
 The package smoke is run from a temporary Windows path containing spaces. It
 uses no repository checkout, source `.venv`, Bun server, game process, or
-physical input. The Tauri self-test uses the production release launch
-command and `CoreSupervisor` to validate the packaged shell/Core pairing; it
-is intentionally headless so CI does not synthesize a physical playback
-session. Exact GUI visual acceptance remains a manual release check.
+physical input. The headless Tauri self-test uses the production release launch
+command and `CoreSupervisor` to validate the packaged shell/Core pairing. A
+second packaging-only smoke launches the real Wry window and lets the
+production React store exercise bootstrap, Library search, settings
+round-trip, and diagnostics enable/disable through the real Tauri bridge
+before the approved controlled shutdown path closes the window. Exact GUI
+visual acceptance remains a manual release check.
 
 Previous-stable qualification is `3.4.5 → 3.5.0` and exercises the native
 updater's ZIP/sidecar/manifest checks, staged verification, managed-file

--- a/docs/evidence/desktop-phase8/README.md
+++ b/docs/evidence/desktop-phase8/README.md
@@ -45,7 +45,9 @@ Previous-stable qualification is `3.4.5 → 3.5.0` and exercises the native
 updater's ZIP/sidecar/manifest checks, staged verification, managed-file
 transition, preserved user paths, transaction installation, injected apply
 failure rollback, and interrupted transaction recovery against the actual
-Phase 8 ZIP. The feature-gated
+Phase 8 ZIP. The exact-package harness also launches the shipped updater
+binary through its real READY and canonical-parent wait boundary before the
+offline transaction. The feature-gated
 `sky_updater_e2e` runner supplies only the deterministic local-release
 transport used by the offline exact-artifact handoff/restart harness; the
 shipped `Sky-Auto-Player-Updater.exe` remains the default GitHub/HTTPS

--- a/docs/evidence/desktop-phase8/README.md
+++ b/docs/evidence/desktop-phase8/README.md
@@ -6,8 +6,11 @@ the artifact by `scripts/build_phase8.py`:
 
 - `PROVENANCE.json` records the public repository head, pinned Python/Rust/Bun/
   Tauri/PyInstaller identities, exact ZIP hash, manifest hash, and file count.
+- `PHASE8_ARTIFACT_SUMMARY.json` repeats the final ZIP size/hash, MANIFEST hash,
+  portable file count, and managed-entry count for CI summaries and review.
 - `PHASE8_QUALIFICATION.json` records the Core self-test, packaged
-  Tauri/Core pairing smoke, packaged TUI smoke, and exact-artifact updater
+  Tauri/Core pairing smoke, the fail-closed Core self-test negative matrix,
+  packaged GUI smoke, packaged TUI smoke, and exact-artifact updater
   qualification.
 - `MANIFEST.json` is copied from the assembled tree and the ZIP contains that
   same embedded manifest. The `.sha256` sidecar hashes the exact ZIP bytes.
@@ -32,12 +35,25 @@ physical input. The headless Tauri self-test uses the production release launch
 command and `CoreSupervisor` to validate the packaged shell/Core pairing. A
 second packaging-only smoke launches the real Wry window and lets the
 production React store exercise bootstrap, Library search, settings
-round-trip, and diagnostics enable/disable through the real Tauri bridge
-before the approved controlled shutdown path closes the window. Exact GUI
-visual acceptance remains a manual release check.
+round-trip, diagnostics enable/disable, and the explicit no-input calibration
+seam through the real Tauri bridge before the approved controlled shutdown
+path closes the window. GUI smoke assertions are fail-closed and invalid child
+output is captured as bytes. Exact GUI visual acceptance remains a manual
+release check.
 
 Previous-stable qualification is `3.4.5 → 3.5.0` and exercises the native
 updater's ZIP/sidecar/manifest checks, staged verification, managed-file
-transition, preserved user paths, and transaction installation against the
-actual Phase 8 ZIP. The established updater corpus and fault/rollback tests
-remain separate required gates.
+transition, preserved user paths, transaction installation, and interrupted
+transaction recovery against the actual Phase 8 ZIP. The feature-gated
+`sky_updater_e2e` runner supplies only the deterministic local-release
+transport used by the offline exact-artifact handoff/restart harness; the
+shipped `Sky-Auto-Player-Updater.exe` remains the default GitHub/HTTPS
+production binary and is independently identity-checked from the assembled
+artifact. The established updater corpus and fault-injection tests remain
+separate required gates.
+
+The offline harness cannot claim a public GitHub release transaction without
+publishing a release or introducing a local HTTP/socket source. It therefore
+records the production updater identity check separately from the exact ZIP
+transaction/restart qualification rather than weakening the production
+source/trust policy.

--- a/docs/evidence/desktop-phase8/README.md
+++ b/docs/evidence/desktop-phase8/README.md
@@ -1,0 +1,40 @@
+# Phase 8 packaging evidence
+
+Phase 8 produces one unsigned portable release candidate from the exact
+checked-out commit. The authoritative generated evidence is emitted beside
+the artifact by `scripts/build_phase8.py`:
+
+- `PROVENANCE.json` records the public repository head, pinned Python/Rust/Bun/
+  Tauri/PyInstaller identities, exact ZIP hash, manifest hash, and file count.
+- `PHASE8_QUALIFICATION.json` records the Core self-test, packaged
+  Tauri/Core pairing smoke, packaged TUI smoke, and exact-artifact updater
+  qualification.
+- `MANIFEST.json` is copied from the assembled tree and the ZIP contains that
+  same embedded manifest. The `.sha256` sidecar hashes the exact ZIP bytes.
+
+The CI packaged job uploads the exact output directory without rebuilding the
+ZIP after qualification. The release tree is:
+
+```text
+Sky-Auto-Player-v3.5.0/
+├── Sky-Auto-Player.exe
+├── Sky-Auto-Player-Core.exe
+├── Sky-Auto-Player-Updater.exe
+├── native_calibration.exe
+├── MANIFEST.json
+├── _internal/
+└── songs/
+```
+
+The package smoke is run from a temporary Windows path containing spaces. It
+uses no repository checkout, source `.venv`, Bun server, game process, or
+physical input. The Tauri self-test uses the production release launch
+command and `CoreSupervisor` to validate the packaged shell/Core pairing; it
+is intentionally headless so CI does not synthesize a physical playback
+session. Exact GUI visual acceptance remains a manual release check.
+
+Previous-stable qualification is `3.4.5 → 3.5.0` and exercises the native
+updater's ZIP/sidecar/manifest checks, staged verification, managed-file
+transition, preserved user paths, and transaction installation against the
+actual Phase 8 ZIP. The established updater corpus and fault/rollback tests
+remain separate required gates.

--- a/play.bat
+++ b/play.bat
@@ -1,4 +1,9 @@
 @echo off
+set "PACKAGED_CORE=%~dp0Sky-Auto-Player-Core.exe"
+if exist "%PACKAGED_CORE%" (
+    "%PACKAGED_CORE%" --tui %*
+    exit /b %ERRORLEVEL%
+)
 where uv >nul 2>nul
 if %ERRORLEVEL% equ 0 (
     uv run python src/main.py %*

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -18,7 +18,7 @@ use sky_updater::install::{install_verified, read_staged_manifest};
 use sky_updater::local_source::LocalReleaseSource;
 use sky_updater::manifest::{Manifest, ManifestFile};
 use sky_updater::progress::NoopProgressSink;
-use sky_updater::recovery::{has_unresolved_transaction, recover_before_update};
+use sky_updater::recovery::{has_unresolved_transaction, recover_before_update, rollback_prepared};
 use sky_updater::transaction::verify_installed_managed;
 use sky_updater::transaction::{build_plan, prepare_journal};
 use sky_updater::{
@@ -308,9 +308,15 @@ fn exact_phase8_artifact_interrupted_transaction_recovers_and_preserves_user_sta
     assert!(has_unresolved_transaction(&install));
 
     // Simulate an interrupted apply after target files were written but before
-    // the transaction could commit. Recovery must use the verified journal,
-    // not process teardown, to restore the previous stable installation.
-    extract_zip_file(&zip, &install)?;
+    // the transaction could commit. Copy only manifest-owned files here: the
+    // real transaction never replaces preserved user state such as
+    // config.json, songs/, or logs/.
+    for file in &target.files {
+        let source = staging.join(&file.path);
+        let destination = install.join(&file.path);
+        fs::create_dir_all(destination.parent().expect("managed file parent"))?;
+        fs::copy(source, destination)?;
+    }
     recover_before_update(&install)?;
 
     assert!(!has_unresolved_transaction(&install));
@@ -330,6 +336,66 @@ fn exact_phase8_artifact_interrupted_transaction_recovers_and_preserves_user_sta
     Ok(())
 }
 
+#[cfg(feature = "e2e-fault-injection")]
+#[test]
+fn exact_phase8_artifact_injected_apply_failure_rolls_back_and_preserves_user_state() -> Result<()>
+{
+    let artifact_dir = match std::env::var_os("SKY_PHASE8_ARTIFACT_DIR") {
+        Some(value) => PathBuf::from(value),
+        None => return Ok(()),
+    };
+    let zip = artifact_dir.join(format!("Sky-Auto-Player-v{TARGET_VERSION}.zip"));
+    assert!(zip.is_file(), "exact ZIP missing");
+
+    let install = temp_root("exact-fault-install");
+    fs::create_dir_all(&install).expect("install");
+    let previous = old_manifest();
+    for file in &previous.files {
+        write_file(&install, &file.path, old_file_bytes(&file.path));
+    }
+    write_manifest(&install, &previous);
+    write_file(&install, "config.json", br#"{"theme":"aurora"}"#);
+    write_file(&install, ".env", b"USER_SECRET=preserve");
+    write_file(&install, "songs/user.skysheet", b"user song");
+    write_file(&install, "logs/user.log", b"user log");
+
+    let staging = temp_root("exact-fault-staging");
+    fs::create_dir_all(&staging).expect("staging");
+    extract_zip_file(&zip, &staging)?;
+    let target = read_staged_manifest(&staging, TARGET_VERSION)?;
+
+    sky_updater::faults::configure(
+        Some("apply:after-replace:Sky-Auto-Player-Updater.exe"),
+        None,
+        None,
+    )
+    .expect("fault config");
+    let error = install_verified(&install, &staging, &target, &previous, &NoopProgressSink)
+        .expect_err("exact artifact apply fault");
+    assert!(matches!(
+        error,
+        sky_updater::error::UpdaterError::InstallCopyFailed(_)
+    ));
+    assert!(has_unresolved_transaction(&install));
+
+    sky_updater::faults::configure(None, None, None).expect("clear fault");
+    rollback_prepared(&install)?;
+    for file in &previous.files {
+        assert_eq!(
+            fs::read(install.join(&file.path)).expect("restored managed file"),
+            old_file_bytes(&file.path),
+            "restored {}",
+            file.path
+        );
+    }
+    assert_preserved(&install);
+    assert!(!has_unresolved_transaction(&install));
+
+    let _ = fs::remove_dir_all(&staging);
+    let _ = fs::remove_dir_all(&install);
+    Ok(())
+}
+
 #[test]
 fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
     let artifact_dir = match std::env::var_os("SKY_PHASE8_ARTIFACT_DIR") {
@@ -340,8 +406,9 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
         Some(value) => PathBuf::from(value),
         None => panic!("exact package updater qualification runner is missing"),
     };
-    let actual_updater = artifact_dir.join(UPDATER_EXE);
-    let primary = artifact_dir.join(PRIMARY_EXE);
+    let release_dir = artifact_dir.join(format!("Sky-Auto-Player-v{TARGET_VERSION}"));
+    let actual_updater = release_dir.join(UPDATER_EXE);
+    let primary = release_dir.join(PRIMARY_EXE);
     assert!(actual_updater.is_file(), "packaged updater is missing");
     assert!(primary.is_file(), "packaged Tauri executable is missing");
     let version = Command::new(&actual_updater).arg("--version").output()?;

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -1,0 +1,186 @@
+//! Exact Phase 8 artifact qualification.
+//!
+//! The normal updater tests use small synthetic payloads.  When
+//! `SKY_PHASE8_ARTIFACT_DIR` is supplied, this test consumes the exact ZIP,
+//! sidecar, external manifest, and embedded manifest emitted by the Phase 8
+//! assembler, then runs the real install/rollback transaction against a
+//! 3.4.5-style install.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use sky_updater::archive::{extract_zip_file, sha256_bytes, sha256_file};
+use sky_updater::error::Result;
+use sky_updater::github::ReleaseSource;
+use sky_updater::install::{install_verified, read_staged_manifest};
+use sky_updater::local_source::LocalReleaseSource;
+use sky_updater::manifest::{Manifest, ManifestFile};
+use sky_updater::progress::NoopProgressSink;
+use sky_updater::transaction::verify_installed_managed;
+use sky_updater::{
+    APP_NAME, CALIBRATION_EXE, MANIFEST_NAME, PRIMARY_EXE, SCHEMA_VERSION, UPDATER_EXE,
+};
+
+const PREVIOUS_VERSION: &str = "3.4.5";
+const TARGET_VERSION: &str = "3.5.0";
+
+fn temp_root(label: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "sky-phase8-{label}-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos()
+    ))
+}
+
+fn write_file(root: &Path, relative: &str, bytes: &[u8]) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().expect("file parent")).expect("parent");
+    fs::write(path, bytes).expect("fixture file");
+}
+
+fn write_manifest(root: &Path, manifest: &Manifest) {
+    write_file(
+        root,
+        MANIFEST_NAME,
+        &serde_json::to_vec_pretty(manifest).expect("manifest JSON"),
+    );
+}
+
+fn old_manifest() -> Manifest {
+    let files = [
+        (PRIMARY_EXE, b"previous Tauri replacement".as_slice()),
+        (UPDATER_EXE, b"previous updater".as_slice()),
+        (CALIBRATION_EXE, b"previous calibration".as_slice()),
+        ("Sky-Player.exe", b"obsolete v3 identity".as_slice()),
+    ];
+    Manifest {
+        schema_version: SCHEMA_VERSION,
+        app: APP_NAME.into(),
+        version: PREVIOUS_VERSION.into(),
+        executable: PRIMARY_EXE.into(),
+        git_head: "a".repeat(40),
+        dirty_worktree: false,
+        native_build_commit: "b".repeat(40),
+        build_time_utc: "2026-08-30T00:00:00Z".into(),
+        files: files
+            .into_iter()
+            .map(|(path, bytes)| ManifestFile {
+                path: path.into(),
+                size: bytes.len() as u64,
+                sha256: sha256_bytes(bytes),
+            })
+            .collect(),
+    }
+}
+
+fn old_file_bytes(path: &str) -> &'static [u8] {
+    match path {
+        PRIMARY_EXE => b"previous Tauri replacement",
+        UPDATER_EXE => b"previous updater",
+        CALIBRATION_EXE => b"previous calibration",
+        "Sky-Player.exe" => b"obsolete v3 identity",
+        _ => unreachable!("unknown previous fixture path"),
+    }
+}
+
+fn assert_preserved(install: &Path) {
+    assert_eq!(
+        fs::read(install.join("config.json")).expect("config"),
+        br#"{"theme":"aurora"}"#
+    );
+    assert_eq!(
+        fs::read(install.join(".env")).expect("env"),
+        b"USER_SECRET=preserve"
+    );
+    assert_eq!(
+        fs::read(install.join("songs/user.skysheet")).expect("song"),
+        b"user song"
+    );
+    assert_eq!(
+        fs::read(install.join("logs/user.log")).expect("log"),
+        b"user log"
+    );
+}
+
+#[test]
+fn exact_phase8_artifact_updates_previous_stable_and_preserves_user_state() -> Result<()> {
+    let artifact_dir = match std::env::var_os("SKY_PHASE8_ARTIFACT_DIR") {
+        Some(value) => PathBuf::from(value),
+        None => {
+            eprintln!("SKY_PHASE8_ARTIFACT_DIR is not set; exact artifact qualification skipped");
+            return Ok(());
+        }
+    };
+    let zip = artifact_dir.join(format!("Sky-Auto-Player-v{TARGET_VERSION}.zip"));
+    let sidecar = artifact_dir.join(format!("Sky-Auto-Player-v{TARGET_VERSION}.zip.sha256"));
+    let external_manifest = artifact_dir.join(MANIFEST_NAME);
+    assert!(zip.is_file(), "exact ZIP missing");
+    assert!(sidecar.is_file(), "exact ZIP sidecar missing");
+    assert!(
+        external_manifest.is_file(),
+        "exact external manifest missing"
+    );
+    let sidecar_text = fs::read_to_string(&sidecar).expect("sidecar");
+    let actual_hash = sha256_file(&zip)?;
+    assert!(sidecar_text.starts_with(&actual_hash));
+
+    let source = LocalReleaseSource::new(&artifact_dir).expect("local exact release source");
+    let download_root = temp_root("download");
+    fs::create_dir_all(&download_root).expect("download root");
+    let downloaded = download_root.join("downloaded.zip");
+    let payload = source.fetch_exact_release(
+        TARGET_VERSION,
+        sky_updater::cli::Channel::Stable,
+        &downloaded,
+    )?;
+    assert_eq!(payload.zip_sha256, actual_hash);
+
+    let staging = temp_root("staging");
+    fs::create_dir_all(&staging).expect("staging");
+    extract_zip_file(&downloaded, &staging)?;
+    let staged = read_staged_manifest(&staging, TARGET_VERSION)?;
+    assert_eq!(
+        staged, payload.manifest,
+        "embedded/external manifests differ"
+    );
+    assert_eq!(staged.executable, PRIMARY_EXE);
+    assert!(
+        staged
+            .files
+            .iter()
+            .any(|file| file.path == "Sky-Auto-Player-Core.exe")
+    );
+
+    let install = temp_root("install with spaces");
+    fs::create_dir_all(&install).expect("install");
+    let previous = old_manifest();
+    for file in &previous.files {
+        write_file(&install, &file.path, old_file_bytes(&file.path));
+    }
+    write_manifest(&install, &previous);
+    write_file(&install, "config.json", br#"{"theme":"aurora"}"#);
+    write_file(&install, ".env", b"USER_SECRET=preserve");
+    write_file(&install, "songs/user.skysheet", b"user song");
+    write_file(&install, "logs/user.log", b"user log");
+
+    install_verified(&install, &staging, &staged, &previous, &NoopProgressSink)?;
+    verify_installed_managed(&install, &staged)?;
+    assert_preserved(&install);
+    assert!(
+        !install.join("Sky-Player.exe").exists(),
+        "obsolete managed identity removed"
+    );
+    assert_eq!(
+        Manifest::parse(&fs::read(install.join(MANIFEST_NAME)).expect("installed manifest"))?,
+        staged
+    );
+
+    fs::remove_dir_all(download_root).expect("download cleanup");
+    fs::remove_dir_all(staging).expect("staging cleanup");
+    fs::remove_dir_all(install).expect("install cleanup");
+    Ok(())
+}

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -375,7 +375,7 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
     write_file(&install, "logs/user.log", b"user log");
 
     let restart_marker = temp_root("restart-marker");
-    let mut parent = Command::new(&install.join(PRIMARY_EXE));
+    let mut parent = Command::new(install.join(PRIMARY_EXE));
     parent
         .arg("--selftest-desktop-parent")
         .current_dir(&install)

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -16,7 +16,7 @@ use sky_updater::error::Result;
 use sky_updater::github::ReleaseSource;
 use sky_updater::install::{install_verified, read_staged_manifest};
 use sky_updater::local_source::LocalReleaseSource;
-use sky_updater::manifest::{Manifest, ManifestFile};
+use sky_updater::manifest::{Manifest, ManifestFile, PreserveClass, classify_preserved};
 use sky_updater::progress::NoopProgressSink;
 use sky_updater::recovery::{has_unresolved_transaction, recover_before_update, rollback_prepared};
 use sky_updater::transaction::verify_installed_managed;
@@ -312,6 +312,9 @@ fn exact_phase8_artifact_interrupted_transaction_recovers_and_preserves_user_sta
     // real transaction never replaces preserved user state such as
     // config.json, songs/, or logs/.
     for file in &target.files {
+        if classify_preserved(&file.path) == PreserveClass::Preserved {
+            continue;
+        }
         let source = staging.join(&file.path);
         let destination = install.join(&file.path);
         fs::create_dir_all(destination.parent().expect("managed file parent"))?;
@@ -421,6 +424,8 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
     let local_app_data = temp_root("localappdata");
     let _local_app_data = EnvGuard::set("LOCALAPPDATA", &local_app_data);
     fs::create_dir_all(&local_app_data).expect("local app data");
+    let update_runs = local_app_data.join(APP_NAME).join("update-runs");
+    fs::create_dir_all(&update_runs).expect("update runs");
     let install = temp_root("exact-install-with-spaces");
     fs::create_dir_all(&install).expect("install");
     extract_zip_file(&zip, &install)?;
@@ -449,7 +454,11 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
         .env("SKY_PHASE8_RESTART_MARKER", &restart_marker);
     no_window(&mut parent);
     let mut parent = ChildGuard(parent.spawn()?);
-    let mut updater = Command::new(&e2e_updater);
+    let e2e_run_root = update_runs.join("run-0123456789abcdef0123456789abcdef");
+    fs::create_dir_all(&e2e_run_root).expect("E2E updater run root");
+    let e2e_updater_canonical = e2e_run_root.join(UPDATER_EXE);
+    fs::copy(&e2e_updater, &e2e_updater_canonical).expect("canonical E2E updater copy");
+    let mut updater = Command::new(&e2e_updater_canonical);
     updater
         .arg("--release-dir")
         .arg(&artifact_dir)

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -464,6 +464,34 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
         .env("SKY_PHASE8_RESTART_MARKER", &restart_marker);
     no_window(&mut parent);
     let mut parent = ChildGuard(parent.spawn()?);
+
+    // Exercise the shipped updater binary through its real READY/parent-wait
+    // boundary before the offline transaction runner performs the exact
+    // artifact install. The production binary intentionally remains
+    // GitHub/HTTPS-only; the feature-gated runner below is the only local
+    // transport used for the deterministic offline transaction.
+    let packaged_run_root = update_runs.join("run-abcdef0123456789abcdef0123456789");
+    fs::create_dir_all(&packaged_run_root).expect("packaged updater run root");
+    let packaged_updater = packaged_run_root.join(UPDATER_EXE);
+    fs::copy(&actual_updater, &packaged_updater).expect("packaged updater qualification copy");
+    let mut packaged = Command::new(&packaged_updater);
+    packaged
+        .arg("--install-root")
+        .arg(&install)
+        .arg("--parent-pid")
+        .arg(parent.id().to_string())
+        .arg("--current-version")
+        .arg(PREVIOUS_VERSION)
+        .arg("--target-version")
+        .arg(TARGET_VERSION)
+        .arg("--channel")
+        .arg("stable")
+        .current_dir(&install);
+    no_window(&mut packaged);
+    let mut packaged = ChildGuard(packaged.spawn()?);
+    let _packaged_run_root = wait_for_ready_handoff(&local_app_data, packaged.id());
+    packaged.stop();
+
     let e2e_run_root = update_runs.join("run-0123456789abcdef0123456789abcdef");
     fs::create_dir_all(&e2e_run_root).expect("E2E updater run root");
     let e2e_updater_canonical = e2e_run_root.join(UPDATER_EXE);

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -8,6 +8,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use sky_updater::archive::{extract_zip_file, sha256_bytes, sha256_file};
@@ -17,13 +18,39 @@ use sky_updater::install::{install_verified, read_staged_manifest};
 use sky_updater::local_source::LocalReleaseSource;
 use sky_updater::manifest::{Manifest, ManifestFile};
 use sky_updater::progress::NoopProgressSink;
+use sky_updater::recovery::{has_unresolved_transaction, recover_before_update};
 use sky_updater::transaction::verify_installed_managed;
+use sky_updater::transaction::{build_plan, prepare_journal};
 use sky_updater::{
     APP_NAME, CALIBRATION_EXE, MANIFEST_NAME, PRIMARY_EXE, SCHEMA_VERSION, UPDATER_EXE,
 };
 
 const PREVIOUS_VERSION: &str = "3.4.5";
 const TARGET_VERSION: &str = "3.5.0";
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &Path) -> Self {
+        let previous = std::env::var_os(key);
+        // These integration tests run single-threaded because the updater
+        // contract deliberately uses process-wide LOCALAPPDATA state.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => unsafe { std::env::set_var(self.key, value) },
+            None => unsafe { std::env::remove_var(self.key) },
+        }
+    }
+}
 
 fn temp_root(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
@@ -106,6 +133,72 @@ fn assert_preserved(install: &Path) {
     );
 }
 
+fn stop_child(child: &mut Child) {
+    if child.try_wait().expect("child status").is_none() {
+        let _ = child.kill();
+    }
+    let _ = child.wait();
+}
+
+struct ChildGuard(Child);
+
+impl ChildGuard {
+    fn id(&self) -> u32 {
+        self.0.id()
+    }
+
+    fn stop(&mut self) {
+        stop_child(&mut self.0);
+    }
+
+    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        self.0.wait()
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        stop_child(&mut self.0);
+    }
+}
+
+fn wait_for_ready_handoff(local_app_data: &Path, updater_pid: u32) -> PathBuf {
+    let runs = local_app_data
+        .join(APP_NAME)
+        .join("update-state")
+        .join("update-runs");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    while std::time::Instant::now() < deadline {
+        if let Ok(entries) = fs::read_dir(&runs) {
+            for entry in entries.flatten() {
+                let handoff = entry.path().join("handoff.json");
+                let Ok(bytes) = fs::read(&handoff) else {
+                    continue;
+                };
+                let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+                    continue;
+                };
+                if value.get("state").and_then(|v| v.as_str()) == Some("ready")
+                    && value.get("updater_pid").and_then(|v| v.as_u64()) == Some(updater_pid as u64)
+                {
+                    return entry.path();
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!("native updater did not publish READY within the bounded handoff budget");
+}
+
+#[cfg(windows)]
+fn no_window(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    command.creation_flags(0x0800_0000);
+}
+
+#[cfg(not(windows))]
+fn no_window(_command: &mut Command) {}
+
 #[test]
 fn exact_phase8_artifact_updates_previous_stable_and_preserves_user_state() -> Result<()> {
     let artifact_dir = match std::env::var_os("SKY_PHASE8_ARTIFACT_DIR") {
@@ -182,5 +275,161 @@ fn exact_phase8_artifact_updates_previous_stable_and_preserves_user_state() -> R
     fs::remove_dir_all(download_root).expect("download cleanup");
     fs::remove_dir_all(staging).expect("staging cleanup");
     fs::remove_dir_all(install).expect("install cleanup");
+    Ok(())
+}
+
+#[test]
+fn exact_phase8_artifact_interrupted_transaction_recovers_and_preserves_user_state() -> Result<()> {
+    let artifact_dir = match std::env::var_os("SKY_PHASE8_ARTIFACT_DIR") {
+        Some(value) => PathBuf::from(value),
+        None => return Ok(()),
+    };
+    let zip = artifact_dir.join(format!("Sky-Auto-Player-v{TARGET_VERSION}.zip"));
+    assert!(zip.is_file(), "exact ZIP missing");
+
+    let install = temp_root("exact-recovery-install");
+    fs::create_dir_all(&install).expect("install");
+    let previous = old_manifest();
+    for file in &previous.files {
+        write_file(&install, &file.path, old_file_bytes(&file.path));
+    }
+    write_manifest(&install, &previous);
+    write_file(&install, "config.json", br#"{"theme":"aurora"}"#);
+    write_file(&install, ".env", b"USER_SECRET=preserve");
+    write_file(&install, "songs/user.skysheet", b"user song");
+    write_file(&install, "logs/user.log", b"user log");
+
+    let staging = temp_root("exact-recovery-staging");
+    fs::create_dir_all(&staging).expect("staging");
+    extract_zip_file(&zip, &staging)?;
+    let target = read_staged_manifest(&staging, TARGET_VERSION)?;
+    let plan = build_plan(Some(&previous), &target)?;
+    prepare_journal(&install, &plan, &NoopProgressSink)?;
+    assert!(has_unresolved_transaction(&install));
+
+    // Simulate an interrupted apply after target files were written but before
+    // the transaction could commit. Recovery must use the verified journal,
+    // not process teardown, to restore the previous stable installation.
+    extract_zip_file(&zip, &install)?;
+    recover_before_update(&install)?;
+
+    assert!(!has_unresolved_transaction(&install));
+    for file in &previous.files {
+        assert_eq!(
+            fs::read(install.join(&file.path)).expect("restored managed file"),
+            old_file_bytes(&file.path),
+            "restored {}",
+            file.path
+        );
+    }
+    assert_preserved(&install);
+    assert!(!install.join("Sky-Auto-Player-Core.exe").exists());
+
+    let _ = fs::remove_dir_all(&staging);
+    let _ = fs::remove_dir_all(&install);
+    Ok(())
+}
+
+#[test]
+fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
+    let artifact_dir = match std::env::var_os("SKY_PHASE8_ARTIFACT_DIR") {
+        Some(value) => PathBuf::from(value),
+        None => return Ok(()),
+    };
+    let e2e_updater = match std::env::var_os("SKY_PHASE8_E2E_UPDATER") {
+        Some(value) => PathBuf::from(value),
+        None => panic!("exact package updater qualification runner is missing"),
+    };
+    let actual_updater = artifact_dir.join(UPDATER_EXE);
+    let primary = artifact_dir.join(PRIMARY_EXE);
+    assert!(actual_updater.is_file(), "packaged updater is missing");
+    assert!(primary.is_file(), "packaged Tauri executable is missing");
+    let version = Command::new(&actual_updater).arg("--version").output()?;
+    assert!(
+        version.status.success(),
+        "packaged updater --version failed"
+    );
+
+    let zip = artifact_dir.join(format!("Sky-Auto-Player-v{TARGET_VERSION}.zip"));
+    let local_app_data = temp_root("localappdata");
+    let _local_app_data = EnvGuard::set("LOCALAPPDATA", &local_app_data);
+    fs::create_dir_all(&local_app_data).expect("local app data");
+    let install = temp_root("exact-install-with-spaces");
+    fs::create_dir_all(&install).expect("install");
+    extract_zip_file(&zip, &install)?;
+    let target = read_staged_manifest(&install, TARGET_VERSION)?;
+    let mut previous = target.clone();
+    previous.version = PREVIOUS_VERSION.into();
+    previous.git_head = "a".repeat(40);
+    previous.native_build_commit = "b".repeat(40);
+    previous.files.push(ManifestFile {
+        path: "Sky-Player.exe".into(),
+        size: b"obsolete v3 identity".len() as u64,
+        sha256: sha256_bytes(b"obsolete v3 identity"),
+    });
+    write_file(&install, "Sky-Player.exe", b"obsolete v3 identity");
+    write_manifest(&install, &previous);
+    write_file(&install, "config.json", br#"{"theme":"aurora"}"#);
+    write_file(&install, ".env", b"USER_SECRET=preserve");
+    write_file(&install, "songs/user.skysheet", b"user song");
+    write_file(&install, "logs/user.log", b"user log");
+
+    let restart_marker = temp_root("restart-marker");
+    let mut parent = Command::new(&install.join(PRIMARY_EXE));
+    parent
+        .arg("--selftest-desktop-parent")
+        .current_dir(&install)
+        .env("SKY_PHASE8_RESTART_MARKER", &restart_marker);
+    no_window(&mut parent);
+    let mut parent = ChildGuard(parent.spawn()?);
+    let mut updater = Command::new(&e2e_updater);
+    updater
+        .arg("--release-dir")
+        .arg(&artifact_dir)
+        .arg("--install-root")
+        .arg(&install)
+        .arg("--parent-pid")
+        .arg(parent.id().to_string())
+        .arg("--current-version")
+        .arg(PREVIOUS_VERSION)
+        .arg("--target-version")
+        .arg(TARGET_VERSION)
+        .arg("--channel")
+        .arg("stable")
+        .arg("--restart")
+        .current_dir(&install)
+        .env("SKY_PHASE8_RESTART_SELFTEST", "1")
+        .env("SKY_PHASE8_RESTART_MARKER", &restart_marker);
+    no_window(&mut updater);
+    let mut updater = ChildGuard(updater.spawn()?);
+    let _run_root = wait_for_ready_handoff(&local_app_data, updater.id());
+    parent.stop();
+    let status = updater.wait()?;
+    assert!(
+        status.success(),
+        "local-source native updater failed: {status}"
+    );
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    while !restart_marker.is_file() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        restart_marker.is_file(),
+        "canonical Tauri restart did not bootstrap the new Core"
+    );
+    verify_installed_managed(&install, &target)?;
+    assert_preserved(&install);
+    assert!(!install.join("Sky-Player.exe").exists());
+    assert!(
+        !local_app_data
+            .join(APP_NAME)
+            .join("update-state")
+            .join("active-update.json")
+            .exists()
+    );
+
+    let _ = fs::remove_dir_all(&install);
+    let _ = fs::remove_dir_all(&local_app_data);
+    let _ = fs::remove_file(&restart_marker);
     Ok(())
 }

--- a/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
+++ b/rust/crates/sky_updater/tests/phase8_exact_artifact.rs
@@ -115,9 +115,13 @@ fn old_file_bytes(path: &str) -> &'static [u8] {
 }
 
 fn assert_preserved(install: &Path) {
+    assert_preserved_config(install, br#"{"theme":"aurora"}"#);
+}
+
+fn assert_preserved_config(install: &Path, expected_config: &[u8]) {
     assert_eq!(
         fs::read(install.join("config.json")).expect("config"),
-        br#"{"theme":"aurora"}"#
+        expected_config
     );
     assert_eq!(
         fs::read(install.join(".env")).expect("env"),
@@ -163,10 +167,7 @@ impl Drop for ChildGuard {
 }
 
 fn wait_for_ready_handoff(local_app_data: &Path, updater_pid: u32) -> PathBuf {
-    let runs = local_app_data
-        .join(APP_NAME)
-        .join("update-state")
-        .join("update-runs");
+    let runs = local_app_data.join(APP_NAME).join("update-runs");
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
     while std::time::Instant::now() < deadline {
         if let Ok(entries) = fs::read_dir(&runs) {
@@ -430,6 +431,16 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
     fs::create_dir_all(&install).expect("install");
     extract_zip_file(&zip, &install)?;
     let target = read_staged_manifest(&install, TARGET_VERSION)?;
+    let packaged_config = fs::read(install.join("config.json")).expect("packaged config");
+    let user_config = String::from_utf8(packaged_config)
+        .expect("packaged config UTF-8")
+        .replace(r#""theme": "aurora""#, r#""theme": "classic""#)
+        .into_bytes();
+    assert_ne!(
+        user_config,
+        fs::read(install.join("config.json")).expect("packaged config")
+    );
+    write_file(&install, "config.json", &user_config);
     let mut previous = target.clone();
     previous.version = PREVIOUS_VERSION.into();
     previous.git_head = "a".repeat(40);
@@ -441,7 +452,6 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
     });
     write_file(&install, "Sky-Player.exe", b"obsolete v3 identity");
     write_manifest(&install, &previous);
-    write_file(&install, "config.json", br#"{"theme":"aurora"}"#);
     write_file(&install, ".env", b"USER_SECRET=preserve");
     write_file(&install, "songs/user.skysheet", b"user song");
     write_file(&install, "logs/user.log", b"user log");
@@ -494,7 +504,7 @@ fn exact_packaged_updater_handoff_transaction_and_restart() -> Result<()> {
         "canonical Tauri restart did not bootstrap the new Core"
     );
     verify_installed_managed(&install, &target)?;
-    assert_preserved(&install);
+    assert_preserved_config(&install, &user_config);
     assert!(!install.join("Sky-Player.exe").exists());
     assert!(
         !local_app_data

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -17,9 +17,9 @@ import subprocess
 import sys
 import tempfile
 import zipfile
-from datetime import UTC, datetime
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Iterator, Sequence
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -123,7 +123,7 @@ def _assert_no_path_escape(root: Path) -> None:
         try:
             path.resolve().relative_to(root)
         except ValueError:
-            raise RuntimeError(f"release path escapes root: {relative}")
+            raise RuntimeError(f"release path escapes root: {relative}") from None
         folded = relative.casefold()
         previous = seen.setdefault(folded, relative)
         if previous != relative:

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -264,15 +264,21 @@ def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
 
 
 def _run_tauri_gui_smoke(primary_exe: Path, *, cwd: Path) -> None:
-    result = subprocess.run(
-        [str(primary_exe), "--selftest-desktop-gui"],
-        cwd=str(cwd),
-        capture_output=True,
-        text=True,
-        timeout=90,
-        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            [str(primary_exe), "--selftest-desktop-gui"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(
+            "packaged Tauri GUI smoke timed out; "
+            f"stdout={error.stdout!r} stderr={error.stderr!r}"
+        ) from error
     if result.returncode != 0:
         raise RuntimeError(
             f"packaged Tauri GUI smoke failed ({result.returncode}): "

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -562,6 +562,7 @@ def run_pipeline(output_root: Path) -> Path:
                 "tauri_gui_smoke": "passed",
                 "tui_smoke": "passed",
                 "packaged_updater_identity_smoke": "passed",
+                "packaged_updater_ready_parent_smoke": "passed",
                 "exact_artifact_transaction_restart": "qualified_with_local_source_runner",
                 "production_updater_network_transaction": (
                     "not_run_without_public_release_or_local_http_source"

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -1,0 +1,441 @@
+"""Build and qualify the exact v4 portable Windows release candidate.
+
+This is the Phase 8 release entry point.  It reuses the native build and
+manifest helpers from ``src/build_app.py`` but assembles the Tauri shell and
+the single Core runtime into the canonical portable layout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import build_app  # noqa: E402
+
+APP_NAME = "Sky-Auto-Player"
+VERSION = build_app.get_project_version()
+CORE_EXE = "Sky-Auto-Player-Core.exe"
+PRIMARY_EXE = "Sky-Auto-Player.exe"
+UPDATER_EXE = "Sky-Auto-Player-Updater.exe"
+CALIBRATION_EXE = "native_calibration.exe"
+RELEASE_NAME = f"{APP_NAME}-v{VERSION}"
+ZIP_NAME = f"{RELEASE_NAME}.zip"
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run(command: Sequence[str], *, cwd: Path = ROOT, env: dict[str, str] | None = None) -> None:
+    print(f"[phase8] {' '.join(str(item) for item in command)}", flush=True)
+    subprocess.run(list(command), cwd=str(cwd), env=env, check=True)
+
+
+def _capture(command: Sequence[str], *, cwd: Path = ROOT) -> str:
+    result = subprocess.run(
+        list(command), cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def _default_config() -> dict[str, Any]:
+    return {
+        "schema_version": 3,
+        "theme": "aurora",
+        "ui_background_mode": "transparent",
+        "default_hold_frames": 1.0,
+        "default_tempo_scale": 1.0,
+        "game_fps": 60,
+        "telemetry_enabled_by_default": False,
+        "verbose_hud": False,
+        "hotkeys": {
+            "pause": "f8",
+            "skip": "f9",
+            "quit": "f10",
+            "refocus": "f6",
+            "panic": "ctrl+alt+backspace",
+        },
+        "safety": {"prompt_on_medium_risk": True, "prompt_on_high_risk": True},
+        "songs_dir": "songs",
+        "sky_process_names": ["Sky.exe", "Sky Children of the Light.exe"],
+        "allow_title_fallback": False,
+        "update": {
+            "auto_check": True,
+            "channel": "stable",
+            "skip_version": "",
+            "check_interval_s": 86400,
+            "last_check_ts": 0,
+            "last_error_ts": 0,
+            "last_notified_version": "",
+            "legacy_old_dir_sweep_pending": False,
+        },
+    }
+
+
+def _copy_tree_contents(source: Path, destination: Path) -> None:
+    if not source.is_dir():
+        raise RuntimeError(f"required directory is missing: {source}")
+    destination.mkdir(parents=True, exist_ok=True)
+    for item in source.iterdir():
+        target = destination / item.name
+        if item.is_dir():
+            shutil.copytree(item, target, dirs_exist_ok=True)
+        elif item.is_file():
+            shutil.copy2(item, target)
+        else:
+            raise RuntimeError(f"unsupported package input: {item}")
+
+
+def _copy_file(source: Path, destination: Path) -> None:
+    if not source.is_file():
+        raise RuntimeError(f"required build output is missing: {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+
+
+def _assert_no_path_escape(root: Path) -> None:
+    root = root.resolve()
+    seen: dict[str, str] = {}
+    for path in root.rglob("*"):
+        relative = path.relative_to(root).as_posix()
+        if path.is_symlink():
+            raise RuntimeError(f"release contains a symlink: {relative}")
+        try:
+            path.resolve().relative_to(root)
+        except ValueError:
+            raise RuntimeError(f"release path escapes root: {relative}")
+        folded = relative.casefold()
+        previous = seen.setdefault(folded, relative)
+        if previous != relative:
+            raise RuntimeError(f"case-colliding release paths: {previous}, {relative}")
+
+
+def assemble_release(
+    release_dir: Path,
+    *,
+    tauri_exe: Path,
+    core_dist: Path,
+    calibration_exe: Path,
+    updater_exe: Path,
+    songs_dir: Path,
+    version: str,
+    git_head: str,
+) -> Path:
+    """Assemble one fresh release tree from exact build outputs."""
+    if release_dir.exists():
+        shutil.rmtree(release_dir)
+    release_dir.mkdir(parents=True)
+    _copy_file(tauri_exe, release_dir / PRIMARY_EXE)
+    _copy_file(core_dist / CORE_EXE, release_dir / CORE_EXE)
+    _copy_tree_contents(core_dist / "_internal", release_dir / "_internal")
+    _copy_file(calibration_exe, release_dir / CALIBRATION_EXE)
+    _copy_file(updater_exe, release_dir / UPDATER_EXE)
+    _copy_tree_contents(songs_dir, release_dir / "songs")
+    (release_dir / "config.json").write_text(
+        json.dumps(_default_config(), indent=4) + "\n", encoding="utf-8"
+    )
+    readme = ROOT / "README.md"
+    if readme.is_file():
+        _copy_file(readme, release_dir / "README.md")
+    _assert_no_path_escape(release_dir)
+    build_app.write_release_manifest(
+        release_dir,
+        version,
+        PRIMARY_EXE,
+        git_head,
+        dirty_worktree=False,
+        native_build_commit=git_head,
+    )
+    _assert_no_path_escape(release_dir)
+    return release_dir
+
+
+def write_deterministic_zip(release_dir: Path, destination: Path) -> tuple[Path, str]:
+    """Write a reproducible flat portable ZIP and its SHA-256 sidecar."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(
+        destination, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as archive:
+        for path in sorted(release_dir.rglob("*"), key=lambda item: item.relative_to(release_dir).as_posix()):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(release_dir).as_posix()
+            info = zipfile.ZipInfo(relative, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, path.read_bytes())
+    digest = _hash_file(destination)
+    destination.with_name(destination.name + ".sha256").write_text(
+        f"{digest}  {destination.name}\n", encoding="ascii"
+    )
+    return destination, digest
+
+
+def write_provenance(
+    destination: Path,
+    *,
+    repo_head: str,
+    release_dir: Path,
+    zip_path: Path,
+    native_build_commit: str,
+) -> dict[str, Any]:
+    manifest = release_dir / "MANIFEST.json"
+    data: dict[str, Any] = {
+        "schema_version": 1,
+        "repo_head": repo_head,
+        "version": VERSION,
+        "python": {
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "free_threaded": not bool(getattr(sys, "_is_gil_enabled", lambda: True)()),
+        },
+        "rust": {"compiler": _capture(["rustc", "--version"])},
+        "bun": {"version": _capture(["bun", "--version"])},
+        "tauri": {"api": "2.11.1", "cli": "2.11.4", "runtime": "2.11.5"},
+        "core": {"pyinstaller": _capture([sys.executable, "-c", "import PyInstaller; print(PyInstaller.__version__)"])},
+        "native_build_commit": native_build_commit,
+        "artifact": {
+            "filename": zip_path.name,
+            "size": zip_path.stat().st_size,
+            "sha256": _hash_file(zip_path),
+            "manifest_sha256": _hash_file(manifest),
+            "file_count": sum(1 for path in release_dir.rglob("*") if path.is_file()),
+        },
+        "portable_tree": str(release_dir.name),
+    }
+    destination.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return data
+
+
+def _run_core_selftest(core_exe: Path, *, cwd: Path) -> None:
+    result = subprocess.run(
+        [str(core_exe), "--selftest-desktop-core"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"packaged Core selftest failed ({result.returncode}): "
+            f"{result.stderr[-4000:]}"
+        )
+    print(result.stdout.strip())
+
+
+def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
+    result = subprocess.run(
+        [str(primary_exe), "--selftest-desktop-shell"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"packaged Tauri/Core selftest failed ({result.returncode}): "
+            f"{result.stderr[-4000:]}"
+        )
+    print(result.stdout.strip())
+
+
+def _run_tui_smoke(core_exe: Path, *, cwd: Path) -> None:
+    result = subprocess.run(
+        [str(core_exe), "--tui", "--list"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"packaged TUI smoke failed ({result.returncode}): {result.stderr[-4000:]}"
+        )
+
+
+def _run_exact_updater_qualification(output_root: Path) -> None:
+    env = os.environ.copy()
+    env["SKY_PHASE8_ARTIFACT_DIR"] = str(output_root)
+    _run(
+        [
+            "cargo",
+            "test",
+            "--manifest-path",
+            str(ROOT / "rust" / "Cargo.toml"),
+            "-p",
+            "sky_updater",
+            "--test",
+            "phase8_exact_artifact",
+            "--all-features",
+            "--locked",
+        ],
+        env=env,
+    )
+
+
+def _build() -> tuple[Path, Path, Path, Path]:
+    if sys.platform != "win32":
+        raise RuntimeError("Phase 8 portable build requires Windows")
+    git_head = build_app.get_git_head()
+    version = build_app.get_project_version()
+    if version != VERSION:
+        raise RuntimeError("project version changed during build")
+    build_app.generate_version_py(version)
+    build_app.generate_native_build_py(git_head)
+    build_app.generate_version_info(version)
+    env = build_app.native_build_environment()
+    env["GITHUB_SHA"] = git_head
+    env["SKY_NATIVE_BUILD_COMMIT"] = git_head
+    from sky_music.orchestration.native_provenance import native_source_fingerprint
+
+    env["SKY_NATIVE_SOURCE_FINGERPRINT"] = native_source_fingerprint(ROOT, "cp314t-win_amd64")
+    env["SKY_NATIVE_DIRTY_WORKTREE"] = "false"
+    try:
+        _run([sys.executable, "scripts/build_rust_wheel.py"], env=env)
+        build_app.verify_native_build_info(git_head)
+        core_spec = ROOT / "Sky-Auto-Player-Core.spec"
+        with build_app._source_bootloader_override():
+            _run(
+                [sys.executable, "-m", "PyInstaller", "--noconfirm", "--clean", str(core_spec)],
+                env=env,
+            )
+        core_dist = ROOT / "dist" / "Sky-Auto-Player-Core"
+        _run(["bun", "install", "--frozen-lockfile"], cwd=ROOT / "desktop")
+        _run(["bun", "run", "build"], cwd=ROOT / "desktop")
+        _run(
+            [
+                "cargo",
+                "build",
+                "--manifest-path",
+                str(ROOT / "rust" / "Cargo.toml"),
+                "-p",
+                "sky_desktop_shell",
+                "--bin",
+                "sky_desktop_shell",
+                "--release",
+                "--locked",
+            ],
+            env=env,
+        )
+        _run(
+            build_app.cargo_release_build_command(
+                ROOT / "rust" / "crates" / "sky_dispatch_win32" / "Cargo.toml",
+                "native_calibration",
+            ),
+            env=env,
+        )
+        _run(
+            build_app.cargo_release_build_command(
+                ROOT / "rust" / "crates" / "sky_updater" / "Cargo.toml", "sky_updater"
+            ),
+            env=env,
+        )
+        return (
+            core_dist,
+            ROOT / "rust" / "target" / "release" / "sky_desktop_shell.exe",
+            ROOT / "rust" / "target" / "release" / CALIBRATION_EXE,
+            ROOT / "rust" / "target" / "release" / "sky_updater.exe",
+        )
+    finally:
+        build_app.VERSION_PY.unlink(missing_ok=True)
+        build_app.NATIVE_BUILD_PY.unlink(missing_ok=True)
+
+
+def run_pipeline(output_root: Path) -> Path:
+    repo_head = build_app.get_git_head()
+    core_dist, tauri_exe, calibration_exe, updater_exe = _build()
+    release_dir = output_root / RELEASE_NAME
+    assemble_release(
+        release_dir,
+        tauri_exe=tauri_exe,
+        core_dist=core_dist,
+        calibration_exe=calibration_exe,
+        updater_exe=updater_exe,
+        songs_dir=ROOT / "songs",
+        version=VERSION,
+        git_head=repo_head,
+    )
+    verifier = ROOT / "scripts" / "verify_release_manifest.py"
+    _run(
+        [sys.executable, str(verifier), "--release-dir", str(release_dir), "--version", VERSION]
+    )
+    smoke_root = Path(tempfile.mkdtemp(prefix="Sky Auto Player Phase8 "))
+    try:
+        smoke_dir = smoke_root / release_dir.name
+        shutil.copytree(release_dir, smoke_dir)
+        _run_core_selftest(smoke_dir / CORE_EXE, cwd=smoke_dir)
+        _run_tauri_pair_selftest(smoke_dir / PRIMARY_EXE, cwd=smoke_dir)
+        _run_tui_smoke(smoke_dir / CORE_EXE, cwd=smoke_dir)
+    finally:
+        shutil.rmtree(smoke_root, ignore_errors=True)
+    zip_path, _ = write_deterministic_zip(release_dir, output_root / ZIP_NAME)
+    (output_root / "MANIFEST.json").write_bytes((release_dir / "MANIFEST.json").read_bytes())
+    _run_exact_updater_qualification(output_root)
+    provenance = write_provenance(
+        output_root / "PROVENANCE.json",
+        repo_head=repo_head,
+        release_dir=release_dir,
+        zip_path=zip_path,
+        native_build_commit=repo_head,
+    )
+    (output_root / "PHASE8_QUALIFICATION.json").write_text(
+        json.dumps(
+            {
+                "repo_head": repo_head,
+                "artifact_sha256": provenance["artifact"]["sha256"],
+                "target": "3.5.0",
+                "previous_stable": "3.4.5",
+                "exact_artifact_update": "passed",
+                "package_selftest": "passed",
+                "tauri_core_pair_smoke": "passed",
+                "tui_smoke": "passed",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return release_dir
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", type=Path, default=ROOT / "dist" / "phase8")
+    args = parser.parse_args(argv)
+    if args.output_root.exists():
+        # This is a narrow generated output directory, never a repository path.
+        shutil.rmtree(args.output_root)
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    release_dir = run_pipeline(args.output_root.resolve())
+    print(f"Phase 8 artifact ready: {release_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -263,6 +263,24 @@ def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
     print(result.stdout.strip())
 
 
+def _run_tauri_gui_smoke(primary_exe: Path, *, cwd: Path) -> None:
+    result = subprocess.run(
+        [str(primary_exe), "--selftest-desktop-gui"],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=90,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"packaged Tauri GUI smoke failed ({result.returncode}): "
+            f"{result.stderr[-4000:]}"
+        )
+    print("Packaged Tauri GUI smoke: PASS")
+
+
 def _run_tui_smoke(core_exe: Path, *, cwd: Path) -> None:
     result = subprocess.run(
         [str(core_exe), "--tui", "--list"],
@@ -391,6 +409,7 @@ def run_pipeline(output_root: Path) -> Path:
         shutil.copytree(release_dir, smoke_dir)
         _run_core_selftest(smoke_dir / CORE_EXE, cwd=smoke_dir)
         _run_tauri_pair_selftest(smoke_dir / PRIMARY_EXE, cwd=smoke_dir)
+        _run_tauri_gui_smoke(smoke_dir / PRIMARY_EXE, cwd=smoke_dir)
         _run_tui_smoke(smoke_dir / CORE_EXE, cwd=smoke_dir)
     finally:
         shutil.rmtree(smoke_root, ignore_errors=True)
@@ -414,6 +433,7 @@ def run_pipeline(output_root: Path) -> Path:
                 "exact_artifact_update": "passed",
                 "package_selftest": "passed",
                 "tauri_core_pair_smoke": "passed",
+                "tauri_gui_smoke": "passed",
                 "tui_smoke": "passed",
             },
             indent=2,

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -51,6 +51,15 @@ def _run(command: Sequence[str], *, cwd: Path = ROOT, env: dict[str, str] | None
     subprocess.run(list(command), cwd=str(cwd), env=env, check=True)
 
 
+def _decode_output(value: object) -> str:
+    """Decode child diagnostics deterministically, including invalid bytes."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if value is None:
+        return ""
+    return str(value)
+
+
 def _capture(command: Sequence[str], *, cwd: Path = ROOT) -> str:
     result = subprocess.run(
         list(command), cwd=str(cwd), capture_output=True, text=True, check=True
@@ -232,7 +241,7 @@ def _run_core_selftest(core_exe: Path, *, cwd: Path) -> None:
         [str(core_exe), "--selftest-desktop-core"],
         cwd=str(cwd),
         capture_output=True,
-        text=True,
+        text=False,
         timeout=60,
         creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         check=False,
@@ -240,9 +249,66 @@ def _run_core_selftest(core_exe: Path, *, cwd: Path) -> None:
     if result.returncode != 0:
         raise RuntimeError(
             f"packaged Core selftest failed ({result.returncode}): "
-            f"{result.stderr[-4000:]}"
+            f"{_decode_output(result.stderr)[-4000:]}"
         )
-    print(result.stdout.strip())
+    print(_decode_output(result.stdout).strip())
+
+
+def _run_core_selftest_negative_matrix(core_exe: Path, *, cwd: Path) -> None:
+    """Run the packaged selftest against bounded deterministic bad children."""
+    fixture = ROOT / "desktop" / "src-tauri" / "tests" / "fixtures" / "fake_core.py"
+    if not fixture.is_file():
+        raise RuntimeError(f"Core selftest fixture is missing: {fixture}")
+    scenarios = (
+        "startup_timeout",
+        "eof_before_ready",
+        "fatal_before_ready",
+        "malformed",
+        "non_utf8",
+        "duplicate_output",
+        "oversized_output",
+        "request_timeout",
+        "unknown_id",
+        "force_shutdown",
+    )
+    for scenario in scenarios:
+        env = os.environ.copy()
+        env["SKY_PHASE8_SELFTEST_TIMEOUT_SECONDS"] = "0.1"
+        env["SKY_PHASE8_SELFTEST_CHILD"] = json.dumps(
+            [sys.executable, str(fixture), scenario]
+        )
+        result = subprocess.run(
+            [str(core_exe), "--selftest-desktop-core"],
+            cwd=str(cwd),
+            env=env,
+            capture_output=True,
+            text=False,
+            timeout=10,
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            check=False,
+        )
+        if result.returncode == 0:
+            raise RuntimeError(
+                f"packaged Core selftest accepted bad child scenario {scenario}: "
+                f"{_decode_output(result.stdout)}"
+            )
+    missing_env = os.environ.copy()
+    missing_env["SKY_PHASE8_SELFTEST_CHILD"] = json.dumps(
+        [str(cwd / "missing-core.exe")]
+    )
+    missing = subprocess.run(
+        [str(core_exe), "--selftest-desktop-core"],
+        cwd=str(cwd),
+        env=missing_env,
+        capture_output=True,
+        text=False,
+        timeout=10,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+        check=False,
+    )
+    if missing.returncode == 0:
+        raise RuntimeError("packaged Core selftest accepted a missing child")
+    print(f"Packaged Desktop Core selftest negative matrix: {len(scenarios) + 1} PASS")
 
 
 def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
@@ -250,7 +316,7 @@ def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
         [str(primary_exe), "--selftest-desktop-shell"],
         cwd=str(cwd),
         capture_output=True,
-        text=True,
+        text=False,
         timeout=60,
         creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         check=False,
@@ -258,18 +324,24 @@ def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
     if result.returncode != 0:
         raise RuntimeError(
             f"packaged Tauri/Core selftest failed ({result.returncode}): "
-            f"{result.stderr[-4000:]}"
+            f"{_decode_output(result.stderr)[-4000:]}"
         )
-    print(result.stdout.strip())
+    print(_decode_output(result.stdout).strip())
 
 
 def _run_tauri_gui_smoke(primary_exe: Path, *, cwd: Path) -> None:
+    env = os.environ.copy()
+    # The real production Core remains native-calibration-backed.  This
+    # packaging-only environment selects the explicit no-input seam so the
+    # actual Tauri/Core smoke can exercise calibration safely in CI.
+    env["SKY_PHASE8_SAFE_CALIBRATION"] = "1"
     try:
         result = subprocess.run(
             [str(primary_exe), "--selftest-desktop-gui"],
             cwd=str(cwd),
             capture_output=True,
-            text=True,
+            text=False,
+            env=env,
             timeout=60,
             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             check=False,
@@ -277,12 +349,13 @@ def _run_tauri_gui_smoke(primary_exe: Path, *, cwd: Path) -> None:
     except subprocess.TimeoutExpired as error:
         raise RuntimeError(
             "packaged Tauri GUI smoke timed out; "
-            f"stdout={error.stdout!r} stderr={error.stderr!r}"
+            f"stdout={_decode_output(error.stdout)!r} "
+            f"stderr={_decode_output(error.stderr)!r}"
         ) from error
     if result.returncode != 0:
         raise RuntimeError(
             f"packaged Tauri GUI smoke failed ({result.returncode}): "
-            f"{result.stderr[-4000:]}"
+            f"{_decode_output(result.stderr)[-4000:]}"
         )
     print("Packaged Tauri GUI smoke: PASS")
 
@@ -292,20 +365,22 @@ def _run_tui_smoke(core_exe: Path, *, cwd: Path) -> None:
         [str(core_exe), "--tui", "--list"],
         cwd=str(cwd),
         capture_output=True,
-        text=True,
+        text=False,
         timeout=60,
         creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         check=False,
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"packaged TUI smoke failed ({result.returncode}): {result.stderr[-4000:]}"
+            f"packaged TUI smoke failed ({result.returncode}): "
+            f"{_decode_output(result.stderr)[-4000:]}"
         )
 
 
-def _run_exact_updater_qualification(output_root: Path) -> None:
+def _run_exact_updater_qualification(output_root: Path, e2e_updater: Path) -> None:
     env = os.environ.copy()
     env["SKY_PHASE8_ARTIFACT_DIR"] = str(output_root)
+    env["SKY_PHASE8_E2E_UPDATER"] = str(e2e_updater)
     _run(
         [
             "cargo",
@@ -318,12 +393,14 @@ def _run_exact_updater_qualification(output_root: Path) -> None:
             "phase8_exact_artifact",
             "--all-features",
             "--locked",
+            "--",
+            "--test-threads=1",
         ],
         env=env,
     )
 
 
-def _build() -> tuple[Path, Path, Path, Path]:
+def _build() -> tuple[Path, Path, Path, Path, Path]:
     if sys.platform != "win32":
         raise RuntimeError("Phase 8 portable build requires Windows")
     git_head = build_app.get_git_head()
@@ -374,6 +451,27 @@ def _build() -> tuple[Path, Path, Path, Path]:
             ),
             env=env,
         )
+        # This disposable feature-gated runner is never copied into the
+        # release tree. It lets exact-artifact qualification use the native
+        # updater transaction runner with a deterministic local source while
+        # the shipped updater remains the production GitHub-only binary.
+        _run(
+            [
+                "cargo",
+                "build",
+                "--manifest-path",
+                str(ROOT / "rust" / "crates" / "sky_updater" / "Cargo.toml"),
+                "--bin",
+                "sky_updater_e2e",
+                "--release",
+                "--features",
+                "e2e-local-source,e2e-fault-injection",
+                "--locked",
+            ],
+            env=env,
+        )
+        # Build the shipped updater last so the exact release binary is
+        # produced with the default (GitHub-only) feature set.
         _run(
             build_app.cargo_release_build_command(
                 ROOT / "rust" / "crates" / "sky_updater" / "Cargo.toml", "sky_updater"
@@ -385,6 +483,7 @@ def _build() -> tuple[Path, Path, Path, Path]:
             ROOT / "rust" / "target" / "release" / "sky_desktop_shell.exe",
             ROOT / "rust" / "target" / "release" / CALIBRATION_EXE,
             ROOT / "rust" / "target" / "release" / "sky_updater.exe",
+            ROOT / "rust" / "target" / "release" / "sky_updater_e2e.exe",
         )
     finally:
         build_app.VERSION_PY.unlink(missing_ok=True)
@@ -393,7 +492,7 @@ def _build() -> tuple[Path, Path, Path, Path]:
 
 def run_pipeline(output_root: Path) -> Path:
     repo_head = build_app.get_git_head()
-    core_dist, tauri_exe, calibration_exe, updater_exe = _build()
+    core_dist, tauri_exe, calibration_exe, updater_exe, e2e_updater_exe = _build()
     release_dir = output_root / RELEASE_NAME
     assemble_release(
         release_dir,
@@ -414,6 +513,7 @@ def run_pipeline(output_root: Path) -> Path:
         smoke_dir = smoke_root / release_dir.name
         shutil.copytree(release_dir, smoke_dir)
         _run_core_selftest(smoke_dir / CORE_EXE, cwd=smoke_dir)
+        _run_core_selftest_negative_matrix(smoke_dir / CORE_EXE, cwd=smoke_dir)
         _run_tauri_pair_selftest(smoke_dir / PRIMARY_EXE, cwd=smoke_dir)
         _run_tauri_gui_smoke(smoke_dir / PRIMARY_EXE, cwd=smoke_dir)
         _run_tui_smoke(smoke_dir / CORE_EXE, cwd=smoke_dir)
@@ -421,13 +521,31 @@ def run_pipeline(output_root: Path) -> Path:
         shutil.rmtree(smoke_root, ignore_errors=True)
     zip_path, _ = write_deterministic_zip(release_dir, output_root / ZIP_NAME)
     (output_root / "MANIFEST.json").write_bytes((release_dir / "MANIFEST.json").read_bytes())
-    _run_exact_updater_qualification(output_root)
+    _run_exact_updater_qualification(output_root, e2e_updater_exe)
     provenance = write_provenance(
         output_root / "PROVENANCE.json",
         repo_head=repo_head,
         release_dir=release_dir,
         zip_path=zip_path,
         native_build_commit=repo_head,
+    )
+    (output_root / "PHASE8_ARTIFACT_SUMMARY.json").write_text(
+        json.dumps(
+            {
+                "repo_head": repo_head,
+                "artifact_name": zip_path.name,
+                "artifact_size": provenance["artifact"]["size"],
+                "artifact_sha256": provenance["artifact"]["sha256"],
+                "manifest_sha256": provenance["artifact"]["manifest_sha256"],
+                "portable_file_count": provenance["artifact"]["file_count"],
+                "managed_entry_count": len(
+                    json.loads((release_dir / "MANIFEST.json").read_text(encoding="utf-8"))["files"]
+                ),
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
     )
     (output_root / "PHASE8_QUALIFICATION.json").write_text(
         json.dumps(
@@ -438,9 +556,15 @@ def run_pipeline(output_root: Path) -> Path:
                 "previous_stable": "3.4.5",
                 "exact_artifact_update": "passed",
                 "package_selftest": "passed",
+                "core_selftest_negative_matrix": "passed",
                 "tauri_core_pair_smoke": "passed",
                 "tauri_gui_smoke": "passed",
                 "tui_smoke": "passed",
+                "packaged_updater_identity_smoke": "passed",
+                "exact_artifact_transaction_restart": "qualified_with_local_source_runner",
+                "production_updater_network_transaction": (
+                    "not_run_without_public_release_or_local_http_source"
+                ),
             },
             indent=2,
         )

--- a/scripts/build_phase8.py
+++ b/scripts/build_phase8.py
@@ -555,6 +555,7 @@ def run_pipeline(output_root: Path) -> Path:
                 "target": "3.5.0",
                 "previous_stable": "3.4.5",
                 "exact_artifact_update": "passed",
+                "exact_artifact_fault_rollback": "passed",
                 "package_selftest": "passed",
                 "core_selftest_negative_matrix": "passed",
                 "tauri_core_pair_smoke": "passed",

--- a/scripts/verify_release_manifest.py
+++ b/scripts/verify_release_manifest.py
@@ -9,8 +9,10 @@ from pathlib import Path
 
 APP_NAME = "Sky-Auto-Player"
 PRIMARY_EXE = f"{APP_NAME}.exe"
+CORE_EXE = f"{APP_NAME}-Core.exe"
 REQUIRED = {
     PRIMARY_EXE,
+    CORE_EXE,
     "native_calibration.exe",
     "Sky-Auto-Player-Updater.exe",
     "MANIFEST.json",
@@ -43,9 +45,23 @@ def verify(release_dir: Path, version: str) -> None:
         for path in all_paths
         if path.is_file()
     }
+    folded: dict[str, str] = {}
+    for relative in actual:
+        previous = folded.setdefault(relative.casefold(), relative)
+        if previous != relative:
+            raise RuntimeError(
+                f"release contains case-colliding paths: {previous!r}, {relative!r}"
+            )
     missing = REQUIRED - actual
     if missing:
         raise RuntimeError(f"release is missing required files: {sorted(missing)}")
+    if not any(
+        path.startswith("_internal/")
+        and Path(path).suffix.casefold() == ".pyd"
+        and Path(path).name.casefold().startswith("sky_player_rs")
+        for path in actual
+    ):
+        raise RuntimeError("release is missing the bundled sky_player_rs native extension")
     forbidden = sorted(
         path
         for path in actual
@@ -97,6 +113,13 @@ def verify(release_dir: Path, version: str) -> None:
             or "/../" in f"/{path}/"
         ):
             raise RuntimeError(f"invalid or duplicate manifest entry: {entry!r}")
+        try:
+            (release_dir / path).resolve().relative_to(release_dir.resolve())
+        except (OSError, ValueError):
+            raise RuntimeError(f"manifest path escapes release tree: {path!r}") from None
+        previous = next((name for name in expected if name.casefold() == path.casefold()), None)
+        if previous is not None and previous != path:
+            raise RuntimeError(f"manifest contains case-colliding paths: {previous!r}, {path!r}")
         expected[path] = (size, digest.lower())
     if set(expected) != actual - {"MANIFEST.json"}:
         raise RuntimeError("manifest file set does not match the release tree")

--- a/src/core_main.py
+++ b/src/core_main.py
@@ -2,7 +2,31 @@
 
 from __future__ import annotations
 
-from sky_music.cli.desktop_core import main
+import sys
+
+
+def _run_tui() -> int:
+    """Run the packaged Textual/CLI fallback from this same executable."""
+    from main import main as tui_main
+
+    sys.argv = [argument for argument in sys.argv if argument != "--tui"]
+    return tui_main()
+
+
+def _run_desktop_selftest() -> int:
+    from sky_music.cli.desktop_core_selftest import run_packaged_core_selftest
+
+    return run_packaged_core_selftest()
+
+
+def main() -> int:
+    if "--tui" in sys.argv[1:]:
+        return _run_tui()
+    if "--selftest-desktop-core" in sys.argv[1:]:
+        return _run_desktop_selftest()
+    from sky_music.cli.desktop_core import main as desktop_main
+
+    return desktop_main()
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/src/sky_music/cli/desktop_core.py
+++ b/src/sky_music/cli/desktop_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -17,6 +18,7 @@ from sky_music.infrastructure.desktop_ipc.protocol import (
 from sky_music.infrastructure.desktop_ipc.server import DesktopCoreServer
 from sky_music.infrastructure.realtime import assert_free_threaded_runtime
 from sky_music.orchestration.catalog_service import CatalogService
+from sky_music.orchestration.desktop_calibration import run_packaged_smoke_calibration
 from sky_music.orchestration.native_admission import require_rust_core
 from sky_music.orchestration.settings_service import SettingsService
 
@@ -85,8 +87,6 @@ def run_desktop_core(
         if install_root is not None:
             if not install_root.is_dir():
                 raise ValueError("--install-root must name an existing directory")
-            import os
-
             os.chdir(install_root)
             from sky_music.infrastructure.update_runtime import (
                 active_update_for_install,
@@ -109,6 +109,11 @@ def run_desktop_core(
             native_build_info=native_info,
             parent_pid=parent_pid,
             install_root=install_root,
+            calibration_runner=(
+                run_packaged_smoke_calibration
+                if os.environ.get("SKY_PHASE8_SAFE_CALIBRATION") == "1"
+                else None
+            ),
         )
     except SystemExit as exc:
         code = exc.code if isinstance(exc.code, int) else 2

--- a/src/sky_music/cli/desktop_core_selftest.py
+++ b/src/sky_music/cli/desktop_core_selftest.py
@@ -7,6 +7,7 @@ useful packaging check rather than another in-process unit test.
 
 from __future__ import annotations
 
+import json
 import os
 import queue
 import subprocess
@@ -61,34 +62,57 @@ class _ChildOutput:
 
 def _root_and_command() -> tuple[Path, list[str]]:
     executable = Path(sys.executable).resolve()
+    override = os.environ.get("SKY_PHASE8_SELFTEST_CHILD")
+    if override:
+        try:
+            values = json.loads(override)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("SKY_PHASE8_SELFTEST_CHILD is not valid JSON") from exc
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(not isinstance(value, str) or not value for value in values)
+        ):
+            raise RuntimeError("SKY_PHASE8_SELFTEST_CHILD must be a non-empty string list")
+        return executable.parent, values
     if getattr(sys, "frozen", False):
         return executable.parent, [str(executable)]
     root = Path(__file__).resolve().parents[3]
     return root, [sys.executable, str(root / "src" / "core_main.py")]
 
 
-def run_packaged_core_selftest() -> int:
+def run_core_selftest(
+    *,
+    command: list[str] | None = None,
+    root: Path | None = None,
+    timeout_s: float = _TIMEOUT_S,
+) -> int:
     """Run a bounded ready/bootstrap/request/shutdown round-trip.
 
     Diagnostics are written to stderr so the method remains safe to use from
     an automated package gate and never contaminates Desktop Core stdout.
     """
-    root, command = _root_and_command()
-    if not root.is_dir():
-        print(f"desktop Core selftest: install root missing: {root}", file=sys.stderr)
+    default_root, default_command = _root_and_command()
+    install_root = root if root is not None else default_root
+    child_command = list(command) if command is not None else default_command
+    if not install_root.is_dir():
+        print(
+            f"desktop Core selftest: install root missing: {install_root}",
+            file=sys.stderr,
+        )
         return 2
-    command += [
+    child_command += [
         "--desktop-worker",
         "--parent-pid",
         str(os.getpid()),
         "--install-root",
-        str(root),
+        str(install_root),
     ]
     creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     try:
         process = subprocess.Popen(
-            command,
-            cwd=str(root),
+            child_command,
+            cwd=str(install_root),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -101,7 +125,7 @@ def run_packaged_core_selftest() -> int:
     output = _ChildOutput(process)
     next_id = 1
 
-    def receive(timeout: float = _TIMEOUT_S) -> dict[str, object] | None:
+    def receive(timeout: float = timeout_s) -> dict[str, object] | None:
         try:
             item = output.frames.get(timeout=timeout)
         except queue.Empty:
@@ -166,7 +190,7 @@ def run_packaged_core_selftest() -> int:
         if process.stdin is not None:
             process.stdin.close()
         try:
-            process.wait(timeout=_TIMEOUT_S)
+            process.wait(timeout=timeout_s)
         except subprocess.TimeoutExpired as exc:
             process.kill()
             process.wait(timeout=2)
@@ -183,4 +207,19 @@ def run_packaged_core_selftest() -> int:
         return 1
 
 
-__all__ = ["run_packaged_core_selftest"]
+def run_packaged_core_selftest() -> int:
+    raw_timeout = os.environ.get("SKY_PHASE8_SELFTEST_TIMEOUT_SECONDS")
+    timeout = _TIMEOUT_S
+    if raw_timeout is not None:
+        try:
+            timeout = float(raw_timeout)
+        except ValueError:
+            print("desktop Core selftest: invalid timeout override", file=sys.stderr)
+            return 2
+        if not 0.1 <= timeout <= 60:
+            print("desktop Core selftest: timeout override is out of bounds", file=sys.stderr)
+            return 2
+    return run_core_selftest(timeout_s=timeout)
+
+
+__all__ = ["run_core_selftest", "run_packaged_core_selftest"]

--- a/src/sky_music/cli/desktop_core_selftest.py
+++ b/src/sky_music/cli/desktop_core_selftest.py
@@ -15,7 +15,10 @@ import threading
 from pathlib import Path
 from typing import Any
 
-from sky_music.infrastructure.desktop_ipc.protocol import encode_frame, iter_bounded_frames
+from sky_music.infrastructure.desktop_ipc.protocol import (
+    encode_frame,
+    iter_bounded_frames,
+)
 
 _TIMEOUT_S = 15.0
 _MAX_STDERR_BYTES = 128 * 1024

--- a/src/sky_music/cli/desktop_core_selftest.py
+++ b/src/sky_music/cli/desktop_core_selftest.py
@@ -157,6 +157,11 @@ def run_packaged_core_selftest() -> int:
             raise RuntimeError("bootstrap omitted native build information")
         request("settings.get", {})
         request("app.shutdown", {})
+        # Closing the parent end makes the inherited stdin EOF explicit.  The
+        # Core has already completed the bounded shutdown response; this also
+        # lets its reader thread leave a blocking pipe read on Windows.
+        if process.stdin is not None:
+            process.stdin.close()
         try:
             process.wait(timeout=_TIMEOUT_S)
         except subprocess.TimeoutExpired as exc:

--- a/src/sky_music/cli/desktop_core_selftest.py
+++ b/src/sky_music/cli/desktop_core_selftest.py
@@ -1,0 +1,178 @@
+"""Black-box self-test for the packaged Desktop Core executable.
+
+The test intentionally speaks the same bounded NDJSON protocol as Tauri.  It
+does not import application services from the child process, which makes it a
+useful packaging check rather than another in-process unit test.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+
+from sky_music.infrastructure.desktop_ipc.protocol import encode_frame, iter_bounded_frames
+
+_TIMEOUT_S = 15.0
+_MAX_STDERR_BYTES = 128 * 1024
+
+
+class _ChildOutput:
+    def __init__(self, process: subprocess.Popen[bytes]) -> None:
+        self.frames: queue.Queue[object] = queue.Queue()
+        self.stderr = bytearray()
+        self._stderr_lock = threading.Lock()
+        self._threads = [
+            threading.Thread(target=self._read_stdout, args=(process.stdout,), daemon=True),
+            threading.Thread(target=self._read_stderr, args=(process.stderr,), daemon=True),
+        ]
+        for thread in self._threads:
+            thread.start()
+
+    def _read_stdout(self, stream: Any) -> None:
+        try:
+            for frame in iter_bounded_frames(stream):
+                self.frames.put(frame)
+        except BaseException as exc:  # delivered to the parent test below
+            self.frames.put(exc)
+        finally:
+            self.frames.put(None)
+
+    def _read_stderr(self, stream: Any) -> None:
+        try:
+            while True:
+                chunk = stream.read1(4096) if hasattr(stream, "read1") else stream.read(4096)
+                if not chunk:
+                    return
+                with self._stderr_lock:
+                    remaining = _MAX_STDERR_BYTES - len(self.stderr)
+                    if remaining > 0:
+                        self.stderr.extend(chunk[:remaining])
+        except BaseException:
+            return
+
+
+def _root_and_command() -> tuple[Path, list[str]]:
+    executable = Path(sys.executable).resolve()
+    if getattr(sys, "frozen", False):
+        return executable.parent, [str(executable)]
+    root = Path(__file__).resolve().parents[3]
+    return root, [sys.executable, str(root / "src" / "core_main.py")]
+
+
+def run_packaged_core_selftest() -> int:
+    """Run a bounded ready/bootstrap/request/shutdown round-trip.
+
+    Diagnostics are written to stderr so the method remains safe to use from
+    an automated package gate and never contaminates Desktop Core stdout.
+    """
+    root, command = _root_and_command()
+    if not root.is_dir():
+        print(f"desktop Core selftest: install root missing: {root}", file=sys.stderr)
+        return 2
+    command += [
+        "--desktop-worker",
+        "--parent-pid",
+        str(os.getpid()),
+        "--install-root",
+        str(root),
+    ]
+    creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=str(root),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=creationflags,
+        )
+    except OSError as exc:
+        print(f"desktop Core selftest: launch failed: {exc}", file=sys.stderr)
+        return 2
+
+    output = _ChildOutput(process)
+    next_id = 1
+
+    def receive(timeout: float = _TIMEOUT_S) -> dict[str, object] | None:
+        try:
+            item = output.frames.get(timeout=timeout)
+        except queue.Empty:
+            raise RuntimeError("timed out waiting for Core protocol frame") from None
+        if item is None:
+            return None
+        if isinstance(item, BaseException):
+            raise RuntimeError(f"Core stdout protocol failure: {item}") from item
+        if not isinstance(item, bytes):
+            raise RuntimeError("Core stdout reader returned an invalid frame")
+        try:
+            import json
+
+            decoded = json.loads(item.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise RuntimeError("Core emitted malformed JSON") from exc
+        if not isinstance(decoded, dict):
+            raise RuntimeError("Core emitted a non-object protocol frame")
+        return decoded
+
+    def request(method: str, params: dict[str, object]) -> dict[str, object]:
+        nonlocal next_id
+        request_id = next_id
+        next_id += 1
+        frame = {
+            "v": 1,
+            "id": request_id,
+            "type": "request",
+            "method": method,
+            "params": params,
+        }
+        assert process.stdin is not None
+        process.stdin.write(encode_frame(frame))
+        process.stdin.flush()
+        while True:
+            message = receive()
+            if message is None:
+                raise RuntimeError(f"Core exited while awaiting {method}")
+            if message.get("type") == "event":
+                continue
+            if message.get("id") != request_id:
+                raise RuntimeError(f"unexpected Core response ID for {method}")
+            if message.get("ok") is not True:
+                raise RuntimeError(f"Core rejected {method}: {message.get('error')!r}")
+            result = message.get("result")
+            if not isinstance(result, dict):
+                raise RuntimeError(f"Core returned invalid {method} result")
+            return result
+
+    try:
+        ready = receive()
+        if ready is None or ready.get("type") != "event" or ready.get("name") != "core.ready":
+            raise RuntimeError("Core did not emit core.ready")
+        bootstrap = request("app.bootstrap", {})
+        if not isinstance(bootstrap.get("native_build"), dict):
+            raise RuntimeError("bootstrap omitted native build information")
+        request("settings.get", {})
+        request("app.shutdown", {})
+        try:
+            process.wait(timeout=_TIMEOUT_S)
+        except subprocess.TimeoutExpired as exc:
+            process.kill()
+            process.wait(timeout=2)
+            raise RuntimeError("Core did not exit after app.shutdown") from exc
+        if process.returncode != 0:
+            raise RuntimeError(f"Core exited with status {process.returncode}")
+        print("Packaged Desktop Core selftest: PASS")
+        return 0
+    except (OSError, RuntimeError) as exc:
+        print(f"desktop Core selftest: FAIL: {exc}", file=sys.stderr)
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=2)
+        return 1
+
+
+__all__ = ["run_packaged_core_selftest"]

--- a/src/sky_music/infrastructure/desktop_ipc/server.py
+++ b/src/sky_music/infrastructure/desktop_ipc/server.py
@@ -42,6 +42,7 @@ from sky_music.orchestration.catalog_service import (
     CatalogService,
 )
 from sky_music.orchestration.desktop_calibration import (
+    CalibrationRunner,
     DesktopCalibrationError,
     DesktopCalibrationService,
 )
@@ -245,6 +246,7 @@ class DesktopCoreServer:
         app_version: str = __version__,
         parent_pid: int | None = None,
         install_root: Path | None = None,
+        calibration_runner: CalibrationRunner | None = None,
     ) -> None:
         self.settings_service = settings_service
         self.catalog_service = catalog_service
@@ -275,6 +277,7 @@ class DesktopCoreServer:
             publish_event=self._publish_event,
             physical_playback_active=self.playback.is_physical_active,
             on_success=self.playback.invalidate_settings,
+            runner=calibration_runner,
         )
 
     def ready_event(self) -> dict[str, object]:

--- a/src/sky_music/orchestration/desktop_calibration.py
+++ b/src/sky_music/orchestration/desktop_calibration.py
@@ -49,6 +49,32 @@ CalibrationRunner = Callable[
 ]
 
 
+def run_packaged_smoke_calibration(
+    request: CalibrationStartDto,
+    cancel: threading.Event,
+    progress: CalibrationProgressCallback,
+) -> Mapping[str, Any]:
+    """Run the package smoke calibration without touching game input.
+
+    This seam is only selected by the release-package smoke harness.  The
+    production runner remains ``_run_native`` and therefore keeps the native
+    calibration executable as the sole real calibration boundary.
+    """
+    del request
+    if cancel.is_set():
+        raise CalibrationCancelled()
+    progress("measuring", 0, 1, "Running package-safe calibration")
+    if cancel.wait(0.02):
+        raise CalibrationCancelled()
+    progress("completed", 1, 1, "Package-safe calibration completed")
+    return {
+        "status": "completed",
+        "transport_margin_us": 0,
+        "sample_count": 1,
+        "source": "package-smoke-test",
+    }
+
+
 def _bounded_text(value: object) -> str:
     text = str(value).replace("\x00", "")
     encoded = text.encode("utf-8", errors="replace")
@@ -394,4 +420,5 @@ __all__ = [
     "CALIBRATION_JOIN_TIMEOUT_SECONDS",
     "DesktopCalibrationError",
     "DesktopCalibrationService",
+    "run_packaged_smoke_calibration",
 ]

--- a/tests/fixtures/phase8_core_selftest_child.py
+++ b/tests/fixtures/phase8_core_selftest_child.py
@@ -1,0 +1,106 @@
+"""Small protocol child used to exercise the packaged-Core selftest harness."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+
+def emit(value: object) -> None:
+    sys.stdout.buffer.write(json.dumps(value, separators=(",", ":")).encode() + b"\n")
+    sys.stdout.buffer.flush()
+
+
+def ready() -> None:
+    emit(
+        {
+            "v": 1,
+            "type": "event",
+            "name": "core.ready",
+            "payload": {
+                "app_version": "selftest-fixture",
+                "protocol_version": 1,
+                "native_build": {
+                    "native_build_commit": "a" * 40,
+                    "native_version": "test",
+                    "schema_version": 1,
+                    "native_abi": "test",
+                    "rustc_version": "test",
+                    "win32_backend": False,
+                },
+            },
+        }
+    )
+
+
+def main() -> int:
+    scenario = sys.argv[1]
+    if scenario == "exit_before_ready":
+        return 0
+    if scenario == "startup_fatal":
+        emit(
+            {
+                "v": 1,
+                "type": "event",
+                "name": "core.fatal",
+                "payload": {"code": "fixture", "message": "startup failed"},
+            }
+        )
+        return 0
+    if scenario == "malformed":
+        sys.stdout.buffer.write(b"{not-json}\n")
+        sys.stdout.buffer.flush()
+        return 0
+    if scenario == "non_utf8":
+        sys.stdout.buffer.write(b"\xff\xfe\n")
+        sys.stdout.buffer.flush()
+        return 0
+    ready()
+    for line in sys.stdin.buffer:
+        request = json.loads(line)
+        request_id = request.get("id")
+        method = request.get("method")
+        if scenario == "wrong_response_id":
+            request_id = int(request_id) + 1
+        if scenario == "request_timeout":
+            time.sleep(5)
+            continue
+        if method == "app.bootstrap":
+            emit(
+                {
+                    "v": 1,
+                    "id": request_id,
+                    "type": "response",
+                    "ok": True,
+                    "result": {"native_build": {}},
+                }
+            )
+        elif method == "settings.get":
+            emit(
+                {
+                    "v": 1,
+                    "id": request_id,
+                    "type": "response",
+                    "ok": True,
+                    "result": {},
+                }
+            )
+        elif method == "app.shutdown":
+            emit(
+                {
+                    "v": 1,
+                    "id": request_id,
+                    "type": "response",
+                    "ok": True,
+                    "result": {"shutdown": True},
+                }
+            )
+            if scenario == "shutdown_hang":
+                time.sleep(5)
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_background_worker_static_guard.py
+++ b/tests/test_background_worker_static_guard.py
@@ -22,8 +22,9 @@ def test_static_drift_guard() -> None:
         "sky_music/orchestration/engine.py",
         "sky_music/orchestration/desktop_playback.py",
         "sky_music/orchestration/desktop_calibration.py",
-        "sky_music/infrastructure/desktop_ipc/server.py",
-        "sky_music/platform/win32/global_hotkeys.py",
+            "sky_music/infrastructure/desktop_ipc/server.py",
+            "sky_music/cli/desktop_core_selftest.py",
+            "sky_music/platform/win32/global_hotkeys.py",
     }
 
     errors = []

--- a/tests/test_phase8_core_selftest.py
+++ b/tests/test_phase8_core_selftest.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+
+
+def _load_selftest():
+    path = ROOT / "src" / "sky_music" / "cli" / "desktop_core_selftest.py"
+    spec = importlib.util.spec_from_file_location("phase8_core_selftest_under_test", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load Core selftest")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture_command(scenario: str) -> list[str]:
+    return [
+        sys.executable,
+        str(ROOT / "tests" / "fixtures" / "phase8_core_selftest_child.py"),
+        scenario,
+    ]
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "exit_before_ready",
+        "startup_fatal",
+        "malformed",
+        "non_utf8",
+        "wrong_response_id",
+        "request_timeout",
+        "shutdown_hang",
+    ],
+)
+def test_core_selftest_protocol_failures_are_bounded(
+    tmp_path: Path, scenario: str
+) -> None:
+    selftest = _load_selftest()
+    result = selftest.run_core_selftest(
+        command=_fixture_command(scenario), root=tmp_path, timeout_s=0.25
+    )
+    assert result == 1
+
+
+def test_core_selftest_missing_executable_fails_closed(tmp_path: Path) -> None:
+    selftest = _load_selftest()
+    result = selftest.run_core_selftest(
+        command=[str(tmp_path / "missing-core.exe")], root=tmp_path, timeout_s=0.25
+    )
+    assert result == 2
+
+
+def test_core_selftest_positive_fixture_completes(tmp_path: Path) -> None:
+    selftest = _load_selftest()
+    result = selftest.run_core_selftest(
+        command=_fixture_command("good"), root=tmp_path, timeout_s=0.5
+    )
+    assert result == 0

--- a/tests/test_phase8_packaging.py
+++ b/tests/test_phase8_packaging.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parents[1]
+
+
+def _load_phase8():
+    path = ROOT / "scripts" / "build_phase8.py"
+    spec = importlib.util.spec_from_file_location("build_phase8_under_test", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load Phase 8 builder")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_verifier():
+    path = ROOT / "scripts" / "verify_release_manifest.py"
+    spec = importlib.util.spec_from_file_location("verify_release_manifest_phase8", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load release verifier")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _seed_release(tmp_path: Path) -> Path:
+    release = tmp_path / "release"
+    (release / "_internal" / "sky_player_rs").mkdir(parents=True)
+    for name, payload in (
+        ("Sky-Auto-Player.exe", b"tauri"),
+        ("Sky-Auto-Player-Core.exe", b"core"),
+        ("Sky-Auto-Player-Updater.exe", b"updater"),
+        ("native_calibration.exe", b"calibration"),
+        ("_internal/sky_player_rs/sky_player_rs.pyd", b"native"),
+        ("songs/example.json", b"{}"),
+    ):
+        path = release / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+    from build_app import write_release_manifest
+
+    write_release_manifest(release, "3.5.0", "Sky-Auto-Player.exe", "a" * 40)
+    return release
+
+
+def test_phase8_manifest_requires_core_and_native_extension(tmp_path: Path) -> None:
+    verifier = _load_verifier()
+    release = _seed_release(tmp_path)
+    verifier.verify(release, "3.5.0")
+
+    (release / "Sky-Auto-Player-Core.exe").unlink()
+    with pytest.raises(RuntimeError, match="missing required files"):
+        verifier.verify(release, "3.5.0")
+
+
+def test_phase8_zip_is_byte_deterministic_and_has_sidecar(tmp_path: Path) -> None:
+    phase8 = _load_phase8()
+    release = _seed_release(tmp_path)
+    first, first_hash = phase8.write_deterministic_zip(release, tmp_path / "one.zip")
+    second, second_hash = phase8.write_deterministic_zip(release, tmp_path / "two.zip")
+    assert first.read_bytes() == second.read_bytes()
+    assert first_hash == second_hash == hashlib.sha256(first.read_bytes()).hexdigest()
+    assert (tmp_path / "one.zip.sha256").read_text(encoding="ascii") == (
+        f"{first_hash}  one.zip\n"
+    )
+
+
+def test_phase8_provenance_has_public_head_and_exact_artifact_hash(tmp_path: Path, monkeypatch) -> None:
+    phase8 = _load_phase8()
+    release = _seed_release(tmp_path)
+    zip_path, _ = phase8.write_deterministic_zip(release, tmp_path / "artifact.zip")
+    monkeypatch.setattr(phase8, "_capture", lambda command: "test-version")
+    provenance_path = tmp_path / "PROVENANCE.json"
+    data = phase8.write_provenance(
+        provenance_path,
+        repo_head="a" * 40,
+        release_dir=release,
+        zip_path=zip_path,
+        native_build_commit="a" * 40,
+    )
+    assert data["repo_head"] == "a" * 40
+    assert data["artifact"]["sha256"] == hashlib.sha256(zip_path.read_bytes()).hexdigest()
+    assert json.loads(provenance_path.read_text(encoding="utf-8"))["artifact"]["file_count"] == 7
+
+
+def test_phase8_spec_is_the_single_core_runtime() -> None:
+    spec = (ROOT / "Sky-Auto-Player-Core.spec").read_text(encoding="utf-8")
+    assert "src\" / \"core_main.py" in spec
+    assert 'app_name = "Sky-Auto-Player-Core"' in spec
+    assert '"main"' in spec
+    assert '"sky_player_rs.sky_player_rs"' in spec
+
+
+def test_play_batch_prefers_packaged_core_tui() -> None:
+    batch = (ROOT / "play.bat").read_text(encoding="utf-8")
+    assert "Sky-Auto-Player-Core.exe" in batch
+    assert "--tui" in batch

--- a/tests/test_unsigned_release_contract.py
+++ b/tests/test_unsigned_release_contract.py
@@ -56,7 +56,7 @@ def test_native_package_paths_pin_rust_compiler_explicitly() -> None:
     assert "Expected stable Rust 1.98.0 for packaged build" in ci_workflow
     assert "RUSTUP_TOOLCHAIN: 1.98.0" in ci_workflow
     assert "RUSTUP_TOOLCHAIN: 1.98.0" in release_workflow
-    assert "uv run --env-file .env python -m build_app" in release_workflow
+    assert "uv run --env-file .env python scripts/build_phase8.py" in release_workflow
     assert "scripts/build_phase8.py" in ci_workflow
     assert "Upload exact Phase 8 release candidate" in ci_workflow
     assert "phase8_exact_artifact" in (ROOT / "scripts" / "build_phase8.py").read_text(

--- a/tests/test_unsigned_release_contract.py
+++ b/tests/test_unsigned_release_contract.py
@@ -57,12 +57,11 @@ def test_native_package_paths_pin_rust_compiler_explicitly() -> None:
     assert "RUSTUP_TOOLCHAIN: 1.98.0" in ci_workflow
     assert "RUSTUP_TOOLCHAIN: 1.98.0" in release_workflow
     assert "uv run --env-file .env python -m build_app" in release_workflow
-    assert (
-        "- name: Native updater security E2E\n"
-        "        env:\n"
-        "          RUSTUP_TOOLCHAIN: 1.98.0\n"
-        "        run: cargo test"
-    ) in ci_workflow
+    assert "scripts/build_phase8.py" in ci_workflow
+    assert "Upload exact Phase 8 release candidate" in ci_workflow
+    assert "phase8_exact_artifact" in (ROOT / "scripts" / "build_phase8.py").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_unsigned_release_tree_is_exact_and_has_verified_native_updater(tmp_path: Path) -> None:
@@ -70,8 +69,11 @@ def test_unsigned_release_tree_is_exact_and_has_verified_native_updater(tmp_path
     release_dir = tmp_path / "release"
     release_dir.mkdir()
     (release_dir / "Sky-Auto-Player.exe").write_bytes(b"app")
+    (release_dir / "Sky-Auto-Player-Core.exe").write_bytes(b"core")
     (release_dir / "native_calibration.exe").write_bytes(b"calibration")
     (release_dir / "Sky-Auto-Player-Updater.exe").write_bytes(b"updater")
+    (release_dir / "_internal" / "sky_player_rs").mkdir(parents=True)
+    (release_dir / "_internal" / "sky_player_rs" / "sky_player_rs.pyd").write_bytes(b"native")
     from build_app import write_release_manifest
 
     write_release_manifest(release_dir, "3.2.1", "Sky-Auto-Player.exe", "a" * 40)
@@ -90,8 +92,11 @@ def test_release_tree_rejects_legacy_update_artifacts(tmp_path: Path, legacy_nam
     release_dir = tmp_path / "release"
     release_dir.mkdir()
     (release_dir / "Sky-Auto-Player.exe").write_bytes(b"app")
+    (release_dir / "Sky-Auto-Player-Core.exe").write_bytes(b"core")
     (release_dir / "native_calibration.exe").write_bytes(b"calibration")
     (release_dir / "Sky-Auto-Player-Updater.exe").write_bytes(b"updater")
+    (release_dir / "_internal" / "sky_player_rs").mkdir(parents=True)
+    (release_dir / "_internal" / "sky_player_rs" / "sky_player_rs.pyd").write_bytes(b"native")
     from build_app import write_release_manifest
 
     write_release_manifest(release_dir, "3.2.1", "Sky-Auto-Player.exe", "a" * 40)


### PR DESCRIPTION
## Phase 8 — Packaging + exact release qualification

Exact final head: `a897506c04a1138bb772a347ae61ab79da16a0fa`

This Draft PR produces the v4 portable candidate without activating the final release/canonical cutover. `bundle.active` remains `false`; no Phase 9 work and no physical qualification claim are included.

### Exact final CI artifact

Authoritative provenance was read from the exact artifact uploaded by CI run `33304720656` after the final head completed:

- Workflow artifact ID: `9730252057`
- Workflow artifact name: `sky-auto-player-phase8-portable-v451bdd641df8026ffb77aa8078fc84b7f3c12749293bafad9540a9038cc06bdd`
- Workflow artifact digest: `sha256:b4ce6e29309b6f62076c859c1e5853bc3ef26cd4ec1e8d45954f09a8c3693d3b`
- `repo_head`: `a897506c04a1138bb772a347ae61ab79da16a0fa`
- Release ZIP: `Sky-Auto-Player-v3.5.0.zip`
- ZIP size: `34,042,923` bytes
- ZIP SHA-256: `b11200a8a8d8eb60fb53819f20e47b4d454a5998b7412c380cb998182ec57872`
- MANIFEST SHA-256: `060093b997c19d6bb28fa7122799276f1f700db28d30b87b5e8c51f73dc9fba4`
- Portable tree: `239` files total
- MANIFEST managed entries: `238` (MANIFEST is not self-listed)
- ZIP sidecar, external MANIFEST, and embedded MANIFEST agree; direct verification found zero size/hash/path-set mismatches.

The portable tree is the exact v4 layout: `Sky-Auto-Player.exe`, one `Sky-Auto-Player-Core.exe` (CPython 3.14.7 free-threaded + PyInstaller 6.22.2), `Sky-Auto-Player-Updater.exe`, `native_calibration.exe`, `_internal/`, `songs/`, `config.json`, and `README.md`. The packaged fallback is `Sky-Auto-Player-Core.exe --tui ...`; source fallback remains `uv run python src/main.py`.

Build provenance: CPython 3.14.7 free-threaded, rustc 1.98.0, Bun 1.4.0, Tauri API 2.11.1 / CLI 2.11.4 / runtime 2.11.5. The manifest and provenance identify the same public repo head.

### Qualification

- Frozen packaged Core selftest: PASS.
- Packaged Core negative matrix: PASS, including missing executable, EOF/startup timeout, fatal-before-ready, malformed/non-UTF-8/duplicate/oversized output, unknown response ID, request timeout, and shutdown hang; all paths bounded and cleaned up.
- Headless production Tauri/Core pairing selftest: PASS.
- Fail-closed real Wry packaged GUI smoke from a path containing spaces: PASS. It asserts bootstrap/shell readiness, search completion, settings round-trip, diagnostics enable/disable, safe packaged calibration terminal result, and controlled shutdown before success.
- Packaged TUI smoke: PASS.
- Exact `3.4.5` previous-stable → `3.5.0` artifact transaction checks: PASS for exact ZIP/sidecar/MANIFEST verification, managed-role transition, user-file preservation (`config.json`, `.env`, `songs/**`, `logs/**`), exact-artifact rollback/fault and interrupted-recovery fixtures.
- Actual packaged updater identity/READY/canonical-parent wait smoke: PASS; no fake READY is used for that boundary.
- Exact-artifact transaction/restart qualification uses the feature-gated offline local-source runner because the shipped updater intentionally remains GitHub/HTTPS-source-only and this PR does not publish a public release or introduce HTTP/socket transport. The shipped updater's production network transaction is therefore explicitly **not run** here; this is distinguished from the exact artifact transaction/restart fixture in `PHASE8_QUALIFICATION.json`.
- No SendInput is synthesized by package CI.

### Local verification

- `uv run python scripts/check.py static`: PASS.
- `uv run python scripts/check.py rust`: PASS (workspace/all-features, clippy `-D warnings`, RT/timing/golden suites, updater and desktop Rust tests).
- `uv run python scripts/check.py desktop`: PASS (22 Vitest, 10 Playwright/axe, 105 desktop Rust, generated bindings/decoder clean).
- Full Python regression with repository temp override: `1031 passed, 16 skipped, 1 xfailed, 1 warning`.
- The default full `scripts/check.py` test invocation was blocked by the managed Windows environment's locked `.pytest_tmp`; CI's Windows verification passed on the exact head.

### CI

Workflow `33304720656` passed on this exact head, attempt 1:

- Detect `99239105594`
- Static/security `99239117367`
- Windows/unit/desktop `99239117369`
- Packaged exact artifact `99239117400`
- Required gate `99240669118`

The packaged job both qualified and uploaded the exact bytes reported above; no second unqualified ZIP was rebuilt.

Evidence: `docs/evidence/desktop-phase8/README.md`; generated `PROVENANCE.json`, `PHASE8_ARTIFACT_SUMMARY.json`, and `PHASE8_QUALIFICATION.json` are included in workflow artifact `9730252057`.

This PR intentionally remains Draft/Open/unmerged pending Phase 8 acceptance. Phase 9 has not started.