### PR TITLE
test: stabilize post-merge player timing probes

### DIFF
--- a/rust/crates/sky_player/src/engine/tests.rs
+++ b/rust/crates/sky_player/src/engine/tests.rs
@@ -500,8 +500,17 @@ fn run_startup_first_physical_lead_probe(
         hook.first_physical_send_started.load(Ordering::Acquire) > 0,
         "startup probe did not reach physical dispatch: snapshot={snapshot:?}"
     );
-    if !session.snapshot().is_finished {
-        session.quit().expect("probe quit");
+    if !session.snapshot().is_finished
+        && let Err(error) = session.quit()
+    {
+        // The worker may finish between the state check and quit().  That is
+        // benign cleanup for this probe; any other quit failure must still
+        // fail the test rather than being hidden.
+        assert_eq!(
+            error, "session commands require a running worker",
+            "probe quit"
+        );
+        assert!(session.snapshot().is_finished, "probe quit after race");
     }
     assert!(session.join(Duration::from_secs(5)).expect("probe join"));
     serde_json::from_str(&session.take_telemetry_json().expect("telemetry JSON"))
@@ -5123,7 +5132,7 @@ fn mixed_same_key_retrigger_telemetry_preserves_two_events() {
     ];
     let schedule = sky_dispatch_core::compile::compile_runtime_intents(&actions, &[0x15, 0x16])
         .expect("valid disjoint mixed schedule");
-    let session = NativeDispatchSession::new(test_session_options(
+    let mut options = test_session_options(
         schedule,
         1,
         BackendConfig::Mock {
@@ -5131,8 +5140,14 @@ fn mixed_same_key_retrigger_telemetry_preserves_two_events() {
             latency_per_key_us: 0,
             fault_script: FaultInjectionScript::none(),
         },
-    ))
-    .expect("test session admission");
+    );
+    // This test asserts mixed-packet telemetry cardinality, not the production
+    // 500-us deadline policy.  Keep the real worker/QPC path, but give the
+    // Windows test runner enough scheduling margin that host preemption does
+    // not turn the telemetry assertion into an unrelated startup deadline
+    // failure.  Production configuration remains unchanged.
+    options.timing.down_late_grace_us = 20_000;
+    let session = NativeDispatchSession::new(options).expect("test session admission");
 
     start_with_test_wall_clock_slack(&session);
     assert!(session.join(Duration::from_secs(5)).expect("worker join"));

--- a/scripts/test_windows_updater_e2e.ps1
+++ b/scripts/test_windows_updater_e2e.ps1
@@ -911,14 +911,24 @@ Start-Sleep -Seconds $Seconds
         if ([string]::IsNullOrWhiteSpace($hostPath)) {
             throw "could not determine the current PowerShell host path"
         }
+        # Keep child PowerShell processes from inheriting the harness capture
+        # pipes.  Python's communicate() waits for those pipes to close, and a
+        # hosted Windows runner can otherwise retain them after this script's
+        # five-second polling contract has completed.
+        $writerStdout = Join-Path $root "writer-stdout.txt"
+        $writerStderr = Join-Path $root "writer-stderr.txt"
+        $holderStdout = Join-Path $root "holder-stdout.txt"
+        $holderStderr = Join-Path $root "holder-stderr.txt"
         $writerArguments = @(
             "-NoProfile", "-File", $writerScript, "-ResultPath", $resultPath, "-FinalPath", $finalPath
         )
         $writerLine = ($writerArguments | ForEach-Object { Quote-ProcessArgument ([string]$_) }) -join " "
-        $writer = Start-Process -FilePath $hostPath -ArgumentList $writerLine -WindowStyle Hidden -PassThru
+        $writer = Start-Process -FilePath $hostPath -ArgumentList $writerLine -WindowStyle Hidden `
+            -RedirectStandardOutput $writerStdout -RedirectStandardError $writerStderr -PassThru
         $holderArguments = @("-NoProfile", "-File", $holderScript, "-Seconds", "3")
         $holderLine = ($holderArguments | ForEach-Object { Quote-ProcessArgument ([string]$_) }) -join " "
-        $holder = Start-Process -FilePath $hostPath -ArgumentList $holderLine -WindowStyle Hidden -PassThru
+        $holder = Start-Process -FilePath $hostPath -ArgumentList $holderLine -WindowStyle Hidden `
+            -RedirectStandardOutput $holderStdout -RedirectStandardError $holderStderr -PassThru
         $scenario = [pscustomobject]@{ Name = "result-polling-self-test"; Local = $local }
         $runInfo = [pscustomobject]@{ Process = $holder }
         $observed = Wait-ForUpdaterResult $scenario $runInfo "failure" "RESTART_FAILED" 5


### PR DESCRIPTION
Fixes the post-merge Rust verification failure observed in workflow 33381228198. Adds test-only scheduling margin to the telemetry-cardinality probe and makes startup-probe cleanup race-safe while preserving production timing/realtime configuration. Local validation: cargo fmt, strict sky_player clippy, repeated sky_player suite (236/236), and scripts/check.py rust pass. No production behavior change intended.