### PR TITLE
perf: separate fast release checks from dist qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
           SKY_EXPECTED_BUILD_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: uv run --env-file .env python scripts/build_rust_wheel.py --test-support
+        run: uv run --env-file .env python scripts/build_rust_wheel.py --test-support --profile release
 
       - name: Repository verification — Rust
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Rust — build native wheel
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
-        run: uv run --env-file .env python scripts/build_rust_wheel.py
+        run: uv run --env-file .env python scripts/build_rust_wheel.py --profile dist
 
       - name: Repository verification — full Python tests
         run: uv run python scripts/check.py tests-full

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "node scripts/run-e2e.mjs",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
+    "tauri:build": "tauri build --profile dist",
     "check": "bun run typecheck && bun run lint && bun run format:check && bun run test && bun run build:web"
   },
   "dependencies": {

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,9 +16,12 @@ rust-version = "1.98"
 authors = ["Sky Auto Player Team"]
 
 [profile.release]
-lto = "thin"
-codegen-units = 1
-opt-level = 3
+# Keep routine optimized engineering builds responsive. Shipped artifacts use
+# the explicit `dist` profile below, so this profile may trade some throughput
+# for shorter compile/link cycles.
+lto = false
+codegen-units = 16
+opt-level = 2
 panic = "unwind"
 strip = "symbols"
 overflow-checks = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,3 +22,12 @@ opt-level = 3
 panic = "unwind"
 strip = "symbols"
 overflow-checks = true
+
+# Engineering builds may use the faster `release` profile. Every shipped
+# native artifact must use this profile so distribution optimization remains
+# explicit and cannot drift when the engineering profile changes.
+[profile.dist]
+inherits = "release"
+lto = "thin"
+codegen-units = 1
+opt-level = 3

--- a/scripts/audit_dispatch_assembly.ps1
+++ b/scripts/audit_dispatch_assembly.ps1
@@ -1,5 +1,5 @@
 param(
-    [string]$AssemblyPath = (Join-Path $PSScriptRoot '..\rust\target\release\deps\sky_player_rs.s')
+    [string]$AssemblyPath = (Join-Path $PSScriptRoot '..\rust\target\dist\deps\sky_player_rs.s')
 )
 
 $resolvedAssemblyPath = Resolve-Path -LiteralPath $AssemblyPath -ErrorAction Stop

--- a/scripts/build_portable_release.py
+++ b/scripts/build_portable_release.py
@@ -418,7 +418,7 @@ def _build() -> tuple[Path, Path, Path, Path, Path]:
     env["SKY_NATIVE_SOURCE_FINGERPRINT"] = native_source_fingerprint(ROOT, "cp314t-win_amd64")
     env["SKY_NATIVE_DIRTY_WORKTREE"] = "false"
     try:
-        _run([sys.executable, "scripts/build_rust_wheel.py"], env=env)
+        _run([sys.executable, "scripts/build_rust_wheel.py", "--profile", "dist"], env=env)
         build_app.verify_native_build_info(git_head)
         core_spec = ROOT / "Sky-Auto-Player-Core.spec"
         with build_app._source_bootloader_override():
@@ -439,7 +439,8 @@ def _build() -> tuple[Path, Path, Path, Path, Path]:
                 "sky_desktop_shell",
                 "--bin",
                 "sky_desktop_shell",
-                "--release",
+                "--profile",
+                "dist",
                 "--locked",
             ],
             env=env,
@@ -463,7 +464,8 @@ def _build() -> tuple[Path, Path, Path, Path, Path]:
                 str(ROOT / "rust" / "crates" / "sky_updater" / "Cargo.toml"),
                 "--bin",
                 "sky_updater_e2e",
-                "--release",
+                "--profile",
+                "dist",
                 "--features",
                 "e2e-local-source,e2e-fault-injection",
                 "--locked",
@@ -480,10 +482,10 @@ def _build() -> tuple[Path, Path, Path, Path, Path]:
         )
         return (
             core_dist,
-            ROOT / "rust" / "target" / "release" / "sky_desktop_shell.exe",
-            ROOT / "rust" / "target" / "release" / CALIBRATION_EXE,
-            ROOT / "rust" / "target" / "release" / "sky_updater.exe",
-            ROOT / "rust" / "target" / "release" / "sky_updater_e2e.exe",
+            ROOT / "rust" / "target" / "dist" / "sky_desktop_shell.exe",
+            ROOT / "rust" / "target" / "dist" / CALIBRATION_EXE,
+            ROOT / "rust" / "target" / "dist" / "sky_updater.exe",
+            ROOT / "rust" / "target" / "dist" / "sky_updater_e2e.exe",
         )
     finally:
         build_app.VERSION_PY.unlink(missing_ok=True)

--- a/scripts/build_rust_wheel.py
+++ b/scripts/build_rust_wheel.py
@@ -26,6 +26,17 @@ from packaging.utils import canonicalize_name, parse_wheel_filename
 EXPECTED_NATIVE_TAG = Tag("cp314", "cp314t", "win_amd64")
 EXPECTED_NATIVE_ABI = "cp314t-win_amd64"
 SUPPORTED_CARGO_PROFILES = ("release", "dist")
+PRODUCTION_DEFAULT_PROFILE = "dist"
+TEST_SUPPORT_DEFAULT_PROFILE = "release"
+
+
+def resolve_cargo_profile(profile: str | None, *, test_support: bool) -> str:
+    """Resolve the wheel builder's safe default for the requested build kind."""
+
+    resolved = profile or (TEST_SUPPORT_DEFAULT_PROFILE if test_support else PRODUCTION_DEFAULT_PROFILE)
+    if resolved not in SUPPORTED_CARGO_PROFILES:
+        raise ValueError(f"unsupported Cargo profile: {resolved}")
+    return resolved
 
 
 def cargo_profile_arguments(profile: str) -> list[str]:
@@ -189,10 +200,14 @@ def main() -> int:
     parser.add_argument(
         "--profile",
         choices=("release", "dist"),
-        default="release",
-        help="Cargo profile to use (production artifacts must select dist explicitly)",
+        default=None,
+        help="Cargo profile (defaults to dist for production, release for --test-support)",
     )
     args = parser.parse_args()
+    try:
+        profile = resolve_cargo_profile(args.profile, test_support=args.test_support)
+    except ValueError as exc:
+        parser.error(str(exc))
     repo_root = Path(__file__).resolve().parent.parent
     rust_dir = repo_root / "rust"
 
@@ -226,7 +241,7 @@ def main() -> int:
         "-m",
         "maturin",
         "build",
-        *cargo_profile_arguments(args.profile),
+        *cargo_profile_arguments(profile),
         "--locked",
         "--manifest-path",
         str(cargo_manifest),

--- a/scripts/build_rust_wheel.py
+++ b/scripts/build_rust_wheel.py
@@ -25,6 +25,13 @@ from packaging.utils import canonicalize_name, parse_wheel_filename
 
 EXPECTED_NATIVE_TAG = Tag("cp314", "cp314t", "win_amd64")
 EXPECTED_NATIVE_ABI = "cp314t-win_amd64"
+SUPPORTED_CARGO_PROFILES = ("release", "dist")
+
+
+def cargo_profile_arguments(profile: str) -> list[str]:
+    if profile not in SUPPORTED_CARGO_PROFILES:
+        raise ValueError(f"unsupported Cargo profile: {profile}")
+    return ["--profile", profile]
 
 
 def pinned_rust_toolchain(rust_dir: Path) -> str:
@@ -179,6 +186,12 @@ def main() -> int:
         action="store_true",
         help="build the non-production wheel with native benchmark test support",
     )
+    parser.add_argument(
+        "--profile",
+        choices=("release", "dist"),
+        default="release",
+        help="Cargo profile to use (production artifacts must select dist explicitly)",
+    )
     args = parser.parse_args()
     repo_root = Path(__file__).resolve().parent.parent
     rust_dir = repo_root / "rust"
@@ -213,7 +226,7 @@ def main() -> int:
         "-m",
         "maturin",
         "build",
-        "--release",
+        *cargo_profile_arguments(args.profile),
         "--locked",
         "--manifest-path",
         str(cargo_manifest),

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -63,19 +63,9 @@ GROUPS: dict[str, tuple[Check, ...]] = {
             "Rust format",
             ("cargo", "fmt", "--manifest-path", "rust/Cargo.toml", "--all", "--", "--check"),
         ),
-        Check(
-            "Rust check",
-            (
-                "cargo",
-                "check",
-                "--manifest-path",
-                "rust/Cargo.toml",
-                "--workspace",
-                "--all-targets",
-                "--all-features",
-                "--locked",
-            ),
-        ),
+        # Clippy performs the same workspace/all-target/all-feature Cargo
+        # compilation as the standalone check, then adds lint analysis. Keep
+        # one compilation surface in the CI-oriented Rust group.
         Check(
             "Rust clippy",
             (

--- a/scripts/test_windows_updater_e2e.ps1
+++ b/scripts/test_windows_updater_e2e.ps1
@@ -969,13 +969,13 @@ try {
     if ($SyntheticTargetVersion -eq $fromManifest.version) { throw "synthetic target version must be newer than source" }
 
     $cargoManifest = Join-Path $script:RepoRoot "rust\Cargo.toml"
-    & cargo build --manifest-path $cargoManifest -p sky_updater --bin sky_updater --release
+    & cargo build --manifest-path $cargoManifest -p sky_updater --bin sky_updater --profile dist
     if ($LASTEXITCODE -ne 0) { throw "production updater build failed" }
     & cargo build --manifest-path $cargoManifest -p sky_updater --bin sky_updater_e2e `
-        --features e2e-local-source,e2e-fault-injection --release
+        --features e2e-local-source,e2e-fault-injection --profile dist
     if ($LASTEXITCODE -ne 0) { throw "E2E updater build failed" }
-    $productionCandidate = Join-Path $script:RepoRoot "rust\target\release\sky_updater.exe"
-    $e2eCandidate = Join-Path $script:RepoRoot "rust\target\release\sky_updater_e2e.exe"
+    $productionCandidate = Join-Path $script:RepoRoot "rust\target\dist\sky_updater.exe"
+    $e2eCandidate = Join-Path $script:RepoRoot "rust\target\dist\sky_updater_e2e.exe"
     if (-not (Test-Path $productionCandidate) -or -not (Test-Path $e2eCandidate)) { throw "updater candidates missing" }
     $packagedUpdater = Join-Path $toRoot "Sky-Auto-Player-Updater.exe"
     $candidateHashes = [ordered]@{

--- a/src/build_app.py
+++ b/src/build_app.py
@@ -68,6 +68,12 @@ def native_build_environment() -> dict[str, str]:
 
 
 def cargo_release_build_command(manifest: Path, binary: str) -> list[str]:
+    """Return the locked Cargo command for a shipped native binary.
+
+    The historical function name is retained for callers and tests. Release
+    packaging now uses the explicit ``dist`` profile so an engineering profile
+    change cannot silently affect distributed binaries.
+    """
     return [
         "cargo",
         "build",
@@ -75,7 +81,8 @@ def cargo_release_build_command(manifest: Path, binary: str) -> list[str]:
         str(manifest),
         "--bin",
         binary,
-        "--release",
+        "--profile",
+        "dist",
         "--locked",
     ]
 
@@ -508,7 +515,7 @@ def main() -> None:
         build_script = PROJECT_ROOT / "scripts" / "build_rust_wheel.py"
         native_build_env = native_build_environment()
         subprocess.run(
-            [sys.executable, str(build_script)],
+            [sys.executable, str(build_script), "--profile", "dist"],
             check=True,
             cwd=str(PROJECT_ROOT),
             env=native_build_env,
@@ -558,14 +565,14 @@ def main() -> None:
         shutil.rmtree(release_dir)
     shutil.move(str(raw_dist), str(release_dir))
 
-    calibration_binary = rust_dir / "target" / "release" / NATIVE_CALIBRATION_BINARY
+    calibration_binary = rust_dir / "target" / "dist" / NATIVE_CALIBRATION_BINARY
     if not calibration_binary.is_file():
         raise RuntimeError(f"Native calibration binary is missing: {calibration_binary}")
     copy_asset(calibration_binary, release_dir / NATIVE_CALIBRATION_BINARY)
     if not run_native_calibration_smoke_test(release_dir / NATIVE_CALIBRATION_BINARY):
         raise RuntimeError("Native calibration binary smoke test failed")
 
-    updater_binary = rust_dir / "target" / "release" / "sky_updater.exe"
+    updater_binary = rust_dir / "target" / "dist" / "sky_updater.exe"
     if not updater_binary.is_file():
         raise RuntimeError(f"Native updater binary is missing: {updater_binary}")
     copy_asset(updater_binary, release_dir / NATIVE_UPDATER_BINARY)

--- a/tests/test_build_rust_wheel.py
+++ b/tests/test_build_rust_wheel.py
@@ -52,6 +52,23 @@ def test_cargo_profile_arguments_are_explicit_and_bounded() -> None:
         BUILD.cargo_profile_arguments("debug")
 
 
+def test_wheel_profile_defaults_fail_safe_by_build_kind() -> None:
+    assert BUILD.resolve_cargo_profile(None, test_support=False) == "dist"
+    assert BUILD.resolve_cargo_profile(None, test_support=True) == "release"
+
+
+def test_wheel_profile_explicit_values_are_honored_for_both_build_kinds() -> None:
+    assert BUILD.resolve_cargo_profile("dist", test_support=False) == "dist"
+    assert BUILD.resolve_cargo_profile("dist", test_support=True) == "dist"
+    assert BUILD.resolve_cargo_profile("release", test_support=False) == "release"
+    assert BUILD.resolve_cargo_profile("release", test_support=True) == "release"
+
+
+def test_wheel_profile_resolution_rejects_unsupported_profiles() -> None:
+    with pytest.raises(ValueError, match="unsupported Cargo profile"):
+        BUILD.resolve_cargo_profile("debug", test_support=False)
+
+
 def test_build_commit_requires_clean_matching_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(BUILD, "git_head", lambda repo_root: "head-commit")
     monkeypatch.setattr(BUILD, "git_status", lambda repo_root: "")

--- a/tests/test_build_rust_wheel.py
+++ b/tests/test_build_rust_wheel.py
@@ -45,6 +45,13 @@ def test_wheel_build_reads_exact_toolchain_and_checks_compiler_metadata() -> Non
         )
 
 
+def test_cargo_profile_arguments_are_explicit_and_bounded() -> None:
+    assert BUILD.cargo_profile_arguments("release") == ["--profile", "release"]
+    assert BUILD.cargo_profile_arguments("dist") == ["--profile", "dist"]
+    with pytest.raises(ValueError, match="unsupported Cargo profile"):
+        BUILD.cargo_profile_arguments("debug")
+
+
 def test_build_commit_requires_clean_matching_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(BUILD, "git_head", lambda repo_root: "head-commit")
     monkeypatch.setattr(BUILD, "git_status", lambda repo_root: "")

--- a/tests/test_dist_profile_contract.py
+++ b/tests/test_dist_profile_contract.py
@@ -4,7 +4,6 @@ import json
 import tomllib
 from pathlib import Path
 
-
 ROOT = Path(__file__).parents[1]
 
 

--- a/tests/test_dist_profile_contract.py
+++ b/tests/test_dist_profile_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_dist_profile_preserves_shipping_optimization() -> None:
+    cargo = tomllib.loads((ROOT / "rust" / "Cargo.toml").read_text(encoding="utf-8"))
+    assert cargo["profile"]["dist"] == {
+        "inherits": "release",
+        "lto": "thin",
+        "codegen-units": 1,
+        "opt-level": 3,
+    }
+
+
+def test_production_native_build_commands_select_dist() -> None:
+    import sys
+
+    sys.path.insert(0, str(ROOT / "src"))
+    import build_app
+
+    command = build_app.cargo_release_build_command(Path("native/Cargo.toml"), "native")
+    assert command[command.index("--profile") + 1] == "dist"
+    assert "--release" not in command
+
+    build_app_source = (ROOT / "src" / "build_app.py").read_text(encoding="utf-8")
+    portable_source = (ROOT / "scripts" / "build_portable_release.py").read_text(encoding="utf-8")
+    release_workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    assert '"scripts/build_rust_wheel.py", "--profile", "dist"' in portable_source
+    assert "scripts/build_rust_wheel.py --profile dist" in release_workflow
+    assert '[sys.executable, str(build_script), "--profile", "dist"]' in build_app_source
+    assert '"--profile",\n                "dist"' in portable_source
+
+    desktop_package = json.loads((ROOT / "desktop" / "package.json").read_text(encoding="utf-8"))
+    assert desktop_package["scripts"]["tauri:build"] == "tauri build --profile dist"
+
+
+def test_shipping_binary_paths_match_dist_profile() -> None:
+    build_app_source = (ROOT / "src" / "build_app.py").read_text(encoding="utf-8")
+    portable_source = (ROOT / "scripts" / "build_portable_release.py").read_text(encoding="utf-8")
+    updater_e2e_source = (ROOT / "scripts" / "test_windows_updater_e2e.ps1").read_text(encoding="utf-8")
+    assembly_source = (ROOT / "scripts" / "audit_dispatch_assembly.ps1").read_text(encoding="utf-8")
+
+    assert '"target" / "dist" / NATIVE_CALIBRATION_BINARY' in build_app_source
+    assert '"target" / "dist" / "sky_updater.exe"' in build_app_source
+    assert '"target" / "dist" / "sky_desktop_shell.exe"' in portable_source
+    assert '"target" / "dist" / "sky_updater_e2e.exe"' in portable_source
+    assert 'rust\\target\\dist\\sky_updater.exe' in updater_e2e_source
+    assert "rust\\target\\dist\\deps\\sky_player_rs.s" in assembly_source

--- a/tests/test_dist_profile_contract.py
+++ b/tests/test_dist_profile_contract.py
@@ -9,6 +9,14 @@ ROOT = Path(__file__).parents[1]
 
 def test_dist_profile_preserves_shipping_optimization() -> None:
     cargo = tomllib.loads((ROOT / "rust" / "Cargo.toml").read_text(encoding="utf-8"))
+    assert cargo["profile"]["release"] == {
+        "lto": False,
+        "codegen-units": 16,
+        "opt-level": 2,
+        "panic": "unwind",
+        "strip": "symbols",
+        "overflow-checks": True,
+    }
     assert cargo["profile"]["dist"] == {
         "inherits": "release",
         "lto": "thin",

--- a/tests/test_dist_profile_contract.py
+++ b/tests/test_dist_profile_contract.py
@@ -47,6 +47,16 @@ def test_production_native_build_commands_select_dist() -> None:
     assert desktop_package["scripts"]["tauri:build"] == "tauri build --profile dist"
 
 
+def test_wheel_builder_defaults_are_fail_safe() -> None:
+    source = (ROOT / "scripts" / "build_rust_wheel.py").read_text(encoding="utf-8")
+    tests_source = (ROOT / "tests" / "test_build_rust_wheel.py").read_text(encoding="utf-8")
+    assert 'resolve_cargo_profile(None, test_support=False) == "dist"' in tests_source
+    assert 'PRODUCTION_DEFAULT_PROFILE = "dist"' in source
+    assert 'TEST_SUPPORT_DEFAULT_PROFILE = "release"' in source
+    assert "default=None" in source
+    assert "resolve_cargo_profile(args.profile, test_support=args.test_support)" in source
+
+
 def test_shipping_binary_paths_match_dist_profile() -> None:
     build_app_source = (ROOT / "src" / "build_app.py").read_text(encoding="utf-8")
     portable_source = (ROOT / "scripts" / "build_portable_release.py").read_text(encoding="utf-8")

--- a/tests/test_native_acceptance.py
+++ b/tests/test_native_acceptance.py
@@ -1018,7 +1018,6 @@ def test_workflow_keeps_required_gates_without_optional_benchmark_wiring() -> No
     assert "uv run python scripts/check.py tests" in workflow
     for required in (
         '"cargo", "fmt", "--manifest-path", "rust/Cargo.toml", "--all", "--", "--check"',
-        '"cargo",\n                "check",',
         '"cargo",\n                "clippy",',
         '"cargo",\n                "test",',
         'sys.executable, "-m", "pytest", "-m", "not slow"',
@@ -1032,6 +1031,7 @@ def test_workflow_keeps_required_gates_without_optional_benchmark_wiring() -> No
     assert "--backend sendinput" not in workflow
     assert "--allow-real-input" not in workflow
     assert "SKY_NATIVE_TARGET_HWND" not in workflow
+    assert '"Rust check"' not in verifier
 
 
 @pytest.mark.windows


### PR DESCRIPTION
## Wave 1 — Track A

Phase 0 is formally accepted. This PR is based on the accepted Phase 0 merge:
`main@e5a5ca7c526c09544305b0cae925058ccd61d1ef`.

Scope:

- keep the dedicated `dist` profile at `opt-level=3`, thin LTO, and `codegen-units=1`;
- keep the faster engineering `release` profile for development checks;
- make the native wheel builder fail-safe: production/default resolves to `dist`, while
  `--test-support` defaults to `release`; explicit supported profiles remain honored;
- retain exact production qualification for every shipping path;
- no runtime behavior change, Python removal, or Tauri command cutover.

Review boundary:

- no product/runtime behavior change is intended;
- exact artifact qualification remains mandatory on `main`;
- the Python runtime is NOT removed in this PR;
- commits remain independently reviewable and revertible;
- Phase 1 remains blocked until this PR is accepted.

Local evidence: wheel profile contract tests, dist profile contract tests, Ruff, and diff
verification pass. The existing before/after engineering profile timing remains favorable;
full CI and exact packaged qualification on this remediation HEAD are the authoritative
release evidence.

This PR is not to be merged automatically; it is awaiting architectural acceptance.
