### PR TITLE
refactor: establish pure Rust application core

### DIFF
--- a/docs/architecture-target.md
+++ b/docs/architecture-target.md
@@ -10,7 +10,7 @@ React / TypeScript
         ▼
 sky_desktop_shell  ── composition root and delivery adapter
         │
-        ├── sky_app_core ── domain, use cases, and inward ports
+        ├── sky_app_core ── pure application/domain home; ports added just-in-time
         ├── sky_player ──── playback adapter
         ├── sky_updater ─── hardened update adapter
         └── dispatch adapters ── sky_dispatch_core + sky_dispatch_win32
@@ -21,7 +21,9 @@ xtask ── developer/release tooling only
 ## Dependency rules
 
 - `sky_app_core` has no Tauri, Win32, PyO3, WebView, or concrete filesystem/HTTP
-  dependency.
+  dependency. It remains an architecture-only foundation until a subsystem
+  migration supplies current-behavior evidence and parity fixtures for each
+  model or port introduced.
 - `sky_player` remains a pure Rust production engine; the temporary Python
   bridge is isolated and deleted after parity.
 - `sky_dispatch_core` remains platform-neutral; `sky_dispatch_win32` owns QPC,

--- a/docs/rust-architecture.md
+++ b/docs/rust-architecture.md
@@ -22,6 +22,11 @@ Python application
 - `sky_dispatch_win32`: Windows/QPC/SendInput platform adapter. Must not import PyO3.
 - `sky_player`: Pure Rust runtime orchestration and playback engine. It must not import PyO3.
 - `sky_player_rs`: Temporary Python FFI adapter. Only this crate may import PyO3.
+- `sky_app_core`: Pure application/domain home. During the foundation phase it
+  intentionally has no speculative models or ports; each future abstraction is
+  introduced just-in-time with current-behavior evidence and a parity fixture.
+  It must not depend on Tauri, PyO3, Win32, the desktop shell, or the player
+  crate.
 
 ## Module Ownership
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3057,6 +3057,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "sky_app_core"
+version = "0.1.0"
+
+[[package]]
 name = "sky_desktop_shell"
 version = "3.5.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "crates/sky_dispatch_core",
     "crates/sky_dispatch_win32",
+    "crates/sky_app_core",
     "crates/sky_player",
     "crates/sky_player_rs",
     "crates/sky_updater",

--- a/rust/crates/sky_app_core/Cargo.toml
+++ b/rust/crates/sky_app_core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "sky_app_core"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+name = "sky_app_core"

--- a/rust/crates/sky_app_core/src/lib.rs
+++ b/rust/crates/sky_app_core/src/lib.rs
@@ -1,0 +1,9 @@
+//! Pure application/domain home for the Rust-first migration.
+//!
+//! The crate is intentionally an architecture-only foundation in this phase.
+//! Its first real model or port must be introduced together with a concrete
+//! subsystem migration, current-behavior evidence, and a parity fixture. This
+//! keeps speculative contracts from becoming a second application-service
+//! owner while the existing runtime remains canonical.
+
+#![forbid(unsafe_code)]

--- a/scripts/check_rust_architecture.py
+++ b/scripts/check_rust_architecture.py
@@ -53,6 +53,13 @@ PLAYER_ADAPTER_FORBIDDEN_DIRECT_DEPENDENCIES = {
     "sky_dispatch_core",
     "sky_dispatch_win32",
 }
+APP_CORE_FORBIDDEN_DEPENDENCIES = {
+    "tauri",
+    "pyo3",
+    "windows-sys",
+    "sky_desktop_shell",
+    "sky_player",
+}
 
 ALLOWED_UNSAFE_MODULES = {
     "rust/crates/sky_dispatch_win32/src/calibration.rs",
@@ -329,6 +336,41 @@ def _player_adapter_violations(repository_root: Path) -> list[Violation]:
     ]
 
 
+def _app_core_violations(repository_root: Path) -> list[Violation]:
+    """Reject delivery/platform/player dependencies in the pure app crate."""
+
+    crate_root = repository_root / "rust/crates/sky_app_core"
+    manifest = crate_root / "Cargo.toml"
+    if not manifest.exists():
+        return []
+
+    data = tomllib.loads(manifest.read_text(encoding="utf-8"))
+    dependencies = data.get("dependencies", {})
+    violations = [
+        Violation(
+            "app_core_dependency",
+            "rust/crates/sky_app_core/Cargo.toml",
+            f"sky_app_core must not depend directly on {name}",
+        )
+        for name in sorted(APP_CORE_FORBIDDEN_DEPENDENCIES.intersection(dependencies))
+    ]
+    source_markers = re.compile(
+        r"\b(?:tauri|pyo3|windows-sys|windows_sys|sky_desktop_shell|sky_player)\b"
+    )
+    for filepath in sorted((crate_root / "src").rglob("*.rs")):
+        relative = filepath.relative_to(repository_root).as_posix()
+        joined = "".join(_without_comments(filepath.read_text(encoding="utf-8").splitlines(keepends=True)))
+        if source_markers.search(joined):
+            violations.append(
+                Violation(
+                    "app_core_dependency",
+                    relative,
+                    "sky_app_core source references a forbidden delivery/platform/player dependency",
+                )
+            )
+    return violations
+
+
 def check_repository(repository_root: Path) -> CheckReport:
     report = CheckReport()
     allowlist = _load_allowlist(repository_root)
@@ -338,6 +380,9 @@ def check_repository(repository_root: Path) -> CheckReport:
         return report
 
     for violation in _player_adapter_violations(repository_root):
+        _record(report, violation, allowlist)
+
+    for violation in _app_core_violations(repository_root):
         _record(report, violation, allowlist)
 
     dispatch_dir = repository_root / "rust/crates/sky_player/src/engine/worker/dispatch"
@@ -366,7 +411,7 @@ def check_repository(repository_root: Path) -> CheckReport:
                 )
             )
 
-    for crate in ("sky_dispatch_core", "sky_dispatch_win32", "sky_player", "sky_player_rs"):
+    for crate in ("sky_dispatch_core", "sky_dispatch_win32", "sky_app_core", "sky_player", "sky_player_rs"):
         crate_path = workspace_root / crate / "src"
         if not crate_path.exists():
             continue

--- a/tests/test_rust_architecture.py
+++ b/tests/test_rust_architecture.py
@@ -215,3 +215,19 @@ def test_checker_rejects_player_adapter_source_dispatch_import(tmp_path):
     report = _checker().check_repository(tmp_path)
 
     assert any(item.rule == "player_adapter_dependency" for item in report.errors)
+
+
+def test_checker_rejects_forbidden_sky_app_core_dependency(tmp_path):
+    crate = tmp_path / "rust" / "crates" / "sky_app_core"
+    crate.mkdir(parents=True)
+    (crate / "Cargo.toml").write_text(
+        "[package]\nname = 'sky_app_core'\nversion = '0.1.0'\n"
+        "[dependencies]\ntauri = '2'\n",
+        encoding="utf-8",
+    )
+    (crate / "src").mkdir()
+    (crate / "src" / "lib.rs").write_text("pub fn core() {}\n", encoding="utf-8")
+
+    report = _checker().check_repository(tmp_path)
+
+    assert any(item.rule == "app_core_dependency" for item in report.errors)

--- a/tests/test_sky_app_core_contract.py
+++ b/tests/test_sky_app_core_contract.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+FORBIDDEN = {"tauri", "pyo3", "windows-sys", "sky_desktop_shell", "sky_player"}
+
+
+def test_sky_app_core_is_pure_and_does_not_depend_on_player_or_delivery() -> None:
+    manifest = tomllib.loads(
+        (ROOT / "rust" / "crates" / "sky_app_core" / "Cargo.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert not FORBIDDEN.intersection(manifest.get("dependencies", {}))
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / "rust" / "crates" / "sky_app_core" / "src").rglob("*.rs"))
+    )
+    assert not any(marker in source for marker in FORBIDDEN)
+    assert "#![forbid(unsafe_code)]" in source
+    assert "ApplicationCore" not in source
+    assert "PlaybackRequest" not in source
+    assert "SongSource" not in source
+    assert "UpdateGateway" not in source
+    assert sorted(path.name for path in (ROOT / "rust" / "crates" / "sky_app_core" / "src").glob("*.rs")) == [
+        "lib.rs"
+    ]
+    assert not (ROOT / "rust" / "crates" / "sky_app_core" / "tests" / "use_cases.rs").exists()


### PR DESCRIPTION
## Wave 1 — Track C

Track A / PR #82 and Track B / PR #83 were accepted and merged through the protected PR path.
This PR is based on the resulting main:
`main@fcf684b0bbbb79aa38e58de9d3aa078af6e12ce6`.

This PR establishes `sky_app_core` as a pure Rust application/domain home without taking
ownership of current application services.

Final history is intentionally clean and contains one logical Track C commit:
`a6127fe48ff71355dfe2c7fe1ed0d386a030650e refactor: establish pure Rust application core foundation`.

Scope:

- retain an intentionally small architecture-only `sky_app_core` foundation;
- require future models/ports to arrive just-in-time with current-production behavior evidence
  and parity fixtures;
- keep the crate free of Tauri, PyO3, Win32, `sky_desktop_shell`, `sky_player`, filesystem,
  and network implementations;
- mechanically enforce the forbidden inward dependencies;
- preserve `#![forbid(unsafe_code)]`;
- do not introduce SettingsStore, SongSource, PlaybackEngine, UpdateGateway, EventSink,
  speculative event models, fake use cases, or subsystem ownership cutover.

Review boundary:

- no product/runtime behavior change is intended;
- exact artifact qualification remains mandatory on `main`;
- the Python runtime remains canonical and is NOT removed in this PR;
- no Settings, Catalog, Event Hub, updater-policy, playback, or other Wave 2 migration starts here;
- the single Track C commit is independently reviewable and revertible;
- this PR must not be merged automatically and is awaiting architectural acceptance.

The branch was rebuilt from the post-Track-B main history. Rejected speculative-domain history
and duplicated Track A/Track B commits are not part of this PR.
