### PR TITLE
refactor: cut over native desktop ownership

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ desktop-runtime = [
     "tauri/x11",
     "tauri/dbus",
 ]
-tauri-test = ["tauri/test"]
+tauri-test = ["tauri/test", "sky_player/test-support"]
 
 [lib]
 name = "sky_desktop_shell_lib"
@@ -32,6 +32,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "=2.11.5", default-features = false, features = [] }
 sky_dispatch_win32 = { path = "../../rust/crates/sky_dispatch_win32" }
+sky_player = { path = "../../rust/crates/sky_player" }
+sha2 = "0.11"
+smallvec = "1"
+sky_app_core = { path = "../../rust/crates/sky_app_core" }
+sky_native_adapters = { path = "../../rust/crates/sky_native_adapters" }
 sky_updater = { path = "../../rust/crates/sky_updater" }
 ts-rs = { version = "=12.0.1", features = ["serde-json-impl"] }
 thiserror = "2"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -40,3 +40,4 @@ sky_native_adapters = { path = "../../rust/crates/sky_native_adapters" }
 sky_updater = { path = "../../rust/crates/sky_updater" }
 ts-rs = { version = "=12.0.1", features = ["serde-json-impl"] }
 thiserror = "2"
+getrandom = "0.3"

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -1,4 +1,5 @@
 use crate::core::CoreSupervisor;
+use crate::native_runtime::NativeDesktopRuntime;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, mpsc};
 
@@ -9,6 +10,7 @@ pub struct AppState {
 
 struct AppStateInner {
     core: Mutex<CoreState>,
+    native: Mutex<Option<Arc<NativeDesktopRuntime>>>,
     settings_writes: Mutex<()>,
     closing: AtomicBool,
     gui_smoke_exit: AtomicBool,
@@ -27,6 +29,7 @@ impl Default for AppState {
         Self {
             inner: Arc::new(AppStateInner {
                 core: Mutex::new(CoreState::Idle),
+                native: Mutex::new(None),
                 settings_writes: Mutex::new(()),
                 closing: AtomicBool::new(false),
                 gui_smoke_exit: AtomicBool::new(false),
@@ -37,6 +40,30 @@ impl Default for AppState {
 }
 
 impl AppState {
+    /// Lazily construct the single native application runtime.  Production
+    /// commands use this path; Core startup remains available only for the
+    /// transitional Python-owned/test protocol surface.
+    pub(crate) fn ensure_native_blocking(&self) -> Result<Arc<NativeDesktopRuntime>, String> {
+        if self.is_closing() {
+            return Err("Desktop application is closing".into());
+        }
+        let mut native = self.inner.native.lock().expect("native state poisoned");
+        if let Some(runtime) = &*native {
+            return Ok(Arc::clone(runtime));
+        }
+        let runtime = Arc::new(NativeDesktopRuntime::for_current_install()?);
+        *native = Some(Arc::clone(&runtime));
+        Ok(runtime)
+    }
+
+    pub fn shutdown_native(&self) {
+        if let Ok(native) = self.inner.native.lock()
+            && let Some(runtime) = &*native
+        {
+            runtime.shutdown();
+        }
+    }
+
     /// Start the Core at most once and let concurrent callers share its result.
     /// The caller must invoke this from a blocking worker because Core startup
     /// waits for the child process readiness event.

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -1,5 +1,6 @@
 use crate::core::CoreSupervisor;
 use crate::core::protocol::CoreEvent;
+use crate::core::supervisor::CoreEventObserver;
 use crate::native_runtime::NativeDesktopRuntime;
 use crate::ui_events::CalibrationOutcome;
 use std::collections::VecDeque;
@@ -156,11 +157,27 @@ struct AppStateInner {
     native: Mutex<Option<Arc<NativeDesktopRuntime>>>,
     settings_writes: Mutex<()>,
     coherence: Mutex<()>,
-    pending_core_events: Mutex<VecDeque<crate::ui_events::UiEvent>>,
+    core_event_route: Mutex<CoreEventRoute>,
     activity: ActivityCoordinator,
     closing: AtomicBool,
     gui_smoke_exit: AtomicBool,
     gui_smoke_failed: AtomicBool,
+}
+
+#[derive(Default)]
+struct CoreEventRoute {
+    phase: CoreEventRoutePhase,
+    queue: VecDeque<crate::ui_events::UiEvent>,
+    draining: bool,
+}
+
+#[derive(Default)]
+enum CoreEventRoutePhase {
+    #[default]
+    Pending,
+    Transitioning,
+    Live(Arc<NativeDesktopRuntime>),
+    Failed,
 }
 
 enum CoreState {
@@ -178,7 +195,7 @@ impl Default for AppState {
                 native: Mutex::new(None),
                 settings_writes: Mutex::new(()),
                 coherence: Mutex::new(()),
-                pending_core_events: Mutex::new(VecDeque::new()),
+                core_event_route: Mutex::new(CoreEventRoute::default()),
                 activity: ActivityCoordinator {
                     state: Arc::new(Mutex::new(ActivityState::default())),
                 },
@@ -271,34 +288,65 @@ impl AppState {
             runtime.invalidate_prepared_for_calibration();
         }
         self.inner.activity.observe_core_event(event);
-        let ui_event = event.clone().into_ui_event();
-        if let Some(runtime) = self.native_if_present() {
-            if runtime.relay_core_event(ui_event).is_err() {
-                // A failed UI delivery must not leave the cross-owner
-                // calibration reservation held forever.  The native hub has
-                // already entered its fail-closed state.
-                self.inner.activity.release_calibration();
-                return Err("unified UI event delivery failed".into());
+        self.queue_core_event(event.clone().into_ui_event())
+    }
+
+    pub(crate) fn begin_core_event_route_transition(&self) -> Result<(), String> {
+        let mut route = self
+            .inner
+            .core_event_route
+            .lock()
+            .map_err(|_| "Core event route poisoned".to_string())?;
+        match &route.phase {
+            CoreEventRoutePhase::Pending => {
+                route.phase = CoreEventRoutePhase::Transitioning;
+                Ok(())
             }
-        } else {
-            self.queue_core_event(ui_event)?;
+            CoreEventRoutePhase::Transitioning => {
+                Err("Core event route transition already in progress".into())
+            }
+            CoreEventRoutePhase::Live(_) => Err("Core event route is already live".into()),
+            CoreEventRoutePhase::Failed => Err("Core event route is failed closed".into()),
+        }
+    }
+
+    pub(crate) fn complete_core_event_route_transition(
+        &self,
+        native: Arc<NativeDesktopRuntime>,
+    ) -> Result<(), String> {
+        let should_drain = {
+            let mut route = self
+                .inner
+                .core_event_route
+                .lock()
+                .map_err(|_| "Core event route poisoned".to_string())?;
+            if !matches!(&route.phase, CoreEventRoutePhase::Transitioning) {
+                return Err("Core event route was not transitioning".into());
+            }
+            route.phase = CoreEventRoutePhase::Live(native);
+            if route.queue.is_empty() || route.draining {
+                false
+            } else {
+                route.draining = true;
+                true
+            }
+        };
+        if should_drain {
+            self.drain_core_event_route()?;
         }
         Ok(())
     }
 
-    pub(crate) fn take_pending_core_events(
-        &self,
-    ) -> Result<Vec<crate::ui_events::UiEvent>, String> {
-        let mut pending = self
-            .inner
-            .pending_core_events
-            .lock()
-            .map_err(|_| "pending Core event queue poisoned".to_string())?;
-        Ok(pending.drain(..).collect())
+    pub(crate) fn fail_core_event_route(&self) {
+        if let Ok(mut route) = self.inner.core_event_route.lock() {
+            route.phase = CoreEventRoutePhase::Failed;
+            route.queue.clear();
+            route.draining = false;
+        }
     }
 
     fn queue_core_event(&self, event: crate::ui_events::UiEvent) -> Result<(), String> {
-        const MAX_PENDING_CORE_EVENTS: usize = 128;
+        const MAX_CORE_ROUTE_EVENTS: usize = 128;
         let snapshot_key = match &event {
             crate::ui_events::UiEvent::PlaybackSnapshot { payload, .. } => {
                 Some((1_u8, payload.session_id.clone()))
@@ -311,48 +359,115 @@ impl AppState {
             }
             _ => None,
         };
-        let mut pending = self
-            .inner
-            .pending_core_events
-            .lock()
-            .map_err(|_| "pending Core event queue poisoned".to_string())?;
-        if let Some(key) = snapshot_key {
-            if let Some(index) = pending.iter().position(|candidate| {
-                let candidate_key = match candidate {
-                    crate::ui_events::UiEvent::PlaybackSnapshot { payload, .. } => {
-                        Some((1_u8, payload.session_id.clone()))
-                    }
-                    crate::ui_events::UiEvent::DiagnosticsSnapshot { payload, .. } => {
-                        Some((2_u8, payload.session_id.clone().unwrap_or_default()))
-                    }
-                    crate::ui_events::UiEvent::CalibrationProgress { payload, .. } => {
-                        Some((3_u8, payload.operation_id.clone()))
-                    }
-                    _ => None,
-                };
-                candidate_key == Some(key.clone())
-            }) {
-                pending[index] = event;
-                return Ok(());
+        let should_drain = {
+            let mut route = self
+                .inner
+                .core_event_route
+                .lock()
+                .map_err(|_| "Core event route poisoned".to_string())?;
+            if matches!(&route.phase, CoreEventRoutePhase::Failed) {
+                return Err("unified UI event delivery failed".into());
             }
-            if pending.len() >= MAX_PENDING_CORE_EVENTS
-                && let Some(index) = pending.iter().position(|candidate| {
-                    matches!(
-                        candidate,
-                        crate::ui_events::UiEvent::PlaybackSnapshot { .. }
-                            | crate::ui_events::UiEvent::DiagnosticsSnapshot { .. }
-                            | crate::ui_events::UiEvent::CalibrationProgress { .. }
-                    )
-                })
-            {
-                pending.remove(index);
+            if let Some(key) = snapshot_key {
+                if let Some(index) = route.queue.iter().position(|candidate| {
+                    let candidate_key = match candidate {
+                        crate::ui_events::UiEvent::PlaybackSnapshot { payload, .. } => {
+                            Some((1_u8, payload.session_id.clone()))
+                        }
+                        crate::ui_events::UiEvent::DiagnosticsSnapshot { payload, .. } => {
+                            Some((2_u8, payload.session_id.clone().unwrap_or_default()))
+                        }
+                        crate::ui_events::UiEvent::CalibrationProgress { payload, .. } => {
+                            Some((3_u8, payload.operation_id.clone()))
+                        }
+                        _ => None,
+                    };
+                    candidate_key == Some(key.clone())
+                }) {
+                    route.queue[index] = event;
+                    false
+                } else {
+                    if route.queue.len() >= MAX_CORE_ROUTE_EVENTS
+                        && let Some(index) = route.queue.iter().position(|candidate| {
+                            matches!(
+                                candidate,
+                                crate::ui_events::UiEvent::PlaybackSnapshot { .. }
+                                    | crate::ui_events::UiEvent::DiagnosticsSnapshot { .. }
+                                    | crate::ui_events::UiEvent::CalibrationProgress { .. }
+                            )
+                        })
+                    {
+                        route.queue.remove(index);
+                    }
+                    if route.queue.len() >= MAX_CORE_ROUTE_EVENTS {
+                        route.phase = CoreEventRoutePhase::Failed;
+                        return Err("Core lifecycle event buffer overflow".into());
+                    }
+                    route.queue.push_back(event);
+                    if matches!(&route.phase, CoreEventRoutePhase::Live(_)) && !route.draining {
+                        route.draining = true;
+                        true
+                    } else {
+                        false
+                    }
+                }
+            } else {
+                if route.queue.len() >= MAX_CORE_ROUTE_EVENTS
+                    && let Some(index) = route.queue.iter().position(|candidate| {
+                        matches!(
+                            candidate,
+                            crate::ui_events::UiEvent::PlaybackSnapshot { .. }
+                                | crate::ui_events::UiEvent::DiagnosticsSnapshot { .. }
+                                | crate::ui_events::UiEvent::CalibrationProgress { .. }
+                        )
+                    })
+                {
+                    route.queue.remove(index);
+                }
+                if route.queue.len() >= MAX_CORE_ROUTE_EVENTS {
+                    route.phase = CoreEventRoutePhase::Failed;
+                    return Err("Core lifecycle event buffer overflow".into());
+                }
+                route.queue.push_back(event);
+                if matches!(&route.phase, CoreEventRoutePhase::Live(_)) && !route.draining {
+                    route.draining = true;
+                    true
+                } else {
+                    false
+                }
             }
+        };
+        if should_drain {
+            self.drain_core_event_route()?;
         }
-        if pending.len() >= MAX_PENDING_CORE_EVENTS {
-            return Err("pending Core lifecycle event buffer overflow".into());
-        }
-        pending.push_back(event);
         Ok(())
+    }
+
+    fn drain_core_event_route(&self) -> Result<(), String> {
+        loop {
+            let next = {
+                let mut route = self
+                    .inner
+                    .core_event_route
+                    .lock()
+                    .map_err(|_| "Core event route poisoned".to_string())?;
+                let CoreEventRoutePhase::Live(native) = &route.phase else {
+                    route.draining = false;
+                    return Ok(());
+                };
+                let native = Arc::clone(native);
+                let Some(event) = route.queue.pop_front() else {
+                    route.draining = false;
+                    return Ok(());
+                };
+                (native, event)
+            };
+            if next.0.relay_core_event(next.1).is_err() {
+                self.fail_core_event_route();
+                self.inner.activity.release_calibration();
+                return Err("unified UI event delivery failed".into());
+            }
+        }
     }
 
     /// Start the Core at most once and let concurrent callers share its result.
@@ -403,14 +518,18 @@ impl AppState {
             }
             Ok(supervisor) => {
                 let weak_inner = Arc::downgrade(&self.inner);
-                supervisor.set_event_observer(Arc::new(move |event| {
+                let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
                     if let Some(inner) = weak_inner.upgrade() {
                         let state = AppState { inner };
                         state.observe_core_event(event)
                     } else {
                         Err("desktop state was dropped".into())
                     }
-                }));
+                });
+                if let Err(error) = supervisor.install_event_observer_and_drain(observer) {
+                    supervisor.shutdown();
+                    return Err(error);
+                }
                 let weak_inner = Arc::downgrade(&self.inner);
                 supervisor.set_failure_observer(Arc::new(move || {
                     if let Some(inner) = weak_inner.upgrade() {
@@ -505,6 +624,13 @@ impl AppState {
 mod tests {
     use super::{ActivityCoordinator, AppState};
     use crate::core::protocol::CoreEvent;
+    use crate::native_runtime::NativeDesktopRuntime;
+    use crate::ui_events::{CalibrationFinishedPayload, CalibrationOutcome, CatalogChangedPayload};
+    use serde_json::Value;
+    use std::fs;
+    use std::sync::{Arc, Mutex, mpsc};
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
     fn close_transition_is_idempotent() {
@@ -631,5 +757,277 @@ mod tests {
             let calibration_won = calibration_result.is_ok();
             assert_ne!(playback_won, calibration_won);
         }
+    }
+
+    #[test]
+    fn core_route_replays_backlog_before_transition_and_live_events() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-core-route-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        let native =
+            Arc::new(NativeDesktopRuntime::from_install_root(root.clone()).expect("native"));
+        let state = AppState::default();
+
+        let catalog_event = |generation| {
+            CoreEvent::CatalogChanged(CatalogChangedPayload {
+                generation,
+                total: generation,
+            })
+        };
+        // Event one is the pre-observer/backlog equivalent. Event two arrives
+        // after the route enters Transitioning, and event three is live.
+        state
+            .observe_core_event(&catalog_event(1))
+            .expect("backlog event");
+        state
+            .begin_core_event_route_transition()
+            .expect("begin route transition");
+        state
+            .observe_core_event(&catalog_event(2))
+            .expect("transition event");
+
+        let delivered = Arc::new(Mutex::new(Vec::new()));
+        let delivered_for_channel = Arc::clone(&delivered);
+        let channel = tauri::ipc::Channel::<crate::ui_events::UiEvent>::new(move |body| {
+            let raw = match body {
+                tauri::ipc::InvokeResponseBody::Json(raw) => raw,
+                tauri::ipc::InvokeResponseBody::Raw(raw) => {
+                    String::from_utf8(raw).map_err(|error| tauri::Error::Anyhow(error.into()))?
+                }
+            };
+            let value: Value =
+                serde_json::from_str(&raw).map_err(|error| tauri::Error::Anyhow(error.into()))?;
+            delivered_for_channel
+                .lock()
+                .expect("delivered events")
+                .push(value["payload"]["generation"].as_u64().expect("generation"));
+            Ok(())
+        });
+        native.subscribe(channel).expect("native subscription");
+
+        let complete_state = state.clone();
+        let complete_native = Arc::clone(&native);
+        let complete = thread::spawn(move || {
+            complete_state.complete_core_event_route_transition(complete_native)
+        });
+        complete
+            .join()
+            .expect("route transition thread")
+            .expect("route complete");
+        state
+            .observe_core_event(&catalog_event(3))
+            .expect("live event");
+
+        assert_eq!(*delivered.lock().expect("delivered events"), vec![1, 2, 3]);
+        native.shutdown();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn core_route_serializes_live_delivery_while_backlog_drain_is_in_flight() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-core-route-drain-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        let native =
+            Arc::new(NativeDesktopRuntime::from_install_root(root.clone()).expect("native"));
+        let state = AppState::default();
+        let catalog_event = |generation| {
+            CoreEvent::CatalogChanged(CatalogChangedPayload {
+                generation,
+                total: generation,
+            })
+        };
+        state
+            .observe_core_event(&catalog_event(1))
+            .expect("backlog event");
+        state
+            .begin_core_event_route_transition()
+            .expect("begin route transition");
+
+        let delivered = Arc::new(Mutex::new(Vec::new()));
+        let delivered_for_channel = Arc::clone(&delivered);
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let release_receiver = Arc::new(Mutex::new(release_receiver));
+        let release_receiver_for_channel = Arc::clone(&release_receiver);
+        let channel = tauri::ipc::Channel::<crate::ui_events::UiEvent>::new(move |body| {
+            let raw = match body {
+                tauri::ipc::InvokeResponseBody::Json(raw) => raw,
+                tauri::ipc::InvokeResponseBody::Raw(raw) => {
+                    String::from_utf8(raw).map_err(|error| tauri::Error::Anyhow(error.into()))?
+                }
+            };
+            let value: Value =
+                serde_json::from_str(&raw).map_err(|error| tauri::Error::Anyhow(error.into()))?;
+            delivered_for_channel
+                .lock()
+                .expect("delivered events")
+                .push(value["payload"]["generation"].as_u64().expect("generation"));
+            if value["payload"]["generation"] == 1 {
+                entered_sender.send(()).expect("entered receiver");
+                release_receiver_for_channel
+                    .lock()
+                    .expect("release receiver")
+                    .recv()
+                    .expect("release sender");
+            }
+            Ok(())
+        });
+        native.subscribe(channel).expect("native subscription");
+
+        let complete_state = state.clone();
+        let complete_native = Arc::clone(&native);
+        let complete = thread::spawn(move || {
+            complete_state.complete_core_event_route_transition(complete_native)
+        });
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("backlog drain entered");
+
+        let live_state = state.clone();
+        let live = thread::spawn(move || live_state.observe_core_event(&catalog_event(2)));
+        // The route drain owns delivery of event one, but the route lock is
+        // released before invoking the Channel. Event two can therefore join
+        // the ordered queue without overtaking event one.
+        live.join().expect("live event thread").expect("live event");
+        release_sender.send(()).expect("release drain");
+        complete
+            .join()
+            .expect("route transition thread")
+            .expect("route complete");
+        assert_eq!(*delivered.lock().expect("delivered events"), vec![1, 2]);
+        native.shutdown();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn settings_patch_and_native_start_share_one_linearization_gate() {
+        let state = Arc::new(AppState::default());
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let (patch_entered_sender, patch_entered_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let patch_state = Arc::clone(&state);
+        let patch_order = Arc::clone(&order);
+        let patch = thread::spawn(move || {
+            let _guard = patch_state.lock_coherence();
+            patch_entered_sender.send(()).expect("patch entered");
+            release_receiver.recv().expect("release patch");
+            patch_order.lock().expect("order").push("settings.patch");
+        });
+        patch_entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("patch gate entered");
+
+        let (start_entered_sender, start_entered_receiver) = mpsc::channel();
+        let start_state = Arc::clone(&state);
+        let start_order = Arc::clone(&order);
+        let start = thread::spawn(move || {
+            let _guard = start_state.lock_coherence();
+            start_entered_sender.send(()).expect("start entered");
+            start_order.lock().expect("order").push("playback.start");
+        });
+        assert!(
+            start_entered_receiver
+                .recv_timeout(Duration::from_millis(50))
+                .is_err()
+        );
+        release_sender.send(()).expect("release patch");
+        start_entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("start gate entered");
+        patch.join().expect("patch thread");
+        start.join().expect("start thread");
+        assert_eq!(
+            *order.lock().expect("order"),
+            vec!["settings.patch", "playback.start"]
+        );
+    }
+
+    #[test]
+    fn calibration_success_invalidates_native_prepared_plan_before_release() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-calibration-invalidation-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        fs::write(
+            root.join("songs/demo.json"),
+            r#"{"name":"Demo","songNotes":[{"time":0,"key":"Key0"}]}"#,
+        )
+        .expect("song");
+        let native =
+            Arc::new(NativeDesktopRuntime::from_install_root(root.clone()).expect("native"));
+        let state = AppState::default();
+        *state.inner.native.lock().expect("native state") = Some(Arc::clone(&native));
+        let bootstrap = native.bootstrap().expect("bootstrap");
+        let search: crate::commands::CatalogSearchDto = serde_json::from_value(
+            native
+                .dispatch(
+                    "catalog.search",
+                    serde_json::json!({
+                        "query": "",
+                        "offset": 0,
+                        "limit": 10,
+                        "generation": bootstrap.catalog_generation
+                    }),
+                )
+                .expect("search"),
+        )
+        .expect("search DTO");
+        let prepared = native
+            .dispatch(
+                "playback.prepare",
+                serde_json::json!({
+                    "song_id": search.items[0].song_id,
+                    "generation": bootstrap.catalog_generation,
+                    "config": {"hold_frames":1.0,"tempo_scale":1.0,"fps":60,"dry_run":true}
+                }),
+            )
+            .expect("prepare");
+        let prepared_id = prepared["prepared_id"]
+            .as_str()
+            .expect("prepared ID")
+            .to_owned();
+        let reservation = state
+            .activity()
+            .reserve_calibration()
+            .expect("calibration slot");
+        reservation.commit();
+
+        state
+            .observe_core_event(&CoreEvent::CalibrationFinished(
+                CalibrationFinishedPayload {
+                    operation_id: "a".repeat(32),
+                    outcome: CalibrationOutcome::Succeeded,
+                    status: "succeeded".into(),
+                    margin_us: Some(777),
+                    sample_count: 10,
+                    source: "fixture".into(),
+                    message: "published".into(),
+                    applied: true,
+                },
+            ))
+            .expect("calibration event");
+        assert!(!state.activity().is_calibration_active());
+        assert!(
+            native
+                .dispatch(
+                    "playback.start",
+                    serde_json::json!({"prepared_id":prepared_id,"decisions":[]}),
+                )
+                .is_err()
+        );
+        native.shutdown();
+        let _ = fs::remove_dir_all(root);
     }
 }

--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -1,7 +1,150 @@
 use crate::core::CoreSupervisor;
+use crate::core::protocol::CoreEvent;
 use crate::native_runtime::NativeDesktopRuntime;
+use crate::ui_events::CalibrationOutcome;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, mpsc};
+
+/// Single non-realtime admission authority for operations that can own the
+/// physical input/calibration boundary.  The Python Core and native runtime
+/// are separate processes/owners during the strangler phase, so two local
+/// booleans cannot safely implement this contract.
+#[derive(Clone)]
+pub(crate) struct ActivityCoordinator {
+    state: Arc<Mutex<ActivityState>>,
+}
+
+impl Default for ActivityCoordinator {
+    fn default() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(ActivityState::default())),
+        }
+    }
+}
+
+#[derive(Default)]
+struct ActivityState {
+    physical_playback: Option<String>,
+    calibration_active: bool,
+    closing: bool,
+}
+
+pub(crate) struct PhysicalActivityLease {
+    coordinator: ActivityCoordinator,
+    session_id: String,
+}
+
+impl Drop for PhysicalActivityLease {
+    fn drop(&mut self) {
+        self.coordinator.release_playback(&self.session_id);
+    }
+}
+
+impl ActivityCoordinator {
+    pub(crate) fn reserve_playback(
+        &self,
+        session_id: impl Into<String>,
+    ) -> Result<PhysicalActivityLease, String> {
+        let session_id = session_id.into();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "activity gate poisoned".to_string())?;
+        if state.closing {
+            return Err("desktop application is closing".into());
+        }
+        if state.calibration_active {
+            return Err("calibration is active".into());
+        }
+        if state.physical_playback.is_some() {
+            return Err("another physical playback session is active".into());
+        }
+        state.physical_playback = Some(session_id.clone());
+        Ok(PhysicalActivityLease {
+            coordinator: self.clone(),
+            session_id,
+        })
+    }
+
+    pub(crate) fn reserve_calibration(&self) -> Result<CalibrationReservation, String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "activity gate poisoned".to_string())?;
+        if state.closing {
+            return Err("desktop application is closing".into());
+        }
+        if state.calibration_active {
+            return Err("a calibration operation is already active".into());
+        }
+        if state.physical_playback.is_some() {
+            return Err("calibration cannot run during physical playback".into());
+        }
+        state.calibration_active = true;
+        Ok(CalibrationReservation {
+            coordinator: self.clone(),
+            committed: false,
+        })
+    }
+
+    fn release_playback(&self, session_id: &str) {
+        if let Ok(mut state) = self.state.lock()
+            && state.physical_playback.as_deref() == Some(session_id)
+        {
+            state.physical_playback = None;
+        }
+    }
+
+    pub(crate) fn release_calibration(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.calibration_active = false;
+        }
+    }
+
+    pub(crate) fn observe_core_event(&self, event: &CoreEvent) {
+        match event {
+            CoreEvent::CalibrationFinished(_) => self.release_calibration(),
+            CoreEvent::Fatal(_) => self.release_calibration(),
+            _ => {}
+        }
+    }
+
+    pub(crate) fn begin_shutdown(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.closing = true;
+            state.physical_playback = None;
+            state.calibration_active = false;
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_calibration_active(&self) -> bool {
+        self.state
+            .lock()
+            .map(|state| state.calibration_active)
+            .unwrap_or(true)
+    }
+}
+
+pub(crate) struct CalibrationReservation {
+    coordinator: ActivityCoordinator,
+    committed: bool,
+}
+
+impl CalibrationReservation {
+    pub(crate) fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for CalibrationReservation {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.coordinator.release_calibration();
+        }
+    }
+}
 
 #[derive(Clone)]
 pub struct AppState {
@@ -12,6 +155,9 @@ struct AppStateInner {
     core: Mutex<CoreState>,
     native: Mutex<Option<Arc<NativeDesktopRuntime>>>,
     settings_writes: Mutex<()>,
+    coherence: Mutex<()>,
+    pending_core_events: Mutex<VecDeque<crate::ui_events::UiEvent>>,
+    activity: ActivityCoordinator,
     closing: AtomicBool,
     gui_smoke_exit: AtomicBool,
     gui_smoke_failed: AtomicBool,
@@ -31,6 +177,11 @@ impl Default for AppState {
                 core: Mutex::new(CoreState::Idle),
                 native: Mutex::new(None),
                 settings_writes: Mutex::new(()),
+                coherence: Mutex::new(()),
+                pending_core_events: Mutex::new(VecDeque::new()),
+                activity: ActivityCoordinator {
+                    state: Arc::new(Mutex::new(ActivityState::default())),
+                },
                 closing: AtomicBool::new(false),
                 gui_smoke_exit: AtomicBool::new(false),
                 gui_smoke_failed: AtomicBool::new(false),
@@ -51,7 +202,9 @@ impl AppState {
         if let Some(runtime) = &*native {
             return Ok(Arc::clone(runtime));
         }
-        let runtime = Arc::new(NativeDesktopRuntime::for_current_install()?);
+        let runtime = Arc::new(NativeDesktopRuntime::for_current_install_with_activity(
+            self.activity(),
+        )?);
         *native = Some(Arc::clone(&runtime));
         Ok(runtime)
     }
@@ -60,8 +213,146 @@ impl AppState {
         if let Ok(native) = self.inner.native.lock()
             && let Some(runtime) = &*native
         {
-            runtime.shutdown();
+            let _ = runtime.dispatch("app.shutdown", serde_json::json!({}));
         }
+    }
+
+    pub(crate) fn activity(&self) -> ActivityCoordinator {
+        self.inner.activity.clone()
+    }
+
+    pub(crate) fn native_if_present(&self) -> Option<Arc<NativeDesktopRuntime>> {
+        self.inner
+            .native
+            .lock()
+            .ok()
+            .and_then(|runtime| runtime.as_ref().cloned())
+    }
+
+    /// Complete the cross-process settings mutation barrier after the Python
+    /// owner has committed its atomic config write.  The caller holds the
+    /// shared coherence lock, so a Native start cannot observe the write
+    /// between the Python response and this invalidation.
+    pub(crate) fn invalidate_native_after_python_settings_patch(&self) {
+        if let Some(native) = self.native_if_present() {
+            native.invalidate_prepared_for_external_mutation();
+        }
+    }
+
+    pub(crate) fn lock_coherence(&self) -> MutexGuard<'_, ()> {
+        self.inner
+            .coherence
+            .lock()
+            .expect("coherence gate poisoned")
+    }
+
+    pub(crate) fn observe_core_event(&self, event: &CoreEvent) -> Result<(), String> {
+        // Terminal calibration events are the linearization point between the
+        // Python-owned calibration operation and a Native playback start.  Do
+        // not release the activity slot first and invalidate prepared plans
+        // later: a waiting start could otherwise acquire the slot and consume
+        // the old plan in that gap.  The same non-realtime coherence gate is
+        // used by settings.patch/playback.start.
+        let calibration_terminal = matches!(event, CoreEvent::CalibrationFinished(_));
+        let _coherence_guard = calibration_terminal.then(|| self.lock_coherence());
+        let calibration_succeeded = matches!(
+            event,
+            CoreEvent::CalibrationFinished(payload)
+                if payload.outcome == CalibrationOutcome::Succeeded
+        );
+        // Invalidate first, then release the shared slot.  Native playback
+        // start is serialized by the same coherence gate, so no caller can
+        // acquire the released slot while an old prepared plan is still
+        // usable.
+        if calibration_succeeded
+            && let Ok(native) = self.inner.native.lock()
+            && let Some(runtime) = &*native
+        {
+            runtime.invalidate_prepared_for_calibration();
+        }
+        self.inner.activity.observe_core_event(event);
+        let ui_event = event.clone().into_ui_event();
+        if let Some(runtime) = self.native_if_present() {
+            if runtime.relay_core_event(ui_event).is_err() {
+                // A failed UI delivery must not leave the cross-owner
+                // calibration reservation held forever.  The native hub has
+                // already entered its fail-closed state.
+                self.inner.activity.release_calibration();
+                return Err("unified UI event delivery failed".into());
+            }
+        } else {
+            self.queue_core_event(ui_event)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn take_pending_core_events(
+        &self,
+    ) -> Result<Vec<crate::ui_events::UiEvent>, String> {
+        let mut pending = self
+            .inner
+            .pending_core_events
+            .lock()
+            .map_err(|_| "pending Core event queue poisoned".to_string())?;
+        Ok(pending.drain(..).collect())
+    }
+
+    fn queue_core_event(&self, event: crate::ui_events::UiEvent) -> Result<(), String> {
+        const MAX_PENDING_CORE_EVENTS: usize = 128;
+        let snapshot_key = match &event {
+            crate::ui_events::UiEvent::PlaybackSnapshot { payload, .. } => {
+                Some((1_u8, payload.session_id.clone()))
+            }
+            crate::ui_events::UiEvent::DiagnosticsSnapshot { payload, .. } => {
+                Some((2_u8, payload.session_id.clone().unwrap_or_default()))
+            }
+            crate::ui_events::UiEvent::CalibrationProgress { payload, .. } => {
+                Some((3_u8, payload.operation_id.clone()))
+            }
+            _ => None,
+        };
+        let mut pending = self
+            .inner
+            .pending_core_events
+            .lock()
+            .map_err(|_| "pending Core event queue poisoned".to_string())?;
+        if let Some(key) = snapshot_key {
+            if let Some(index) = pending.iter().position(|candidate| {
+                let candidate_key = match candidate {
+                    crate::ui_events::UiEvent::PlaybackSnapshot { payload, .. } => {
+                        Some((1_u8, payload.session_id.clone()))
+                    }
+                    crate::ui_events::UiEvent::DiagnosticsSnapshot { payload, .. } => {
+                        Some((2_u8, payload.session_id.clone().unwrap_or_default()))
+                    }
+                    crate::ui_events::UiEvent::CalibrationProgress { payload, .. } => {
+                        Some((3_u8, payload.operation_id.clone()))
+                    }
+                    _ => None,
+                };
+                candidate_key == Some(key.clone())
+            }) {
+                pending[index] = event;
+                return Ok(());
+            }
+            if pending.len() >= MAX_PENDING_CORE_EVENTS
+                && let Some(index) = pending.iter().position(|candidate| {
+                    matches!(
+                        candidate,
+                        crate::ui_events::UiEvent::PlaybackSnapshot { .. }
+                            | crate::ui_events::UiEvent::DiagnosticsSnapshot { .. }
+                            | crate::ui_events::UiEvent::CalibrationProgress { .. }
+                    )
+                })
+            {
+                pending.remove(index);
+            }
+        }
+        if pending.len() >= MAX_PENDING_CORE_EVENTS {
+            return Err("pending Core lifecycle event buffer overflow".into());
+        }
+        pending.push_back(event);
+        Ok(())
     }
 
     /// Start the Core at most once and let concurrent callers share its result.
@@ -110,7 +401,28 @@ impl AppState {
                 supervisor.shutdown();
                 Err("Desktop application is closing".into())
             }
-            result => result,
+            Ok(supervisor) => {
+                let weak_inner = Arc::downgrade(&self.inner);
+                supervisor.set_event_observer(Arc::new(move |event| {
+                    if let Some(inner) = weak_inner.upgrade() {
+                        let state = AppState { inner };
+                        state.observe_core_event(event)
+                    } else {
+                        Err("desktop state was dropped".into())
+                    }
+                }));
+                let weak_inner = Arc::downgrade(&self.inner);
+                supervisor.set_failure_observer(Arc::new(move || {
+                    if let Some(inner) = weak_inner.upgrade() {
+                        // An abrupt Core exit has no trustworthy terminal
+                        // calibration event. Release the shared admission
+                        // slot so the shell cannot remain permanently locked.
+                        inner.activity.release_calibration();
+                    }
+                }));
+                Ok(supervisor)
+            }
+            Err(error) => Err(error),
         };
         let mut state = self.inner.core.lock().expect("desktop state poisoned");
         let waiters = match std::mem::replace(&mut *state, CoreState::Idle) {
@@ -147,7 +459,11 @@ impl AppState {
     }
 
     pub fn begin_close(&self) -> bool {
-        !self.inner.closing.swap(true, Ordering::AcqRel)
+        let first = !self.inner.closing.swap(true, Ordering::AcqRel);
+        if first {
+            self.inner.activity.begin_shutdown();
+        }
+        first
     }
 
     pub fn set_gui_smoke_exit(&self, enabled: bool) {
@@ -187,7 +503,8 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::AppState;
+    use super::{ActivityCoordinator, AppState};
+    use crate::core::protocol::CoreEvent;
 
     #[test]
     fn close_transition_is_idempotent() {
@@ -240,5 +557,79 @@ mod tests {
             Err(error) => error,
         };
         assert_eq!(error, "Desktop application is closing");
+    }
+
+    #[test]
+    fn physical_playback_and_calibration_are_one_atomic_exclusion_gate() {
+        let state = AppState::default();
+        let activity = state.activity();
+        let playback = activity
+            .reserve_playback("session")
+            .expect("playback lease");
+        assert!(activity.reserve_calibration().is_err());
+        drop(playback);
+        let calibration = activity.reserve_calibration().expect("calibration slot");
+        assert!(activity.reserve_playback("other").is_err());
+        calibration.commit();
+        activity.release_calibration();
+        let playback = activity.reserve_playback("other").expect("released slot");
+        drop(playback);
+        assert!(!activity.is_calibration_active());
+    }
+
+    #[test]
+    fn terminal_core_calibration_event_releases_the_shared_activity_slot() {
+        let state = AppState::default();
+        let reservation = state.activity().reserve_calibration().expect("slot");
+        reservation.commit();
+        assert!(state.activity().is_calibration_active());
+
+        state
+            .observe_core_event(&CoreEvent::CalibrationFinished(
+                crate::ui_events::CalibrationFinishedPayload {
+                    operation_id: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+                    outcome: crate::ui_events::CalibrationOutcome::Failed,
+                    status: "failed".into(),
+                    margin_us: None,
+                    sample_count: 0,
+                    source: "none".into(),
+                    message: "test failure".into(),
+                    applied: false,
+                },
+            ))
+            .expect("event is relayed/queued");
+        assert!(!state.activity().is_calibration_active());
+    }
+
+    #[test]
+    fn concurrent_playback_and_calibration_reservation_has_one_winner() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        for _ in 0..64 {
+            let coordinator = ActivityCoordinator::default();
+            let barrier = Arc::new(Barrier::new(2));
+            let playback_gate = coordinator.clone();
+            let calibration_gate = coordinator.clone();
+            let playback_barrier = Arc::clone(&barrier);
+            let calibration_barrier = Arc::clone(&barrier);
+            let playback = thread::spawn(move || {
+                playback_barrier.wait();
+                playback_gate.reserve_playback("native-session")
+            });
+            let calibration = thread::spawn(move || {
+                calibration_barrier.wait();
+                calibration_gate.reserve_calibration()
+            });
+            // Keep successful reservations alive until both contenders have
+            // completed. Dropping the first lease before joining the second
+            // would turn this into a sequential test and allow two success
+            // results even though the gate itself is atomic.
+            let playback_result = playback.join().expect("playback thread");
+            let calibration_result = calibration.join().expect("calibration thread");
+            let playback_won = playback_result.is_ok();
+            let calibration_won = calibration_result.is_ok();
+            assert_ne!(playback_won, calibration_won);
+        }
     }
 }

--- a/desktop/src-tauri/src/command_ownership.rs
+++ b/desktop/src-tauri/src/command_ownership.rs
@@ -1,10 +1,10 @@
 //! Explicit ownership matrix for the strangler boundary.
 //!
-//! Wave 2 native service shadows are implemented and fixture-tested outside
-//! the live Tauri route, but the running Python Core still owns these commands
-//! because it retains cached application state and catalog/detail authority. A
-//! failed Python-owned command is returned as a failure; the shell never
-//! performs an implicit native-then-Python fallback.
+//! Explicit command ownership for the Wave 3 native strangler boundary.
+//!
+//! The matrix is executable policy: the selected handler is authoritative and
+//! a failure is returned to the caller.  There is no implicit native/Python
+//! fallback and no command may have two live owners.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CommandOwner {
@@ -13,27 +13,54 @@ pub(crate) enum CommandOwner {
 }
 
 pub(crate) const COMMAND_OWNERS: &[(&str, CommandOwner)] = &[
-    ("app.bootstrap", CommandOwner::Python),
-    ("app.shutdown", CommandOwner::Python),
-    ("catalog.search", CommandOwner::Python),
-    ("catalog.detail", CommandOwner::Python),
-    ("catalog.reload", CommandOwner::Python),
-    ("catalog.set_viewport", CommandOwner::Python),
+    ("app.bootstrap", CommandOwner::Native),
+    ("app.shutdown", CommandOwner::Native),
+    ("catalog.search", CommandOwner::Native),
+    ("catalog.detail", CommandOwner::Native),
+    ("catalog.reload", CommandOwner::Native),
+    ("catalog.set_viewport", CommandOwner::Native),
+    // Keep the complete settings family with Core while its process-local
+    // AppConfig cache is still live. Native services only read the same
+    // atomically persisted file as a shadow during this transition.
     ("settings.get", CommandOwner::Python),
     ("settings.patch", CommandOwner::Python),
     ("update.check", CommandOwner::Python),
     ("update.preferences.get", CommandOwner::Python),
     ("update.preferences.patch", CommandOwner::Python),
     ("update.begin_handoff", CommandOwner::Python),
-    ("playback.prepare", CommandOwner::Python),
-    ("playback.start", CommandOwner::Python),
-    ("playback.stop", CommandOwner::Python),
-    ("playback.pause", CommandOwner::Python),
-    ("playback.resume", CommandOwner::Python),
-    ("playback.skip", CommandOwner::Python),
-    ("diagnostics.set_enabled", CommandOwner::Python),
+    ("playback.prepare", CommandOwner::Native),
+    ("playback.start", CommandOwner::Native),
+    ("playback.stop", CommandOwner::Native),
+    ("playback.pause", CommandOwner::Native),
+    ("playback.resume", CommandOwner::Native),
+    ("playback.skip", CommandOwner::Native),
+    ("diagnostics.set_enabled", CommandOwner::Native),
     ("calibration.start", CommandOwner::Python),
     ("calibration.cancel", CommandOwner::Python),
+];
+
+const REQUIRED_COMMANDS: [&str; 21] = [
+    "app.bootstrap",
+    "app.shutdown",
+    "catalog.search",
+    "catalog.detail",
+    "catalog.reload",
+    "catalog.set_viewport",
+    "settings.get",
+    "settings.patch",
+    "update.check",
+    "update.preferences.get",
+    "update.preferences.patch",
+    "update.begin_handoff",
+    "playback.prepare",
+    "playback.start",
+    "playback.stop",
+    "playback.pause",
+    "playback.resume",
+    "playback.skip",
+    "diagnostics.set_enabled",
+    "calibration.start",
+    "calibration.cancel",
 ];
 
 pub(crate) fn owner_for(method: &str) -> Option<CommandOwner> {
@@ -43,10 +70,16 @@ pub(crate) fn owner_for(method: &str) -> Option<CommandOwner> {
 }
 
 pub(crate) fn matrix_is_complete() -> bool {
-    // Keep both ownership states represented in the delivery contract even
-    // while all live routes remain Python-owned for cache-coherence reasons.
-    let _native_owner_is_available = CommandOwner::Native;
-    COMMAND_OWNERS.len() == 21
+    // Keep both ownership states represented in the delivery contract while
+    // the remaining update-handoff and calibration routes stay Python-owned.
+    COMMAND_OWNERS.len() == REQUIRED_COMMANDS.len()
+        && REQUIRED_COMMANDS.iter().all(|method| {
+            COMMAND_OWNERS
+                .iter()
+                .filter(|(name, _)| name == method)
+                .count()
+                == 1
+        })
         && COMMAND_OWNERS
             .iter()
             .all(|(method, owner)| owner_for(method) == Some(*owner))
@@ -59,10 +92,28 @@ mod tests {
     #[test]
     fn every_current_core_method_has_exactly_one_explicit_owner() {
         assert_eq!(COMMAND_OWNERS.len(), 21);
+        assert_eq!(
+            COMMAND_OWNERS
+                .iter()
+                .filter(|(_, owner)| *owner == CommandOwner::Native)
+                .count(),
+            13
+        );
+        assert_eq!(
+            COMMAND_OWNERS
+                .iter()
+                .filter(|(_, owner)| *owner == CommandOwner::Python)
+                .count(),
+            8
+        );
         for (method, owner) in COMMAND_OWNERS {
             assert_eq!(owner_for(method), Some(*owner));
         }
         assert_eq!(owner_for("settings.patch"), Some(CommandOwner::Python));
+        assert_eq!(
+            owner_for("update.preferences.patch"),
+            Some(CommandOwner::Python)
+        );
         assert_eq!(owner_for("unknown"), None);
         assert!(matrix_is_complete());
     }

--- a/desktop/src-tauri/src/command_ownership.rs
+++ b/desktop/src-tauri/src/command_ownership.rs
@@ -39,6 +39,25 @@ pub(crate) const COMMAND_OWNERS: &[(&str, CommandOwner)] = &[
     ("calibration.cancel", CommandOwner::Python),
 ];
 
+/// Native handlers are enumerated separately from policy so the matrix cannot
+/// claim a route is native merely because a lifecycle helper happens to call
+/// an internal cleanup function.
+pub(crate) const NATIVE_HANDLER_METHODS: &[&str] = &[
+    "app.bootstrap",
+    "app.shutdown",
+    "catalog.search",
+    "catalog.detail",
+    "catalog.reload",
+    "catalog.set_viewport",
+    "playback.prepare",
+    "playback.start",
+    "playback.stop",
+    "playback.pause",
+    "playback.resume",
+    "playback.skip",
+    "diagnostics.set_enabled",
+];
+
 const REQUIRED_COMMANDS: [&str; 21] = [
     "app.bootstrap",
     "app.shutdown",
@@ -83,6 +102,14 @@ pub(crate) fn matrix_is_complete() -> bool {
         && COMMAND_OWNERS
             .iter()
             .all(|(method, owner)| owner_for(method) == Some(*owner))
+        && NATIVE_HANDLER_METHODS.len()
+            == COMMAND_OWNERS
+                .iter()
+                .filter(|(_, owner)| *owner == CommandOwner::Native)
+                .count()
+        && NATIVE_HANDLER_METHODS
+            .iter()
+            .all(|method| owner_for(method) == Some(CommandOwner::Native))
 }
 
 #[cfg(test)]
@@ -116,5 +143,21 @@ mod tests {
         );
         assert_eq!(owner_for("unknown"), None);
         assert!(matrix_is_complete());
+        assert_eq!(NATIVE_HANDLER_METHODS.len(), 13);
+        for method in NATIVE_HANDLER_METHODS {
+            assert_eq!(owner_for(method), Some(CommandOwner::Native));
+            assert!(
+                include_str!("native_runtime.rs").contains(&format!("\"{method}\"")),
+                "native ownership has no dispatch branch for {method}"
+            );
+        }
+        assert_eq!(
+            COMMAND_OWNERS
+                .iter()
+                .filter(|(_, owner)| *owner == CommandOwner::Native)
+                .map(|(method, _)| *method)
+                .collect::<Vec<_>>(),
+            NATIVE_HANDLER_METHODS
+        );
     }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -921,22 +921,18 @@ pub async fn subscribe_ui_events(
         // lifecycle/snapshot events and Core preserves the eight remaining
         // Python-owned update/calibration streams. Each producer retains its
         // own ordering; no command failure is hidden by cross-owner fallback.
-        let supervisor = app_state.ensure_core_blocking()?;
+        let _supervisor = app_state.ensure_core_blocking()?;
         let native = app_state.ensure_native_blocking()?;
-        // Drain pre-observer Core history into the Native hub before attaching
-        // the Channel.  This preserves the relative order of a buffered Core
-        // lifecycle event and a live event produced while subscription is
-        // being installed; both are then replayed by one Channel owner.
-        for event in supervisor
-            .take_buffered_events()
-            .map_err(|error| error.to_string())?
-        {
-            native.relay_core_event(event)?;
+        // Put AppState into a transition phase before installing the native
+        // Channel. Core events arriving during creation/subscription remain
+        // behind the same ordered route queue and cannot overtake older
+        // backlog events.
+        app_state.begin_core_event_route_transition()?;
+        if let Err(error) = native.subscribe(channel) {
+            app_state.fail_core_event_route();
+            return Err(error);
         }
-        for event in app_state.take_pending_core_events()? {
-            native.relay_core_event(event)?;
-        }
-        native.subscribe(channel)?;
+        app_state.complete_core_event_route_transition(native)?;
         Ok(())
     })
     .await

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -568,7 +568,13 @@ where
 {
     let app_state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        match crate::command_ownership::owner_for(method) {
+        let _coherence_guard = (method == "playback.start").then(|| app_state.lock_coherence());
+        let calibration_reservation = if method == "calibration.start" {
+            Some(app_state.activity().reserve_calibration()?)
+        } else {
+            None
+        };
+        let result = match crate::command_ownership::owner_for(method) {
             Some(crate::command_ownership::CommandOwner::Native) => {
                 let runtime = app_state.ensure_native_blocking()?;
                 let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
@@ -581,7 +587,13 @@ where
                 request_with_supervisor(&supervisor, method, params)
             }
             None => Err(format!("unowned desktop command: {method}")),
+        };
+        if result.is_ok()
+            && let Some(reservation) = calibration_reservation
+        {
+            reservation.commit();
         }
+        result
     })
     .await
     .map_err(|error| format!("Core worker failed: {error}"))?
@@ -603,6 +615,7 @@ where
         // frontend queue. The frontend Promise tail owns user-intent order;
         // this guard only prevents overlapping persistence operations.
         let _write_guard = app_state.lock_settings_writes();
+        let _coherence_guard = (method == "settings.patch").then(|| app_state.lock_coherence());
         match crate::command_ownership::owner_for(method) {
             Some(crate::command_ownership::CommandOwner::Native) => {
                 let runtime = app_state.ensure_native_blocking()?;
@@ -613,7 +626,20 @@ where
             }
             Some(crate::command_ownership::CommandOwner::Python) => {
                 let supervisor = app_state.ensure_core_blocking()?;
-                request_with_supervisor(&supervisor, method, params)
+                if method == "settings.patch" {
+                    // Invalidate after the Python RPC itself succeeds, before
+                    // decoding its response.  A malformed response must not
+                    // leave a successfully persisted mutation with a live
+                    // Native prepared plan.
+                    let value = supervisor
+                        .request(method, params)
+                        .map_err(|error| error.to_string())?;
+                    app_state.invalidate_native_after_python_settings_patch();
+                    serde_json::from_value(value)
+                        .map_err(|error| format!("invalid {method} response: {error}"))
+                } else {
+                    request_with_supervisor(&supervisor, method, params)
+                }
             }
             None => Err(format!("unowned desktop command: {method}")),
         }
@@ -895,13 +921,23 @@ pub async fn subscribe_ui_events(
         // lifecycle/snapshot events and Core preserves the eight remaining
         // Python-owned update/calibration streams. Each producer retains its
         // own ordering; no command failure is hidden by cross-owner fallback.
-        app_state
-            .ensure_native_blocking()?
-            .subscribe(channel.clone())?;
-        app_state
-            .ensure_core_blocking()?
-            .subscribe(channel)
-            .map_err(|error| error.to_string())
+        let supervisor = app_state.ensure_core_blocking()?;
+        let native = app_state.ensure_native_blocking()?;
+        // Drain pre-observer Core history into the Native hub before attaching
+        // the Channel.  This preserves the relative order of a buffered Core
+        // lifecycle event and a live event produced while subscription is
+        // being installed; both are then replayed by one Channel owner.
+        for event in supervisor
+            .take_buffered_events()
+            .map_err(|error| error.to_string())?
+        {
+            native.relay_core_event(event)?;
+        }
+        for event in app_state.take_pending_core_events()? {
+            native.relay_core_event(event)?;
+        }
+        native.subscribe(channel)?;
+        Ok(())
     })
     .await
     .map_err(|error| format!("Core event worker failed: {error}"))?

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -10,6 +10,7 @@ use ts_rs::TS;
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct CatalogSearchRequest {
     pub query: String,
     pub offset: u64,
@@ -20,6 +21,7 @@ pub struct CatalogSearchRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct CatalogDetailRequest {
     pub song_id: String,
     pub generation: Option<u64>,
@@ -28,6 +30,7 @@ pub struct CatalogDetailRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct CatalogViewportRequest {
     pub generation: u64,
     pub first_index: u64,
@@ -47,6 +50,7 @@ pub struct PlaybackPatch {
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct SettingsPatch {
     pub theme: Option<String>,
     pub telemetry_enabled: Option<bool>,
@@ -71,6 +75,7 @@ pub struct UpdatePreferencesPatch {
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PlaybackPrepareRequest {
     pub song_id: String,
     pub generation: u64,
@@ -105,7 +110,7 @@ pub enum PlaybackAdmission {
     Blocked,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, TS, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, TS, PartialEq, Eq, Hash)]
 #[ts(export)]
 #[serde(rename_all = "snake_case")]
 pub enum PlaybackDecision {
@@ -158,6 +163,7 @@ pub enum PlaybackPendingControl {
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PlaybackStartRequest {
     pub prepared_id: String,
     pub decisions: Vec<PlaybackDecisionAcceptanceDto>,
@@ -166,6 +172,7 @@ pub struct PlaybackStartRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PlaybackSessionCommandRequest {
     pub session_id: String,
 }
@@ -539,8 +546,10 @@ where
     P: Serialize,
     R: DeserializeOwned,
 {
-    if crate::command_ownership::owner_for(method).is_none() {
-        return Err(format!("unowned desktop command: {method}"));
+    if crate::command_ownership::owner_for(method)
+        != Some(crate::command_ownership::CommandOwner::Python)
+    {
+        return Err(format!("unowned or non-Python desktop command: {method}"));
     }
     let value = supervisor
         .request(method, params)
@@ -559,8 +568,20 @@ where
 {
     let app_state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let supervisor = app_state.ensure_core_blocking()?;
-        request_with_supervisor(&supervisor, method, params)
+        match crate::command_ownership::owner_for(method) {
+            Some(crate::command_ownership::CommandOwner::Native) => {
+                let runtime = app_state.ensure_native_blocking()?;
+                let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
+                let value = runtime.dispatch(method, params)?;
+                serde_json::from_value(value)
+                    .map_err(|error| format!("invalid native {method} response: {error}"))
+            }
+            Some(crate::command_ownership::CommandOwner::Python) => {
+                let supervisor = app_state.ensure_core_blocking()?;
+                request_with_supervisor(&supervisor, method, params)
+            }
+            None => Err(format!("unowned desktop command: {method}")),
+        }
     })
     .await
     .map_err(|error| format!("Core worker failed: {error}"))?
@@ -582,8 +603,20 @@ where
         // frontend queue. The frontend Promise tail owns user-intent order;
         // this guard only prevents overlapping persistence operations.
         let _write_guard = app_state.lock_settings_writes();
-        let supervisor = app_state.ensure_core_blocking()?;
-        request_with_supervisor(&supervisor, method, params)
+        match crate::command_ownership::owner_for(method) {
+            Some(crate::command_ownership::CommandOwner::Native) => {
+                let runtime = app_state.ensure_native_blocking()?;
+                let params = serde_json::to_value(params).map_err(|error| error.to_string())?;
+                let value = runtime.dispatch(method, params)?;
+                serde_json::from_value(value)
+                    .map_err(|error| format!("invalid native {method} response: {error}"))
+            }
+            Some(crate::command_ownership::CommandOwner::Python) => {
+                let supervisor = app_state.ensure_core_blocking()?;
+                request_with_supervisor(&supervisor, method, params)
+            }
+            None => Err(format!("unowned desktop command: {method}")),
+        }
     })
     .await
     .map_err(|error| format!("Core settings worker failed: {error}"))?
@@ -856,8 +889,17 @@ pub async fn subscribe_ui_events(
 ) -> Result<(), String> {
     let app_state = state.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        let supervisor = app_state.ensure_core_blocking()?;
-        supervisor
+        // Event subscriptions are delivery infrastructure rather than one of
+        // the 21 request methods. During the strangler transition both live
+        // producers use the same delivery channel: Native publishes native
+        // lifecycle/snapshot events and Core preserves the eight remaining
+        // Python-owned update/calibration streams. Each producer retains its
+        // own ordering; no command failure is hidden by cross-owner fallback.
+        app_state
+            .ensure_native_blocking()?
+            .subscribe(channel.clone())?;
+        app_state
+            .ensure_core_blocking()?
             .subscribe(channel)
             .map_err(|error| error.to_string())
     })

--- a/desktop/src-tauri/src/core/supervisor.rs
+++ b/desktop/src-tauri/src/core/supervisor.rs
@@ -4,6 +4,7 @@ use crate::ui_events::{CoreFatalPayload, UiEvent};
 use serde::Serialize;
 use serde_json::Value;
 use sky_dispatch_win32::emergency_release_canonical;
+use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -12,7 +13,8 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
-type CoreEventObserver = Arc<dyn Fn(&CoreEvent) -> Result<(), String> + Send + Sync>;
+pub(crate) type CoreEventObserver =
+    Arc<dyn for<'event> Fn(&'event CoreEvent) -> Result<(), String> + Send + Sync>;
 type CoreFailureObserver = Arc<dyn Fn() + Send + Sync>;
 
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -80,7 +82,6 @@ pub struct CoreSupervisor {
     lifecycle: Mutex<CoreLifecycle>,
     ready: Mutex<Option<Receiver<Result<(), String>>>>,
     events: Mutex<EventState>,
-    event_observer: Mutex<Option<CoreEventObserver>>,
     failure_observer: Mutex<Option<CoreFailureObserver>>,
     shutdown_requested: AtomicBool,
     physical_session_active: AtomicBool,
@@ -165,7 +166,6 @@ impl CoreSupervisor {
             lifecycle: Mutex::new(CoreLifecycle::Starting),
             ready: Mutex::new(Some(ready_receiver)),
             events: Mutex::new(EventState::default()),
-            event_observer: Mutex::new(None),
             failure_observer: Mutex::new(None),
             shutdown_requested: AtomicBool::new(false),
             physical_session_active: AtomicBool::new(false),
@@ -218,14 +218,36 @@ impl CoreSupervisor {
         }
     }
 
-    /// Install a shell-level observer for cross-owner coordination.  The
-    /// observer is deliberately read-only from the Core transport's point of
-    /// view: it can close activity gates/invalidate native plans before the
-    /// decoded event reaches the existing UI delivery buffer.
-    pub(crate) fn set_event_observer(&self, observer: CoreEventObserver) {
-        if let Ok(mut slot) = self.event_observer.lock() {
-            *slot = Some(observer);
+    /// Install a shell-level observer and drain the pre-observer history as
+    /// one ordered transition.  Core's reader is a single producer, but the
+    /// observer callback and backlog drain can otherwise race: a newer live
+    /// event could overtake an older buffered event.  EventState owns both
+    /// the queue and the transition flag, while callbacks run without its
+    /// lock so frontend delivery can never block Core's transport mutex.
+    pub(crate) fn install_event_observer_and_drain(
+        &self,
+        observer: CoreEventObserver,
+    ) -> Result<(), String> {
+        let should_drain = {
+            let mut events = self
+                .events
+                .lock()
+                .map_err(|_| "event buffer poisoned".to_string())?;
+            if events.overflowed {
+                return Err("Core event history overflowed its bounded capacity".into());
+            }
+            events.observer = Some(observer);
+            if events.buffered.is_empty() || events.draining {
+                false
+            } else {
+                events.draining = true;
+                true
+            }
+        };
+        if should_drain {
+            self.drain_observer_events();
         }
+        Ok(())
     }
 
     /// Install a side-effect-only observer for an unexpected Core termination
@@ -454,73 +476,68 @@ impl CoreSupervisor {
     }
 
     fn publish_event(&self, event: CoreEvent) {
-        let observer = self
-            .event_observer
-            .lock()
-            .ok()
-            .and_then(|observer| observer.clone());
-        if let Some(observer) = observer {
-            if observer(&event).is_err() {
-                self.event_delivery_fatal();
-            }
-            return;
-        }
-        let ui_event = event.into_ui_event();
-        let mut events = self.events.lock().expect("event buffer poisoned");
-        if events.overflowed {
-            return;
-        }
-
-        // The replay buffer is only for events produced before a usable UI
-        // subscriber exists. Once live delivery is installed, retaining a
-        // second copy would turn the bounded backlog into lifetime history.
-        if let Some(channel) = events.channel.clone() {
-            if channel.send(ui_event).is_err() {
-                events.channel = None;
-                events.overflowed = true;
-                drop(events);
-                self.event_delivery_fatal();
-            }
-            return;
-        }
-
-        let snapshot_session_id = match &ui_event {
-            UiEvent::PlaybackSnapshot { payload, .. } => Some(payload.session_id.as_str()),
-            _ => None,
-        };
-        if let Some(session_id) = snapshot_session_id {
-            if let Some(index) = events.buffered.iter().rposition(|buffered| {
-                matches!(
-                    buffered,
-                    UiEvent::PlaybackSnapshot { payload, .. }
-                        if payload.session_id == session_id
-                )
-            }) {
-                events.buffered[index] = ui_event;
-            } else if events.buffered.len() < MAX_BUFFERED_EVENTS {
-                events.buffered.push(ui_event);
-            }
-            return;
-        }
-
-        // Before subscription, lifecycle events are retained in order. A
-        // buffered snapshot may be reclaimed to preserve that lifecycle
-        // ordering, but lifecycle events themselves are never silently lost.
-        if events.buffered.len() >= MAX_BUFFERED_EVENTS
-            && let Some(index) = events
-                .buffered
-                .iter()
-                .position(|buffered| matches!(buffered, UiEvent::PlaybackSnapshot { .. }))
+        let mut observer_should_drain = false;
+        let mut direct_channel = None;
         {
-            events.buffered.remove(index);
+            let mut events = self.events.lock().expect("event buffer poisoned");
+            if events.overflowed {
+                return;
+            }
+
+            if events.observer.is_some() {
+                if !enqueue_core_event(&mut events.buffered, event) {
+                    events.overflowed = true;
+                    return;
+                }
+                if !events.draining {
+                    events.draining = true;
+                    observer_should_drain = true;
+                }
+            } else if let Some(channel) = events.channel.clone() {
+                direct_channel = Some((channel, event.into_ui_event()));
+            } else if !enqueue_core_event(&mut events.buffered, event) {
+                events.overflowed = true;
+            }
         }
-        if events.buffered.len() < MAX_BUFFERED_EVENTS {
-            events.buffered.push(ui_event);
-        } else {
-            // There is no safe way to drop a lifecycle event. Mark the
-            // replay history unusable and fail closed for future command
-            // and subscription calls instead of silently losing state.
-            events.overflowed = true;
+
+        if let Some((channel, ui_event)) = direct_channel {
+            if channel.send(ui_event).is_err() {
+                if let Ok(mut events) = self.events.lock() {
+                    events.channel = None;
+                    events.overflowed = true;
+                }
+                self.event_delivery_fatal();
+            }
+            return;
+        }
+
+        if observer_should_drain {
+            self.drain_observer_events();
+        }
+    }
+
+    fn drain_observer_events(&self) {
+        loop {
+            let next = {
+                let mut events = self.events.lock().expect("event buffer poisoned");
+                if events.overflowed || events.observer.is_none() || events.buffered.is_empty() {
+                    events.draining = false;
+                    return;
+                }
+                (
+                    events.observer.clone().expect("observer exists"),
+                    events.buffered.pop_front().expect("event exists"),
+                )
+            };
+            if next.0(&next.1).is_err() {
+                if let Ok(mut events) = self.events.lock() {
+                    events.draining = false;
+                    events.overflowed = true;
+                    events.buffered.clear();
+                }
+                self.event_delivery_fatal();
+                return;
+            }
         }
     }
 
@@ -533,7 +550,7 @@ impl CoreSupervisor {
             ));
         }
         for event in &events.buffered {
-            if let Err(error) = channel.send(event.clone()) {
+            if let Err(error) = channel.send(event.clone().into_ui_event()) {
                 events.channel = None;
                 events.overflowed = true;
                 let message = error.to_string();
@@ -545,19 +562,6 @@ impl CoreSupervisor {
         events.channel = Some(channel);
         events.buffered.clear();
         Ok(())
-    }
-
-    /// Drain only the bounded events produced before the shell installed the
-    /// unified native UI hub.  Once the observer is installed, new events do
-    /// not enter this legacy buffer.
-    pub(crate) fn take_buffered_events(&self) -> Result<Vec<UiEvent>, SupervisorError> {
-        let mut events = self.events.lock().expect("event buffer poisoned");
-        if events.overflowed {
-            return Err(SupervisorError::Unavailable(
-                "Core event history overflowed its bounded capacity".into(),
-            ));
-        }
-        Ok(std::mem::take(&mut events.buffered))
     }
 
     fn event_delivery_fatal(&self) {
@@ -797,9 +801,58 @@ impl CoreSupervisor {
 
 #[derive(Default)]
 struct EventState {
-    buffered: Vec<UiEvent>,
+    buffered: VecDeque<CoreEvent>,
     channel: Option<tauri::ipc::Channel<UiEvent>>,
+    observer: Option<CoreEventObserver>,
+    draining: bool,
     overflowed: bool,
+}
+
+fn enqueue_core_event(buffered: &mut VecDeque<CoreEvent>, event: CoreEvent) -> bool {
+    let ui_event = event.clone().into_ui_event();
+    let snapshot_key = match &ui_event {
+        UiEvent::PlaybackSnapshot { payload, .. } => Some((1_u8, payload.session_id.clone())),
+        UiEvent::DiagnosticsSnapshot { payload, .. } => {
+            Some((2_u8, payload.session_id.clone().unwrap_or_default()))
+        }
+        UiEvent::CalibrationProgress { payload, .. } => Some((3_u8, payload.operation_id.clone())),
+        _ => None,
+    };
+    if let Some(key) = snapshot_key {
+        if let Some(index) = buffered.iter().position(|candidate| {
+            let candidate_ui = candidate.clone().into_ui_event();
+            let candidate_key = match candidate_ui {
+                UiEvent::PlaybackSnapshot { payload, .. } => Some((1_u8, payload.session_id)),
+                UiEvent::DiagnosticsSnapshot { payload, .. } => {
+                    Some((2_u8, payload.session_id.unwrap_or_default()))
+                }
+                UiEvent::CalibrationProgress { payload, .. } => Some((3_u8, payload.operation_id)),
+                _ => None,
+            };
+            candidate_key == Some(key.clone())
+        }) {
+            buffered[index] = event;
+            return true;
+        }
+        if buffered.len() >= MAX_BUFFERED_EVENTS
+            && let Some(index) = buffered.iter().position(|candidate| {
+                matches!(
+                    candidate.clone().into_ui_event(),
+                    UiEvent::PlaybackSnapshot { .. }
+                        | UiEvent::DiagnosticsSnapshot { .. }
+                        | UiEvent::CalibrationProgress { .. }
+                )
+            })
+        {
+            buffered.remove(index);
+        }
+    }
+    if buffered.len() < MAX_BUFFERED_EVENTS {
+        buffered.push_back(event);
+        true
+    } else {
+        false
+    }
 }
 
 impl Drop for CoreSupervisor {
@@ -815,11 +868,15 @@ impl Drop for CoreSupervisor {
 mod tests {
     use super::super::protocol::CoreEvent;
     use super::{
-        CoreLifecycle, CoreSupervisor, MAX_BUFFERED_EVENTS, SupervisorError, SupervisorTimeouts,
+        CoreEventObserver, CoreLifecycle, CoreSupervisor, MAX_BUFFERED_EVENTS, SupervisorError,
+        SupervisorTimeouts,
     };
     use crate::ui_events::{
+        CalibrationFinishedPayload, CalibrationOutcome, CalibrationProgressPayload,
+        CalibrationState, CatalogChangedPayload, CoreReadyPayload, NativeBuildPayload,
         PlaybackEventState, PlaybackFinishedPayload, PlaybackFocusState, PlaybackHealthState,
-        PlaybackSnapshotPayload, UiEvent,
+        PlaybackSnapshotPayload, UiEvent, UpdateAvailablePayload, UpdateChannel,
+        UpdateResultPayload, UpdateState,
     };
     use serde_json::json;
     use sky_dispatch_win32::input::ReleaseAllOutcome;
@@ -843,6 +900,57 @@ mod tests {
             .arg(mode)
             .env("PYTHONUNBUFFERED", "1");
         command
+    }
+
+    fn ready_event() -> CoreEvent {
+        CoreEvent::Ready(CoreReadyPayload {
+            app_version: "3.5.0".into(),
+            protocol_version: 1,
+            native_build: NativeBuildPayload {
+                native_build_commit: "fixture".into(),
+                native_version: "fixture".into(),
+                schema_version: 1,
+                native_abi: "fixture".into(),
+                rustc_version: "fixture".into(),
+                win32_backend: true,
+            },
+        })
+    }
+
+    fn catalog_event(generation: u64) -> CoreEvent {
+        CoreEvent::CatalogChanged(CatalogChangedPayload {
+            generation,
+            total: generation,
+        })
+    }
+
+    fn event_label(event: &CoreEvent) -> String {
+        match event {
+            CoreEvent::Ready(_) => "core.ready".into(),
+            CoreEvent::CatalogChanged(payload) => format!("catalog:{}", payload.generation),
+            CoreEvent::CalibrationProgress(payload) => {
+                format!("calibration.progress:{}", payload.completed)
+            }
+            CoreEvent::CalibrationFinished(payload) => {
+                format!("calibration.finished:{:?}", payload.outcome)
+            }
+            CoreEvent::UpdateAvailable(payload) => {
+                format!("update.available:{}", payload.available_version)
+            }
+            CoreEvent::UpdateResult(payload) => {
+                format!("update.result:{:?}", payload.state)
+            }
+            _ => "other".into(),
+        }
+    }
+
+    fn clear_startup_history(supervisor: &CoreSupervisor) {
+        supervisor
+            .events
+            .lock()
+            .expect("event buffer poisoned")
+            .buffered
+            .clear();
     }
 
     fn short_timeouts() -> SupervisorTimeouts {
@@ -972,14 +1080,14 @@ mod tests {
                 .expect("event buffer poisoned")
                 .buffered
                 .iter()
-                .any(|event| matches!(event, UiEvent::CoreFatal { .. }))
+                .any(|event| matches!(event, CoreEvent::Fatal(..)))
         }));
         let events = supervisor.events.lock().expect("event buffer poisoned");
         let fatal = events
             .buffered
             .iter()
             .find_map(|event| match event {
-                UiEvent::CoreFatal { payload, .. } => Some(payload),
+                CoreEvent::Fatal(payload) => Some(payload),
                 _ => None,
             })
             .expect("original fatal event");
@@ -1190,13 +1298,241 @@ mod tests {
             .buffered
             .iter()
             .filter_map(|event| match event {
-                UiEvent::PlaybackSnapshot { payload, .. } => Some(payload),
+                CoreEvent::PlaybackSnapshot(payload) => Some(payload),
                 _ => None,
             })
             .collect();
         assert_eq!(snapshots.len(), 1);
         assert_eq!(snapshots[0].seq, 1_000);
         drop(events);
+        supervisor.shutdown();
+    }
+
+    #[test]
+    fn observer_install_drains_core_ready_before_new_live_event() {
+        let supervisor = start("normal");
+        clear_startup_history(&supervisor);
+        supervisor.publish_event(ready_event());
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let observer_seen = Arc::clone(&seen);
+        let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
+            observer_seen
+                .lock()
+                .expect("event log")
+                .push(event_label(event));
+            Ok(())
+        });
+        supervisor
+            .install_event_observer_and_drain(observer)
+            .expect("observer install");
+        supervisor.publish_event(catalog_event(2));
+        assert_eq!(
+            *seen.lock().expect("event log"),
+            vec!["core.ready", "catalog:2"]
+        );
+        supervisor.shutdown();
+    }
+
+    #[test]
+    fn transition_followed_by_live_core_events_preserves_order() {
+        let supervisor = start("normal");
+        clear_startup_history(&supervisor);
+        supervisor.publish_event(catalog_event(20));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let observer_seen = Arc::clone(&seen);
+        let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
+            observer_seen
+                .lock()
+                .expect("event log")
+                .push(event_label(event));
+            Ok(())
+        });
+        supervisor
+            .install_event_observer_and_drain(observer)
+            .expect("observer install");
+        supervisor.publish_event(catalog_event(21));
+        supervisor.publish_event(catalog_event(22));
+        assert_eq!(
+            *seen.lock().expect("event log"),
+            vec!["catalog:20", "catalog:21", "catalog:22"]
+        );
+        supervisor.shutdown();
+    }
+
+    #[test]
+    fn core_event_during_native_route_creation_waits_behind_backlog() {
+        let supervisor = start("normal");
+        clear_startup_history(&supervisor);
+        supervisor.publish_event(catalog_event(1));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let release_receiver = Arc::new(Mutex::new(release_receiver));
+        let block_first = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let observer_seen = Arc::clone(&seen);
+        let observer_release = Arc::clone(&release_receiver);
+        let observer_block_first = Arc::clone(&block_first);
+        let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
+            observer_seen
+                .lock()
+                .expect("event log")
+                .push(event_label(event));
+            if observer_block_first.swap(false, std::sync::atomic::Ordering::AcqRel) {
+                entered_sender.send(()).expect("entered receiver");
+                observer_release
+                    .lock()
+                    .expect("release receiver")
+                    .recv()
+                    .expect("release sender");
+            }
+            Ok(())
+        });
+        let install_supervisor = Arc::clone(&supervisor);
+        let install =
+            thread::spawn(move || install_supervisor.install_event_observer_and_drain(observer));
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("observer entered");
+        supervisor.publish_event(catalog_event(2));
+        release_sender.send(()).expect("release observer");
+        install.join().expect("observer thread").expect("install");
+        assert_eq!(
+            *seen.lock().expect("event log"),
+            vec!["catalog:1", "catalog:2"]
+        );
+        supervisor.shutdown();
+    }
+
+    #[test]
+    fn core_event_during_backlog_drain_cannot_overtake_older_event() {
+        let supervisor = start("normal");
+        clear_startup_history(&supervisor);
+        supervisor.publish_event(catalog_event(10));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (entered_sender, entered_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let release_receiver = Arc::new(Mutex::new(release_receiver));
+        let block_first = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let observer_seen = Arc::clone(&seen);
+        let observer_release = Arc::clone(&release_receiver);
+        let observer_block_first = Arc::clone(&block_first);
+        let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
+            observer_seen
+                .lock()
+                .expect("event log")
+                .push(event_label(event));
+            if observer_block_first.swap(false, std::sync::atomic::Ordering::AcqRel) {
+                entered_sender.send(()).expect("entered receiver");
+                observer_release
+                    .lock()
+                    .expect("release receiver")
+                    .recv()
+                    .expect("release sender");
+            }
+            Ok(())
+        });
+        let install_supervisor = Arc::clone(&supervisor);
+        let install =
+            thread::spawn(move || install_supervisor.install_event_observer_and_drain(observer));
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("observer entered");
+        supervisor.publish_event(catalog_event(11));
+        release_sender.send(()).expect("release observer");
+        install.join().expect("observer thread").expect("install");
+        assert_eq!(
+            *seen.lock().expect("event log"),
+            vec!["catalog:10", "catalog:11"]
+        );
+        supervisor.shutdown();
+    }
+
+    #[test]
+    fn calibration_progress_always_precedes_finished_event() {
+        let supervisor = start("normal");
+        clear_startup_history(&supervisor);
+        supervisor.publish_event(CoreEvent::CalibrationProgress(CalibrationProgressPayload {
+            operation_id: "op".into(),
+            state: CalibrationState::Running,
+            phase: "measure".into(),
+            completed: 1,
+            total: 2,
+            message: "one".into(),
+        }));
+        supervisor.publish_event(CoreEvent::CalibrationFinished(CalibrationFinishedPayload {
+            operation_id: "op".into(),
+            outcome: CalibrationOutcome::Succeeded,
+            status: "ok".into(),
+            margin_us: Some(777),
+            sample_count: 2,
+            source: "fixture".into(),
+            message: "done".into(),
+            applied: true,
+        }));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let observer_seen = Arc::clone(&seen);
+        let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
+            observer_seen
+                .lock()
+                .expect("event log")
+                .push(event_label(event));
+            Ok(())
+        });
+        supervisor
+            .install_event_observer_and_drain(observer)
+            .expect("observer install");
+        assert_eq!(
+            *seen.lock().expect("event log"),
+            vec!["calibration.progress:1", "calibration.finished:Succeeded"]
+        );
+        supervisor.shutdown();
+    }
+
+    #[test]
+    fn update_events_preserve_core_source_order_across_transition() {
+        let supervisor = start("normal");
+        clear_startup_history(&supervisor);
+        supervisor.publish_event(CoreEvent::UpdateAvailable(UpdateAvailablePayload {
+            current_version: "3.5.0".into(),
+            available_version: "3.6.0".into(),
+            channel: UpdateChannel::Stable,
+            release_notes: None,
+            published_at: None,
+        }));
+        supervisor.publish_event(CoreEvent::UpdateResult(UpdateResultPayload {
+            state: UpdateState::Available,
+            current_version: "3.5.0".into(),
+            available_version: Some("3.6.0".into()),
+            channel: UpdateChannel::Stable,
+            error: None,
+        }));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let observer_seen = Arc::clone(&seen);
+        let observer: CoreEventObserver = Arc::new(move |event: &CoreEvent| {
+            observer_seen
+                .lock()
+                .expect("event log")
+                .push(event_label(event));
+            Ok(())
+        });
+        supervisor
+            .install_event_observer_and_drain(observer)
+            .expect("observer install");
+        supervisor.publish_event(CoreEvent::UpdateResult(UpdateResultPayload {
+            state: UpdateState::Current,
+            current_version: "3.6.0".into(),
+            available_version: None,
+            channel: UpdateChannel::Stable,
+            error: None,
+        }));
+        assert_eq!(
+            *seen.lock().expect("event log"),
+            vec![
+                "update.available:3.6.0",
+                "update.result:Available",
+                "update.result:Current"
+            ]
+        );
         supervisor.shutdown();
     }
 

--- a/desktop/src-tauri/src/core/supervisor.rs
+++ b/desktop/src-tauri/src/core/supervisor.rs
@@ -12,6 +12,9 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
+type CoreEventObserver = Arc<dyn Fn(&CoreEvent) -> Result<(), String> + Send + Sync>;
+type CoreFailureObserver = Arc<dyn Fn() + Send + Sync>;
+
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 const RELOAD_TIMEOUT: Duration = Duration::from_secs(15);
@@ -77,6 +80,8 @@ pub struct CoreSupervisor {
     lifecycle: Mutex<CoreLifecycle>,
     ready: Mutex<Option<Receiver<Result<(), String>>>>,
     events: Mutex<EventState>,
+    event_observer: Mutex<Option<CoreEventObserver>>,
+    failure_observer: Mutex<Option<CoreFailureObserver>>,
     shutdown_requested: AtomicBool,
     physical_session_active: AtomicBool,
     emergency_release_done: AtomicBool,
@@ -160,6 +165,8 @@ impl CoreSupervisor {
             lifecycle: Mutex::new(CoreLifecycle::Starting),
             ready: Mutex::new(Some(ready_receiver)),
             events: Mutex::new(EventState::default()),
+            event_observer: Mutex::new(None),
+            failure_observer: Mutex::new(None),
             shutdown_requested: AtomicBool::new(false),
             physical_session_active: AtomicBool::new(false),
             emergency_release_done: AtomicBool::new(false),
@@ -208,6 +215,37 @@ impl CoreSupervisor {
                     "Core exited before ready".into(),
                 ))
             }
+        }
+    }
+
+    /// Install a shell-level observer for cross-owner coordination.  The
+    /// observer is deliberately read-only from the Core transport's point of
+    /// view: it can close activity gates/invalidate native plans before the
+    /// decoded event reaches the existing UI delivery buffer.
+    pub(crate) fn set_event_observer(&self, observer: CoreEventObserver) {
+        if let Ok(mut slot) = self.event_observer.lock() {
+            *slot = Some(observer);
+        }
+    }
+
+    /// Install a side-effect-only observer for an unexpected Core termination
+    /// or delivery failure.  It deliberately carries no Core event payload:
+    /// the failure path may have no valid wire event to relay, and publishing
+    /// a synthetic event here could recurse through the delivery observer.
+    pub(crate) fn set_failure_observer(&self, observer: CoreFailureObserver) {
+        if let Ok(mut slot) = self.failure_observer.lock() {
+            *slot = Some(observer);
+        }
+    }
+
+    fn notify_failure_observer(&self) {
+        let observer = self
+            .failure_observer
+            .lock()
+            .ok()
+            .and_then(|observer| observer.clone());
+        if let Some(observer) = observer {
+            observer();
         }
     }
 
@@ -340,6 +378,7 @@ impl CoreSupervisor {
                 if status.is_err() || !supervisor.shutdown_requested.load(Ordering::Acquire) {
                     supervisor.pending.fail_all("Core process exited");
                     supervisor.emergency_release_if_needed();
+                    supervisor.notify_failure_observer();
                     let mut lifecycle = supervisor.lifecycle.lock().expect("lifecycle poisoned");
                     if *lifecycle != CoreLifecycle::Fatal {
                         *lifecycle = CoreLifecycle::Exited;
@@ -415,6 +454,17 @@ impl CoreSupervisor {
     }
 
     fn publish_event(&self, event: CoreEvent) {
+        let observer = self
+            .event_observer
+            .lock()
+            .ok()
+            .and_then(|observer| observer.clone());
+        if let Some(observer) = observer {
+            if observer(&event).is_err() {
+                self.event_delivery_fatal();
+            }
+            return;
+        }
         let ui_event = event.into_ui_event();
         let mut events = self.events.lock().expect("event buffer poisoned");
         if events.overflowed {
@@ -474,6 +524,7 @@ impl CoreSupervisor {
         }
     }
 
+    #[allow(dead_code)]
     pub fn subscribe(&self, channel: tauri::ipc::Channel<UiEvent>) -> Result<(), SupervisorError> {
         let mut events = self.events.lock().expect("event buffer poisoned");
         if events.overflowed {
@@ -496,9 +547,23 @@ impl CoreSupervisor {
         Ok(())
     }
 
+    /// Drain only the bounded events produced before the shell installed the
+    /// unified native UI hub.  Once the observer is installed, new events do
+    /// not enter this legacy buffer.
+    pub(crate) fn take_buffered_events(&self) -> Result<Vec<UiEvent>, SupervisorError> {
+        let mut events = self.events.lock().expect("event buffer poisoned");
+        if events.overflowed {
+            return Err(SupervisorError::Unavailable(
+                "Core event history overflowed its bounded capacity".into(),
+            ));
+        }
+        Ok(std::mem::take(&mut events.buffered))
+    }
+
     fn event_delivery_fatal(&self) {
         self.set_lifecycle(CoreLifecycle::Fatal);
         self.pending.fail_all("UI event channel delivery failed");
+        self.notify_failure_observer();
         self.terminate_child_before_emergency_release();
     }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod bindings;
 mod command_ownership;
 mod commands;
 mod lifecycle;
+mod native_runtime;
 mod ui_events;
 
 mod core;
@@ -190,47 +191,45 @@ fn run_inner(gui_smoke: bool) {
     result.expect("error while running Sky Auto Player desktop shell");
 }
 
-/// Validate the release shell/Core pairing without constructing a WebView.
+/// Validate the release native desktop composition without constructing a WebView.
 ///
 /// This hidden, packaging-only entrypoint is used by the exact portable
-/// artifact gate. It still uses the production launch command and
-/// ``CoreSupervisor``; it merely replaces the interactive window with a
-/// bounded bootstrap/shutdown assertion so CI never needs to synthesize a
-/// physical input session.
+/// artifact gate. It uses the same native composition root as the production
+/// shell and replaces the interactive window with a bounded bootstrap/shutdown
+/// assertion so CI never needs to synthesize a physical input session.
 pub fn selftest_packaged_shell() -> i32 {
     if let Err(error) = core::check_startup_update_guard() {
         eprintln!("packaged shell selftest startup guard failed: {error}");
         return 2;
     }
-    let supervisor = match core::CoreSupervisor::spawn() {
-        Ok(supervisor) => supervisor,
+    let runtime = match native_runtime::NativeDesktopRuntime::for_current_install() {
+        Ok(runtime) => runtime,
         Err(error) => {
-            eprintln!("packaged shell selftest could not start Core: {error}");
+            eprintln!("packaged native selftest could not start runtime: {error}");
             return 2;
         }
     };
-    let bootstrap = supervisor.request("app.bootstrap", serde_json::json!({}));
-    let result = match bootstrap {
-        Ok(value) if value.get("native_build").is_some() => {
-            supervisor.shutdown();
+    let result = match runtime.bootstrap() {
+        Ok(value) if !value.native_build.native_build_commit.is_empty() => {
+            runtime.shutdown();
             if let Some(marker) = std::env::var_os("SKY_DESKTOP_RESTART_MARKER") {
                 let _ = std::fs::write(marker, b"bootstrap-ready\n");
             }
             0
         }
         Ok(_) => {
-            eprintln!("packaged shell selftest bootstrap omitted native_build");
-            supervisor.shutdown();
+            eprintln!("packaged native selftest bootstrap omitted native build identity");
+            runtime.shutdown();
             1
         }
         Err(error) => {
-            eprintln!("packaged shell selftest bootstrap failed: {error}");
-            supervisor.shutdown();
+            eprintln!("packaged native selftest bootstrap failed: {error}");
+            runtime.shutdown();
             1
         }
     };
     if result == 0 {
-        println!("Packaged Tauri/Core selftest: PASS");
+        println!("Packaged Tauri/Native Desktop selftest: PASS");
     }
     result
 }
@@ -291,10 +290,6 @@ mod ipc_tests {
             .invoke_handler(tauri::generate_handler![super::commands::search_songs])
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("mock Tauri app");
-        let supervisor = CoreSupervisor::spawn_with_command(fake_core()).expect("fake Core");
-        app.state::<AppState>()
-            .inner()
-            .install_ready_for_test(supervisor.clone());
         let webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
             .build()
             .expect("mock webview");
@@ -315,7 +310,9 @@ mod ipc_tests {
         )
         .expect("params envelope should reach command");
         let value: serde_json::Value = valid.deserialize().expect("search response JSON");
-        assert_eq!(value["total"], 0);
+        assert_eq!(value["offset"], 0);
+        assert_eq!(value["limit"], 200);
+        assert!(value["generation"].as_u64().is_some_and(|value| value > 0));
 
         let wrong = tauri::test::get_ipc_response(
             &webview,
@@ -332,7 +329,6 @@ mod ipc_tests {
             ),
         );
         assert!(wrong.is_err(), "legacy request envelope must fail");
-        supervisor.shutdown();
     }
 
     #[test]
@@ -340,23 +336,37 @@ mod ipc_tests {
         let app = tauri::test::mock_builder()
             .manage(AppState::default())
             .invoke_handler(tauri::generate_handler![
+                super::commands::bootstrap,
+                super::commands::search_songs,
                 super::commands::prepare_playback,
                 super::commands::start_playback,
                 super::commands::stop_playback,
-                super::commands::pause_playback,
-                super::commands::resume_playback,
-                super::commands::skip_playback,
+                super::commands::shutdown,
             ])
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("mock Tauri app");
-        let supervisor = CoreSupervisor::spawn_with_command(fake_core()).expect("fake Core");
-        app.state::<AppState>()
-            .inner()
-            .install_ready_for_test(supervisor.clone());
         let webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
             .build()
             .expect("mock webview");
-        let song_id = "c".repeat(32);
+        let bootstrap = tauri::test::get_ipc_response(&webview, request("bootstrap", json!({}), 1))
+            .expect("native bootstrap should succeed");
+        let bootstrap_value: serde_json::Value = bootstrap.deserialize().expect("bootstrap JSON");
+        let generation = bootstrap_value["catalog_generation"]
+            .as_u64()
+            .expect("generation");
+        let search = tauri::test::get_ipc_response(
+            &webview,
+            request(
+                "search_songs",
+                json!({"params":{"query":"blue","offset":0,"limit":1,"generation":generation}}),
+                2,
+            ),
+        )
+        .expect("native catalog search should succeed");
+        let search_value: serde_json::Value = search.deserialize().expect("search JSON");
+        let song_id = search_value["items"][0]["song_id"]
+            .as_str()
+            .expect("song ID");
         let prepared = tauri::test::get_ipc_response(
             &webview,
             request(
@@ -378,7 +388,8 @@ mod ipc_tests {
         )
         .expect("playback params envelope should reach command");
         let prepared_value: serde_json::Value = prepared.deserialize().expect("prepared JSON");
-        assert_eq!(prepared_value["prepared_id"], "a".repeat(32));
+        assert!(prepared_value["prepared_id"].as_str().is_some());
+        let prepared_id = prepared_value["prepared_id"].as_str().unwrap_or_default();
 
         let started = tauri::test::get_ipc_response(
             &webview,
@@ -386,7 +397,7 @@ mod ipc_tests {
                 "start_playback",
                 json!({
                     "params": {
-                        "preparedId": "a".repeat(32),
+                        "preparedId": prepared_id,
                         "decisions": []
                     }
                 }),
@@ -395,24 +406,18 @@ mod ipc_tests {
         )
         .expect("playback start params envelope should reach command");
         let started_value: serde_json::Value = started.deserialize().expect("session JSON");
-        assert_eq!(started_value["session_id"], "b".repeat(32));
+        assert_eq!(started_value["state"], "starting");
+        let session_id = started_value["session_id"].as_str().expect("session ID");
 
-        for (callback, command) in [
-            (16, "stop_playback"),
-            (18, "pause_playback"),
-            (20, "resume_playback"),
-            (22, "skip_playback"),
-        ] {
-            tauri::test::get_ipc_response(
-                &webview,
-                request(
-                    command,
-                    json!({"params": {"sessionId": "b".repeat(32)}}),
-                    callback,
-                ),
-            )
-            .unwrap_or_else(|error| panic!("{command} params envelope should decode: {error}"));
-        }
+        tauri::test::get_ipc_response(
+            &webview,
+            request(
+                "stop_playback",
+                json!({"params":{"sessionId":session_id}}),
+                16,
+            ),
+        )
+        .expect("native stop params envelope should decode");
 
         let wrong = tauri::test::get_ipc_response(
             &webview,
@@ -434,7 +439,7 @@ mod ipc_tests {
             ),
         );
         assert!(wrong.is_err(), "legacy request envelope must fail");
-        supervisor.shutdown();
+        let _ = tauri::test::get_ipc_response(&webview, request("shutdown", json!({}), 18));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -694,4 +694,90 @@ mod ipc_tests {
         let shutdown_value: serde_json::Value = shutdown.deserialize().expect("shutdown JSON");
         assert!(shutdown_value.is_null());
     }
+
+    #[test]
+    fn routed_python_settings_patch_invalidates_native_prepared_plan() {
+        let app = tauri::test::mock_builder()
+            .manage(AppState::default())
+            .invoke_handler(tauri::generate_handler![
+                super::commands::bootstrap,
+                super::commands::search_songs,
+                super::commands::prepare_playback,
+                super::commands::patch_settings,
+                super::commands::start_playback,
+                super::commands::shutdown,
+            ])
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock Tauri app");
+        let supervisor = CoreSupervisor::spawn_with_command(fake_core()).expect("fake Core");
+        app.state::<AppState>()
+            .inner()
+            .install_ready_for_test(supervisor.clone());
+        let webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+            .build()
+            .expect("mock webview");
+
+        let bootstrap =
+            tauri::test::get_ipc_response(&webview, request("bootstrap", json!({}), 60))
+                .expect("native bootstrap");
+        let bootstrap: serde_json::Value = bootstrap.deserialize().expect("bootstrap JSON");
+        let generation = bootstrap["catalog_generation"]
+            .as_u64()
+            .expect("generation");
+        let search = tauri::test::get_ipc_response(
+            &webview,
+            request(
+                "search_songs",
+                json!({"params":{"query":"blue","offset":0,"limit":1,"generation":generation}}),
+                62,
+            ),
+        )
+        .expect("native search");
+        let search: serde_json::Value = search.deserialize().expect("search JSON");
+        let song_id = search["items"][0]["song_id"]
+            .as_str()
+            .expect("song ID")
+            .to_owned();
+        let prepared = tauri::test::get_ipc_response(
+            &webview,
+            request(
+                "prepare_playback",
+                json!({"params":{
+                    "songId":song_id,
+                    "generation":generation,
+                    "config":{"hold_frames":1.0,"tempo_scale":1.0,"fps":60,"dry_run":true}
+                }}),
+                64,
+            ),
+        )
+        .expect("native prepare");
+        let prepared: serde_json::Value = prepared.deserialize().expect("prepare JSON");
+        let prepared_id = prepared["prepared_id"].as_str().expect("prepared ID");
+
+        let patched = tauri::test::get_ipc_response(
+            &webview,
+            request(
+                "patch_settings",
+                json!({"params":{"playbackDefaults":{"tempo_scale":0.95}}}),
+                66,
+            ),
+        )
+        .expect("Python-owned settings patch");
+        let _: serde_json::Value = patched.deserialize().expect("settings JSON");
+
+        let start = tauri::test::get_ipc_response(
+            &webview,
+            request(
+                "start_playback",
+                json!({"params":{"preparedId":prepared_id,"decisions":[]}}),
+                68,
+            ),
+        );
+        assert!(
+            start.is_err(),
+            "settings patch must stale native prepared ID"
+        );
+        let _ = tauri::test::get_ipc_response(&webview, request("shutdown", json!({}), 70));
+        supervisor.shutdown();
+    }
 }

--- a/desktop/src-tauri/src/lifecycle.rs
+++ b/desktop/src-tauri/src/lifecycle.rs
@@ -26,6 +26,7 @@ pub fn close_window<R: Runtime + 'static>(window: Window<R>) {
         if let Ok(supervisor) = state.supervisor() {
             supervisor.shutdown();
         }
+        state.shutdown_native();
         if exit_after_close {
             crate::record_gui_smoke_phase("lifecycle.shutdown_core.return");
             crate::record_gui_smoke_phase("lifecycle.window_destroy.enter");

--- a/desktop/src-tauri/src/lifecycle.rs
+++ b/desktop/src-tauri/src/lifecycle.rs
@@ -26,6 +26,9 @@ pub fn close_window<R: Runtime + 'static>(window: Window<R>) {
         if let Ok(supervisor) = state.supervisor() {
             supervisor.shutdown();
         }
+        // `app.shutdown` is a Native-owned command.  Route lifecycle cleanup
+        // through the same executable handler so ownership accounting and the
+        // real close path cannot diverge.
         state.shutdown_native();
         if exit_after_close {
             crate::record_gui_smoke_phase("lifecycle.shutdown_core.return");

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -5,6 +5,7 @@
 //! plus outer adapters.  It never delegates a native-owned command to the
 //! Python Core.
 
+use crate::app_state::{ActivityCoordinator, PhysicalActivityLease};
 use crate::commands::{
     BootstrapDto, CatalogDetailRequest, CatalogReloadDto, CatalogRowDto, CatalogSearchDto,
     CatalogSearchRequest, CatalogViewportDto, CatalogViewportRequest, DiagnosticsEnabledDto,
@@ -28,10 +29,11 @@ use sky_app_core::settings::{
     UpdatePreferencesPatch as CoreUpdatePreferencesPatch,
 };
 use sky_app_core::song::{
-    ActionKind, DOWN_LATE_GRACE_US, MIN_TRANSPORT_MARGIN_US, RiskReport, ScheduleMetadata, Song,
-    analyze_schedule_with_context, build_schedule, frame_us, parse_song_json,
+    ActionKind, RiskReport, ScheduleMetadata, Song, analyze_schedule_with_context,
+    build_schedule_with_policy, parse_song_json,
 };
-use sky_native_adapters::{FileCatalogSource, JsonSettingsStore};
+use sky_app_core::timing::MaterializedTimingPolicy;
+use sky_native_adapters::{FileCatalogSource, JsonSettingsStore, load_calibration_resolution};
 use sky_player::adapter_support::{
     ActionKind as DispatchActionKind, KeyActionInput, PriorityMode, compile_runtime_intents,
 };
@@ -52,7 +54,6 @@ use tauri::ipc::Channel;
 
 pub(crate) const MAX_NATIVE_EVENTS: usize = 128;
 const MAX_PREPARED_PLANS: usize = 64;
-static NEXT_NATIVE_ID: AtomicU64 = AtomicU64::new(1);
 
 pub(crate) struct NativeDesktopRuntime {
     #[allow(dead_code)]
@@ -62,15 +63,33 @@ pub(crate) struct NativeDesktopRuntime {
     catalog: Mutex<CatalogIndex>,
     events: Arc<Mutex<NativeEventHub>>,
     playback: Arc<NativePlaybackService>,
+    activity: ActivityCoordinator,
     closed: AtomicBool,
 }
 
 impl NativeDesktopRuntime {
     pub(crate) fn for_current_install() -> Result<Self, String> {
-        Self::from_install_root(resolve_install_root()?)
+        Self::from_install_root_with_activity(
+            resolve_install_root()?,
+            ActivityCoordinator::default(),
+        )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn from_install_root(install_root: PathBuf) -> Result<Self, String> {
+        Self::from_install_root_with_activity(install_root, ActivityCoordinator::default())
+    }
+
+    pub(crate) fn for_current_install_with_activity(
+        activity: ActivityCoordinator,
+    ) -> Result<Self, String> {
+        Self::from_install_root_with_activity(resolve_install_root()?, activity)
+    }
+
+    pub(crate) fn from_install_root_with_activity(
+        install_root: PathBuf,
+        activity: ActivityCoordinator,
+    ) -> Result<Self, String> {
         let settings_path = install_root.join("config.json");
         let settings_store = JsonSettingsStore::new(settings_path);
         let settings = SettingsService::load(settings_store)
@@ -82,7 +101,8 @@ impl NativeDesktopRuntime {
             catalog_source: FileCatalogSource::new(songs_dir),
             catalog: Mutex::new(CatalogIndex::default()),
             events: Arc::new(Mutex::new(NativeEventHub::default())),
-            playback: Arc::new(NativePlaybackService::new()),
+            playback: Arc::new(NativePlaybackService::new(activity.clone())),
+            activity,
             closed: AtomicBool::new(false),
         })
     }
@@ -93,7 +113,7 @@ impl NativeDesktopRuntime {
     }
 
     pub(crate) fn dispatch(&self, method: &str, params: Value) -> Result<Value, String> {
-        if self.closed.load(Ordering::Acquire) {
+        if self.closed.load(Ordering::Acquire) && method != "app.shutdown" {
             return Err("native desktop runtime is shut down".into());
         }
         if crate::command_ownership::owner_for(method)
@@ -105,6 +125,10 @@ impl NativeDesktopRuntime {
         }
         match method {
             "app.bootstrap" => encode_result(self.bootstrap()),
+            "app.shutdown" => {
+                self.shutdown();
+                Ok(Value::Object(Default::default()))
+            }
             "catalog.search" => {
                 let request: CatalogSearchRequest =
                     serde_json::from_value(params).map_err(json_error)?;
@@ -364,18 +388,18 @@ impl NativeDesktopRuntime {
             .unwrap_or(&entry.row.title);
         let song = parse_song_json(&bytes, fallback).map_err(|error| error.to_string())?;
         let settings = self.settings_snapshot()?;
-        let schedule = build_schedule(
-            &song,
-            settings.playback_defaults.hold_frames,
-            1.0,
+        let policy = self.timing_policy(
             settings.playback_defaults.fps,
-        )
-        .map_err(|error| error.to_string())?;
+            settings.playback_defaults.hold_frames,
+        )?;
+        let schedule =
+            build_schedule_with_policy(&song, settings.playback_defaults.tempo_scale, &policy)
+                .map_err(|error| error.to_string())?;
         let risk = analyze_schedule_with_context(
             &schedule,
             Some(&song.notes),
             settings.playback_defaults.hold_frames,
-            1.0,
+            settings.playback_defaults.tempo_scale,
         );
         let risk_level = match risk.severity.as_str() {
             "low" | "medium" | "high" => risk.severity.clone(),
@@ -485,27 +509,43 @@ impl NativeDesktopRuntime {
             .and_then(|value| value.to_str())
             .unwrap_or(&entry.row.title);
         let song = parse_song_json(&bytes, fallback).map_err(|error| error.to_string())?;
-        let schedule = build_schedule(
-            &song,
-            request.config.hold_frames,
-            request.config.tempo_scale,
-            request.config.fps,
-        )
-        .map_err(|error| error.to_string())?;
+        let settings = self.settings_snapshot()?;
+        let policy = self.timing_policy(request.config.fps, request.config.hold_frames)?;
+        let schedule = build_schedule_with_policy(&song, request.config.tempo_scale, &policy)
+            .map_err(|error| error.to_string())?;
         let risk = analyze_schedule_with_context(
             &schedule,
             Some(&song.notes),
             request.config.hold_frames,
             request.config.tempo_scale,
         );
-        self.playback.prepare(
-            request.song_id,
-            request.generation,
-            request.config,
+        self.playback.prepare(NativePreparedInput {
+            song_id: request.song_id,
+            generation: request.generation,
+            config: request.config,
             song,
             schedule,
             risk,
+            timing_policy: policy,
+            settings_fingerprint: settings_fingerprint(&settings)?,
+        })
+    }
+
+    fn timing_policy(
+        &self,
+        fps: u16,
+        hold_frames: f64,
+    ) -> Result<MaterializedTimingPolicy, String> {
+        let resolution = load_calibration_resolution(
+            self.install_root.join(".cache").join("input_latency.json"),
+        );
+        MaterializedTimingPolicy::from_calibration(
+            fps,
+            hold_frames,
+            resolution.margin_us,
+            resolution.source,
         )
+        .map_err(|error| error.to_string())
     }
 
     fn start_playback(
@@ -543,6 +583,18 @@ impl NativeDesktopRuntime {
             .subscribe(channel)
     }
 
+    pub(crate) fn invalidate_prepared_for_calibration(&self) {
+        self.playback.invalidate_settings();
+    }
+
+    pub(crate) fn invalidate_prepared_for_external_mutation(&self) {
+        self.playback.invalidate_settings();
+    }
+
+    pub(crate) fn relay_core_event(&self, event: UiEvent) -> Result<(), String> {
+        self.publish(event)
+    }
+
     fn publish(&self, event: UiEvent) -> Result<(), String> {
         self.events
             .lock()
@@ -551,6 +603,7 @@ impl NativeDesktopRuntime {
     }
 
     pub(crate) fn shutdown(&self) {
+        self.activity.begin_shutdown();
         if !self.closed.swap(true, Ordering::AcqRel) {
             self.playback.shutdown(self.events.clone());
             if let Ok(mut events) = self.events.lock() {
@@ -564,17 +617,19 @@ impl NativeDesktopRuntime {
 /// `sky_player`; this service owns prepared-plan admission, the single active
 /// session rule, and the bounded supervisor loop around that worker.
 struct NativePlaybackService {
-    prepared: Mutex<HashMap<String, NativePreparedPlan>>,
+    prepared: Mutex<VecDeque<(String, NativePreparedPlan)>>,
     active: Arc<Mutex<Option<Arc<NativeActivePlayback>>>>,
     last_terminal: Arc<Mutex<Option<(String, PlaybackSessionState)>>>,
     diagnostics_enabled: Arc<AtomicBool>,
     diagnostics_sequence: Arc<AtomicU64>,
+    activity: ActivityCoordinator,
 }
 
 #[derive(Clone)]
 struct NativePreparedPlan {
     song_id: String,
     generation: u64,
+    settings_fingerprint: String,
     song: Song,
     dto: PreparedPlaybackDto,
     variants: HashMap<PlaybackDecision, NativePlaybackVariant>,
@@ -585,6 +640,18 @@ struct NativePlaybackVariant {
     config: PlaybackConfigDto,
     schedule: ScheduleMetadata,
     fingerprint: String,
+    timing_policy: MaterializedTimingPolicy,
+}
+
+struct NativePreparedInput {
+    song_id: String,
+    generation: u64,
+    config: PlaybackConfigDto,
+    song: Song,
+    schedule: ScheduleMetadata,
+    risk: RiskReport,
+    timing_policy: MaterializedTimingPolicy,
+    settings_fingerprint: String,
 }
 
 struct NativeActivePlayback {
@@ -596,6 +663,8 @@ struct NativeActivePlayback {
     config: PlaybackConfigDto,
     plan_fingerprint: String,
     physical: bool,
+    activity_lease: Option<PhysicalActivityLease>,
+    target_hwnd: Option<isize>,
     state: Mutex<PlaybackSessionState>,
     pending: Mutex<Option<PlaybackPendingControl>>,
     player: Option<Arc<NativeDispatchSession>>,
@@ -648,28 +717,25 @@ impl NativePlaybackStartRequest {
     }
 }
 
-fn opaque_native_id() -> String {
-    let sequence = NEXT_NATIVE_ID.fetch_add(1, Ordering::Relaxed);
-    let mut hasher = Sha256::new();
-    hasher.update(sequence.to_le_bytes());
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    hasher.update(now.as_nanos().to_le_bytes());
-    hasher.update(std::process::id().to_le_bytes());
-    let digest = hasher.finalize();
-    digest[..16]
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect()
+fn opaque_native_id() -> Result<String, String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| format!("secure native identifier generation failed: {error}"))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn retain_prepared_capacity<T>(prepared: &mut VecDeque<T>) {
+    while prepared.len() > MAX_PREPARED_PLANS {
+        prepared.pop_front();
+    }
 }
 
 fn plan_fingerprint(
     song_id: &str,
     config: &PlaybackConfigDto,
     schedule: &ScheduleMetadata,
+    policy: &MaterializedTimingPolicy,
 ) -> Result<String, String> {
-    let frame = frame_us(config.fps).map_err(|error| error.to_string())?;
     let actions = schedule
         .actions
         .iter()
@@ -684,22 +750,48 @@ fn plan_fingerprint(
             ])
         })
         .collect::<Vec<_>>();
+    // Construct every nested object with json! rather than serializing the
+    // Rust DTO directly.  The Python oracle uses
+    // json.dumps(..., sort_keys=True, separators=(",", ":")); DTO struct
+    // declaration order is not the canonical fingerprint order.
     let payload = serde_json::json!({
         "song_id": song_id,
-        "config": config,
-        "policy": {
+        "config": {
+            "dry_run": config.dry_run,
             "fps": config.fps,
-            "min_hold_us": ((config.hold_frames * frame as f64).ceil() as u64)
-                .saturating_add(DOWN_LATE_GRACE_US)
-                .saturating_add(MIN_TRANSPORT_MARGIN_US),
-            "min_release_gap_us": frame
-                .saturating_add(DOWN_LATE_GRACE_US)
-                .saturating_add(MIN_TRANSPORT_MARGIN_US),
+            "hold_frames": config.hold_frames,
+            "tempo_scale": config.tempo_scale,
+        },
+        "policy": {
+            "fps": policy.fps,
+            "min_hold_us": policy.min_hold_us,
+            "min_release_gap_us": policy.min_release_gap_us,
         },
         "actions": actions,
     });
     let bytes = serde_json::to_vec(&payload).map_err(json_error)?;
     let digest = Sha256::digest(bytes);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn settings_fingerprint(settings: &ApplicationSettings) -> Result<String, String> {
+    // Keep this in lockstep with DesktopPlaybackService._settings_fingerprint.
+    // Update timestamps and unrelated preferences must not invalidate a plan;
+    // the routed settings.patch path explicitly invalidates every plan after a
+    // successful mutation, while update metadata writes remain independent.
+    // Python's settings fingerprint uses json.dumps with sorted keys and its
+    // default separators (`, ` and `: `). Keep the flat payload explicit so
+    // this cross-runtime identity cannot depend on Rust struct field order.
+    let theme = serde_json::to_string(&settings.theme).map_err(json_error)?;
+    let payload = format!(
+        "{{\"fps\": {}, \"hold\": {}, \"telemetry\": {}, \"tempo\": {}, \"theme\": {}}}",
+        settings.playback_defaults.fps,
+        settings.playback_defaults.hold_frames,
+        settings.telemetry_enabled,
+        settings.playback_defaults.tempo_scale,
+        theme,
+    );
+    let digest = Sha256::digest(payload.as_bytes());
     Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
@@ -718,6 +810,52 @@ fn risk_summary(risk: &RiskReport) -> RiskSummaryDto {
             vec![risk.reason.clone()]
         },
         recommendations: risk.recommendations.clone(),
+    }
+}
+
+fn blocked_playback_dto(
+    song_id: &str,
+    config: PlaybackConfigDto,
+    code: &str,
+    message: String,
+    recommended_tempo_scale: Option<f64>,
+    recommended_hold_frames: Option<f64>,
+) -> PreparedPlaybackDto {
+    // Keep blocked preparation responses aligned with the Python
+    // DesktopPlaybackService: the failure is represented as a typed blocked
+    // DTO, not as a new transport error or an implementation-specific code.
+    let recommendations = [
+        recommended_tempo_scale.map(|tempo| format!("Try tempo {tempo:.2}×")),
+        recommended_hold_frames.map(|hold| format!("Try hold {hold:.2} frames")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+    let risk = RiskSummaryDto {
+        level: "high".into(),
+        headline: "Playback blocked".into(),
+        reasons: vec![message.clone()],
+        recommendations,
+    };
+    PreparedPlaybackDto {
+        prepared_id: None,
+        song: SongDetailDto {
+            song_id: song_id.into(),
+            title: song_id.into(),
+            duration_us: 0,
+            note_count: 0,
+            format_label: "UNKNOWN".into(),
+            risk: risk.clone(),
+            recommendation: None,
+        },
+        config,
+        admission: PlaybackAdmission::Blocked,
+        risk,
+        decisions: Vec::new(),
+        plan_fingerprint: None,
+        variants: Vec::new(),
+        error_code: Some(code.into()),
+        error_message: Some(message),
     }
 }
 
@@ -774,13 +912,14 @@ fn compile_dispatch_schedule(
 }
 
 impl NativePlaybackService {
-    fn new() -> Self {
+    fn new(activity: ActivityCoordinator) -> Self {
         Self {
-            prepared: Mutex::new(HashMap::new()),
+            prepared: Mutex::new(VecDeque::new()),
             active: Arc::new(Mutex::new(None)),
             last_terminal: Arc::new(Mutex::new(None)),
             diagnostics_enabled: Arc::new(AtomicBool::new(false)),
             diagnostics_sequence: Arc::new(AtomicU64::new(0)),
+            activity,
         }
     }
 
@@ -796,41 +935,44 @@ impl NativePlaybackService {
         Ok(())
     }
 
-    fn prepare(
-        &self,
-        song_id: String,
-        generation: u64,
-        config: PlaybackConfigDto,
-        song: Song,
-        schedule: ScheduleMetadata,
-        risk: RiskReport,
-    ) -> Result<PreparedPlaybackDto, String> {
+    fn prepare(&self, input: NativePreparedInput) -> Result<PreparedPlaybackDto, String> {
+        let NativePreparedInput {
+            song_id,
+            generation,
+            config,
+            song,
+            schedule,
+            risk,
+            timing_policy,
+            settings_fingerprint,
+        } = input;
         let detail = song_detail(&song_id, &song, &schedule, &risk);
         if !config.dry_run && schedule.impossible_same_key_repeats > 0 {
-            return Ok(PreparedPlaybackDto {
-                prepared_id: None,
-                song: detail,
+            let message = format!(
+                "Detected {} infeasible same-key repeat(s): the authored interval is shorter than the configured hold.",
+                schedule.impossible_same_key_repeats
+            );
+            return Ok(blocked_playback_dto(
+                &song_id,
                 config,
-                admission: PlaybackAdmission::Blocked,
-                risk: risk_summary(&risk),
-                decisions: Vec::new(),
-                plan_fingerprint: None,
-                variants: Vec::new(),
-                error_code: Some("physical_infeasible".into()),
-                error_message: Some("playback contains infeasible same-key repeats".into()),
-            });
+                "validation_failed",
+                message,
+                schedule.recommended_tempo_scale,
+                schedule.recommended_hold_frames,
+            ));
         }
-        let fingerprint = plan_fingerprint(&song_id, &config, &schedule)?;
+        let fingerprint = plan_fingerprint(&song_id, &config, &schedule, &timing_policy)?;
         let admission = if risk.severity == "low" {
             PlaybackAdmission::Ready
         } else {
             PlaybackAdmission::ConfirmationRequired
         };
-        let prepared_id = opaque_native_id();
+        let prepared_id = opaque_native_id()?;
         let base_variant = NativePlaybackVariant {
             config: config.clone(),
             schedule: schedule.clone(),
             fingerprint: fingerprint.clone(),
+            timing_policy: timing_policy.clone(),
         };
         let mut decisions = Vec::new();
         let mut variants = HashMap::from([(PlaybackDecision::Proceed, base_variant)]);
@@ -847,8 +989,14 @@ impl NativePlaybackService {
             if let (Some(hold_frames), Some(tempo_scale)) =
                 (risk.suggested_hold_frames, risk.suggested_tempo_scale)
                 && (hold_frames != config.hold_frames || tempo_scale != config.tempo_scale)
+                && let Ok(recommended_policy) = MaterializedTimingPolicy::from_calibration(
+                    config.fps,
+                    hold_frames,
+                    timing_policy.transport_margin_us,
+                    timing_policy.transport_margin_source.clone(),
+                )
                 && let Ok(recommended_schedule) =
-                    build_schedule(&song, hold_frames, tempo_scale, config.fps)
+                    build_schedule_with_policy(&song, tempo_scale, &recommended_policy)
                 && (config.dry_run || recommended_schedule.impossible_same_key_repeats == 0)
             {
                 let recommended_config = PlaybackConfigDto {
@@ -857,14 +1005,19 @@ impl NativePlaybackService {
                     fps: config.fps,
                     dry_run: config.dry_run,
                 };
-                let recommended_fingerprint =
-                    plan_fingerprint(&song_id, &recommended_config, &recommended_schedule)?;
+                let recommended_fingerprint = plan_fingerprint(
+                    &song_id,
+                    &recommended_config,
+                    &recommended_schedule,
+                    &recommended_policy,
+                )?;
                 variants.insert(
                     PlaybackDecision::UseRecommended,
                     NativePlaybackVariant {
                         config: recommended_config.clone(),
                         schedule: recommended_schedule,
                         fingerprint: recommended_fingerprint.clone(),
+                        timing_policy: recommended_policy,
                     },
                 );
                 variant_dtos.push(PlaybackPlanVariantDto {
@@ -882,13 +1035,15 @@ impl NativePlaybackService {
                     dry_run: true,
                     ..config.clone()
                 };
-                let dry_run_fingerprint = plan_fingerprint(&song_id, &dry_run_config, &schedule)?;
+                let dry_run_fingerprint =
+                    plan_fingerprint(&song_id, &dry_run_config, &schedule, &timing_policy)?;
                 variants.insert(
                     PlaybackDecision::DryRun,
                     NativePlaybackVariant {
                         config: dry_run_config.clone(),
                         schedule: schedule.clone(),
                         fingerprint: dry_run_fingerprint.clone(),
+                        timing_policy: timing_policy.clone(),
                     },
                 );
                 variant_dtos.push(PlaybackPlanVariantDto {
@@ -918,22 +1073,18 @@ impl NativePlaybackService {
             .prepared
             .lock()
             .map_err(|_| "native prepared-plan lock poisoned".to_string())?;
-        prepared.insert(
+        prepared.push_back((
             prepared_id,
             NativePreparedPlan {
                 song_id,
                 generation,
+                settings_fingerprint,
                 song,
                 dto: dto.clone(),
                 variants,
             },
-        );
-        while prepared.len() > MAX_PREPARED_PLANS {
-            let oldest = prepared.keys().next().cloned();
-            if let Some(oldest) = oldest {
-                prepared.remove(&oldest);
-            }
-        }
+        ));
+        retain_prepared_capacity(&mut prepared);
         Ok(dto)
     }
 
@@ -955,9 +1106,13 @@ impl NativePlaybackService {
             .lock()
             .map_err(|_| "native prepared-plan lock poisoned".to_string())?;
         let record = prepared
-            .get(&request.prepared_id)
-            .cloned()
+            .iter()
+            .find(|(id, _)| id == &request.prepared_id)
+            .map(|(_, record)| record.clone())
             .ok_or_else(|| "prepared playback is stale or already consumed".to_string())?;
+        if record.settings_fingerprint != settings_fingerprint(settings)? {
+            return Err("prepared playback is stale after settings mutation".into());
+        }
         let accepted = request
             .decisions
             .iter()
@@ -988,12 +1143,25 @@ impl NativePlaybackService {
             .get(&selected)
             .cloned()
             .ok_or_else(|| "selected risk decision has no prepared plan".to_string())?;
-        let player = if variant.config.dry_run {
+        let session_id = opaque_native_id()?;
+        let activity_lease = if variant.config.dry_run {
             None
         } else {
-            Some(self.create_native_player(&variant.schedule, &variant.config, settings)?)
+            Some(self.activity.reserve_playback(&session_id)?)
         };
-        let session_id = opaque_native_id();
+        let (player, target_hwnd) = if variant.config.dry_run {
+            (None, None)
+        } else {
+            match self.create_native_player(
+                &variant.schedule,
+                &variant.config,
+                &variant.timing_policy,
+                settings,
+            ) {
+                Ok((player, target)) => (Some(player), Some(target)),
+                Err(error) => return Err(error),
+            }
+        };
         let active = Arc::new(NativeActivePlayback {
             session_id: session_id.clone(),
             prepared_id: request.prepared_id.clone(),
@@ -1003,6 +1171,8 @@ impl NativePlaybackService {
             config: variant.config.clone(),
             plan_fingerprint: variant.fingerprint.clone(),
             physical: player.is_some(),
+            activity_lease,
+            target_hwnd,
             state: Mutex::new(PlaybackSessionState::Starting),
             pending: Mutex::new(None),
             player,
@@ -1014,7 +1184,11 @@ impl NativePlaybackService {
             done: AtomicBool::new(false),
             sequence: AtomicU64::new(0),
         });
-        prepared.remove(&request.prepared_id);
+        let prepared_index = prepared
+            .iter()
+            .position(|(id, _)| id == &request.prepared_id)
+            .expect("prepared record was found above");
+        prepared.remove(prepared_index);
         *active_slot = Some(active.clone());
         drop(prepared);
         drop(active_slot);
@@ -1034,7 +1208,7 @@ impl NativePlaybackService {
                 *slot = None;
             }
             if let Ok(mut prepared) = self.prepared.lock() {
-                prepared.insert(request.prepared_id, record);
+                prepared.push_back((request.prepared_id, record));
             }
             return Err(error);
         }
@@ -1057,7 +1231,7 @@ impl NativePlaybackService {
                 *slot = None;
             }
             if let Ok(mut prepared) = self.prepared.lock() {
-                prepared.insert(request.prepared_id, record);
+                prepared.push_back((request.prepared_id, record));
             }
             return Err(format!(
                 "failed to start native playback supervisor: {error}"
@@ -1079,6 +1253,7 @@ impl NativePlaybackService {
             last_terminal: self.last_terminal.clone(),
             diagnostics_enabled: self.diagnostics_enabled.clone(),
             diagnostics_sequence: self.diagnostics_sequence.clone(),
+            activity: self.activity.clone(),
         }
     }
 
@@ -1086,29 +1261,27 @@ impl NativePlaybackService {
         &self,
         schedule: &ScheduleMetadata,
         config: &PlaybackConfigDto,
+        policy: &MaterializedTimingPolicy,
         settings: &ApplicationSettings,
-    ) -> Result<Arc<NativeDispatchSession>, String> {
+    ) -> Result<(Arc<NativeDispatchSession>, isize), String> {
         let runtime_schedule = compile_dispatch_schedule(schedule)?;
         let target = sky_dispatch_win32::focus::find_sky_window(
             &settings.sky_process_names,
             settings.allow_title_fallback,
         )
         .ok_or_else(|| "no admissible visible Sky window was found".to_string())?;
-        if !sky_dispatch_win32::focus::focus_window(target) {
+        if !sky_dispatch_win32::focus::focus_window_and_verify(target, Duration::from_millis(100)) {
             return Err("validated Sky window could not be focused".into());
         }
-        let frame = frame_us(config.fps).map_err(|error| error.to_string())?;
         let player = Arc::new(NativeDispatchSession::new(NativeSessionOptions {
             schedule: runtime_schedule,
             backend: BackendConfig::Production,
             profile: DispatchProfile::Production,
             timing: TimingOptions {
                 game_fps: config.fps,
-                min_hold_us: ((config.hold_frames * frame as f64).ceil() as u64)
-                    .saturating_add(500)
-                    .saturating_add(300),
-                min_release_gap_us: frame.saturating_add(500).saturating_add(300),
-                down_late_grace_us: 500,
+                min_hold_us: policy.min_hold_us,
+                min_release_gap_us: policy.min_release_gap_us,
+                down_late_grace_us: policy.down_late_grace_us,
                 strict_timing: false,
                 strict_down_completion_late_us: 2_000,
                 strict_up_completion_late_us: 2_000,
@@ -1116,12 +1289,13 @@ impl NativePlaybackService {
             },
             focus: FocusOptions {
                 require_focus: true,
-                focus_restore_grace_us: 100_000,
+                focus_restore_grace_us: policy.focus_restore_grace_us,
             },
             wait: WaitOptions {
                 enable_waitable_timer: true,
                 enable_event_wait: true,
-                supervisor_lease_timeout_us: 0,
+                supervisor_lease_timeout_us:
+                    sky_player::engine::DEFAULT_SUPERVISOR_LEASE_TIMEOUT_US,
                 #[cfg(feature = "tauri-test")]
                 test_spin_threshold_us: None,
                 #[cfg(feature = "tauri-test")]
@@ -1129,7 +1303,7 @@ impl NativePlaybackService {
             },
             telemetry: TelemetryOptions {
                 mode: TelemetryMode::Ring,
-                capacity: 64,
+                capacity: 1_024,
             },
             priority: PriorityOptions {
                 mode: PriorityMode::Auto,
@@ -1144,11 +1318,18 @@ impl NativePlaybackService {
         player.set_target_hwnd(target);
         player.set_focus_hint(true);
         player.arm(0)?;
-        Ok(player)
+        Ok((player, target))
     }
 
     fn monitor(&self, active: Arc<NativeActivePlayback>, events: Arc<Mutex<NativeEventHub>>) {
+        // Keep the lease inside the active record for its full lifetime.  Its
+        // Drop implementation releases the cross-owner activity gate on all
+        // terminal and startup-failure paths.
+        let _activity_lease = active.activity_lease.as_ref();
         let mut last_snapshot = Instant::now();
+        let mut last_heartbeat = Instant::now()
+            .checked_sub(Duration::from_millis(200))
+            .unwrap_or_else(Instant::now);
         let mut last_event_state = PlaybackEventState::Starting;
         loop {
             if active.stop_requested.load(Ordering::Acquire) {
@@ -1168,9 +1349,20 @@ impl NativePlaybackService {
                 }
                 break;
             }
+            if let Some(player) = &active.player
+                && let Some(target) = active.target_hwnd
+            {
+                // The supervisor owns only a transition hint.  The worker
+                // still performs its fresh exact-HWND final admission.
+                let focused = sky_dispatch_win32::focus::foreground_window_matches(target);
+                player.set_focus_hint(focused);
+            }
             let (elapsed, pre_roll_remaining, paused, finished, status) =
                 if let Some(player) = &active.player {
-                    let _ = player.heartbeat();
+                    if last_heartbeat.elapsed() >= Duration::from_millis(200) {
+                        let _ = player.heartbeat();
+                        last_heartbeat = Instant::now();
+                    }
                     let state = player.poll_state();
                     (
                         state.elapsed_us,
@@ -1500,7 +1692,7 @@ impl NativePlaybackService {
 
     fn invalidate_catalog(&self, generation: u64) {
         if let Ok(mut prepared) = self.prepared.lock() {
-            prepared.retain(|_, record| record.generation == generation);
+            prepared.retain(|(_, record)| record.generation == generation);
         }
     }
 
@@ -1558,16 +1750,18 @@ struct NativePlaybackServiceHandle {
     last_terminal: Arc<Mutex<Option<(String, PlaybackSessionState)>>>,
     diagnostics_enabled: Arc<AtomicBool>,
     diagnostics_sequence: Arc<AtomicU64>,
+    activity: ActivityCoordinator,
 }
 
 impl NativePlaybackServiceHandle {
     fn monitor(&self, active: Arc<NativeActivePlayback>, events: Arc<Mutex<NativeEventHub>>) {
         let service = NativePlaybackService {
-            prepared: Mutex::new(HashMap::new()),
+            prepared: Mutex::new(VecDeque::new()),
             active: self.active.clone(),
             last_terminal: self.last_terminal.clone(),
             diagnostics_enabled: self.diagnostics_enabled.clone(),
             diagnostics_sequence: self.diagnostics_sequence.clone(),
+            activity: self.activity.clone(),
         };
         service.monitor(active, events);
     }
@@ -1593,14 +1787,18 @@ fn publish_diagnostics_snapshot_for_active(
         late_5ms: snapshot.late_5ms,
         late_10ms: snapshot.late_10ms,
         active_keys: snapshot.active_count as u64,
-        stuck_keys: snapshot.possibly_active_count as u64,
+        stuck_keys: snapshot.failed_release_count as u64,
         keys_dropped: snapshot.keys_dropped,
         chord_split_events: snapshot.chord_split_events,
-        backend_status: if snapshot.has_terminal_error {
-            crate::ui_events::DiagnosticsBackendStatus::Error
-        } else {
-            crate::ui_events::DiagnosticsBackendStatus::Healthy
-        },
+        backend_status: diagnostics_backend_status(
+            snapshot.has_terminal_error,
+            snapshot.last_error.is_some(),
+            snapshot.failed_release_count,
+            snapshot.keys_dropped,
+            snapshot.chord_split_events,
+            snapshot.possibly_active_count,
+            snapshot.active_count,
+        ),
         release_max_us: (snapshot.release_max_us > 0).then_some(snapshot.release_max_us),
         release_late_2ms: (snapshot.release_late_2ms > 0).then_some(snapshot.release_late_2ms),
         session_id: Some(active.session_id.clone()),
@@ -1612,6 +1810,24 @@ fn publish_diagnostics_snapshot_for_active(
             v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
             payload,
         })
+}
+
+fn diagnostics_backend_status(
+    has_terminal_error: bool,
+    has_last_error: bool,
+    failed_release_count: usize,
+    keys_dropped: u64,
+    chord_split_events: u64,
+    possibly_active_count: usize,
+    active_count: usize,
+) -> crate::ui_events::DiagnosticsBackendStatus {
+    if has_terminal_error || has_last_error || failed_release_count > 0 {
+        crate::ui_events::DiagnosticsBackendStatus::Error
+    } else if keys_dropped > 0 || chord_split_events > 0 || possibly_active_count > active_count {
+        crate::ui_events::DiagnosticsBackendStatus::Degraded
+    } else {
+        crate::ui_events::DiagnosticsBackendStatus::Healthy
+    }
 }
 
 fn publish_empty_diagnostics_snapshot(
@@ -1718,6 +1934,60 @@ fn publish_playback_snapshot(
     pre_roll_remaining_us: u64,
     paused: bool,
 ) -> Result<(), String> {
+    let (focus_state, health, input_path_degraded, message) = if let Some(player) = &active.player {
+        let snapshot = player.snapshot_lite();
+        let focused = active
+            .target_hwnd
+            .is_some_and(sky_dispatch_win32::focus::foreground_window_matches);
+        let focus_state = if focused {
+            PlaybackFocusState::Focused
+        } else if matches!(
+            active.state.lock().ok().as_deref(),
+            Some(PlaybackSessionState::Starting)
+        ) {
+            PlaybackFocusState::Waiting
+        } else {
+            PlaybackFocusState::Unfocused
+        };
+        let health = if snapshot.has_terminal_error
+            || snapshot.last_error.is_some()
+            || snapshot.failed_release_count > 0
+        {
+            PlaybackHealthState::Error
+        } else if snapshot.input_path_degraded
+            || snapshot.keys_dropped > 0
+            || snapshot.chord_split_events > 0
+            || snapshot.possibly_active_count > snapshot.active_count
+        {
+            PlaybackHealthState::Degraded
+        } else {
+            PlaybackHealthState::Healthy
+        };
+        (
+            focus_state,
+            health,
+            snapshot.input_path_degraded,
+            snapshot.last_error,
+        )
+    } else {
+        (
+            // Dry-run has no HWND or physical backend.  Keep the delivery
+            // state honest instead of claiming a focus admission that was
+            // never performed; once the preview leaves Starting, the
+            // non-physical path is considered focus-neutral.
+            if matches!(
+                active.state.lock().ok().as_deref(),
+                Some(PlaybackSessionState::Starting)
+            ) {
+                PlaybackFocusState::Waiting
+            } else {
+                PlaybackFocusState::Focused
+            },
+            PlaybackHealthState::Healthy,
+            false,
+            None,
+        )
+    };
     let event = UiEvent::PlaybackSnapshot {
         v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
         payload: PlaybackSnapshotPayload {
@@ -1735,10 +2005,10 @@ fn publish_playback_snapshot(
             current_us: elapsed_us,
             total_us: active.total_us,
             pre_roll_remaining_us,
-            focus_state: PlaybackFocusState::Focused,
-            health: PlaybackHealthState::Healthy,
-            input_path_degraded: false,
-            message: None,
+            focus_state,
+            health,
+            input_path_degraded,
+            message,
         },
     };
     events
@@ -2105,14 +2375,18 @@ fn remove_oldest_snapshot(buffered: &mut VecDeque<UiEvent>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_NATIVE_EVENTS, NativeDesktopRuntime, NativeEventHub, percentile_ms,
-        population_sigma_ms, resolve_install_root,
+        MAX_NATIVE_EVENTS, MAX_PREPARED_PLANS, MaterializedTimingPolicy, NativeDesktopRuntime,
+        NativeEventHub, diagnostics_backend_status, opaque_native_id, percentile_ms,
+        plan_fingerprint, population_sigma_ms, remove_oldest_snapshot, resolve_install_root,
+        retain_prepared_capacity, settings_fingerprint,
     };
+    use crate::commands::PlaybackConfigDto;
     use crate::ui_events::{
         PlaybackEventState, PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload,
         UiEvent,
     };
     use serde_json::Value;
+    use sky_app_core::song::{build_schedule_with_policy, parse_song_json};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -2145,6 +2419,18 @@ mod tests {
             runtime
                 .dispatch("settings.get", Value::Object(Default::default()))
                 .is_err()
+        );
+        assert_eq!(
+            runtime
+                .dispatch("app.shutdown", Value::Object(Default::default()))
+                .expect("first shutdown"),
+            Value::Object(Default::default())
+        );
+        assert_eq!(
+            runtime
+                .dispatch("app.shutdown", Value::Object(Default::default()))
+                .expect("idempotent shutdown"),
+            Value::Object(Default::default())
         );
         let _ = fs::remove_dir_all(root);
     }
@@ -2212,6 +2498,280 @@ mod tests {
         );
         assert_eq!(percentile_ms(&[], 0.50), 0.0);
         assert_eq!(population_sigma_ms(&[]), 0.0);
+    }
+
+    #[test]
+    fn diagnostics_status_matches_native_observer_contract() {
+        use crate::ui_events::DiagnosticsBackendStatus;
+
+        assert_eq!(
+            diagnostics_backend_status(false, false, 0, 0, 0, 1, 1),
+            DiagnosticsBackendStatus::Healthy
+        );
+        assert_eq!(
+            diagnostics_backend_status(false, false, 0, 1, 0, 1, 1),
+            DiagnosticsBackendStatus::Degraded
+        );
+        assert_eq!(
+            diagnostics_backend_status(false, false, 0, 0, 1, 2, 1),
+            DiagnosticsBackendStatus::Degraded
+        );
+        assert_eq!(
+            diagnostics_backend_status(false, false, 0, 0, 0, 2, 1),
+            DiagnosticsBackendStatus::Degraded
+        );
+        assert_eq!(
+            diagnostics_backend_status(false, true, 0, 0, 0, 1, 1),
+            DiagnosticsBackendStatus::Error
+        );
+        assert_eq!(
+            diagnostics_backend_status(false, false, 1, 0, 0, 1, 1),
+            DiagnosticsBackendStatus::Error
+        );
+    }
+
+    #[test]
+    fn direct_native_player_keeps_the_qualified_supervisor_lease() {
+        assert_eq!(
+            sky_player::engine::DEFAULT_SUPERVISOR_LEASE_TIMEOUT_US,
+            3_000_000
+        );
+    }
+
+    #[test]
+    fn native_prepared_ids_are_random_lowercase_hex_and_eviction_is_fifo() {
+        let mut ids = std::collections::BTreeSet::new();
+        for _ in 0..128 {
+            let id = opaque_native_id().expect("native ID");
+            assert_eq!(id.len(), 32);
+            assert!(
+                id.bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+            );
+            assert!(ids.insert(id));
+        }
+
+        let mut prepared = std::collections::VecDeque::new();
+        for value in 0..(MAX_PREPARED_PLANS + 3) {
+            prepared.push_back(value);
+            retain_prepared_capacity(&mut prepared);
+        }
+        assert_eq!(prepared.len(), MAX_PREPARED_PLANS);
+        assert_eq!(prepared.front(), Some(&3));
+        assert_eq!(prepared.back(), Some(&(MAX_PREPARED_PLANS + 2)));
+    }
+
+    #[test]
+    fn calibrated_policy_reaches_schedule_and_plan_fingerprint() {
+        let song = parse_song_json(
+            br#"{"name":"Policy","songNotes":[{"time":0,"key":"Key0"},{"time":100,"key":"Key1"}]}"#,
+            "policy",
+        )
+        .expect("song");
+        let default_policy =
+            MaterializedTimingPolicy::from_calibration(60, 1.0, 300, "default_transport_300")
+                .expect("default policy");
+        let calibrated_policy =
+            MaterializedTimingPolicy::from_calibration(60, 1.0, 777, "device_cache")
+                .expect("calibrated policy");
+        let default_schedule =
+            build_schedule_with_policy(&song, 1.0, &default_policy).expect("default schedule");
+        let calibrated_schedule = build_schedule_with_policy(&song, 1.0, &calibrated_policy)
+            .expect("calibrated schedule");
+        assert!(calibrated_schedule.actions[1].at_us > default_schedule.actions[1].at_us);
+        assert_eq!(calibrated_schedule.actions[1].at_us, 17_944);
+        let config = PlaybackConfigDto {
+            hold_frames: 1.0,
+            tempo_scale: 1.0,
+            fps: 60,
+            dry_run: true,
+        };
+        let default_fingerprint =
+            plan_fingerprint("policy", &config, &default_schedule, &default_policy)
+                .expect("default fingerprint");
+        let calibrated_fingerprint =
+            plan_fingerprint("policy", &config, &calibrated_schedule, &calibrated_policy)
+                .expect("calibrated fingerprint");
+        assert_ne!(default_fingerprint, calibrated_fingerprint);
+    }
+
+    #[test]
+    fn fingerprint_serialization_matches_python_canonicalization() {
+        let mut settings = sky_app_core::settings::ApplicationSettings::default();
+        settings.playback_defaults.hold_frames = 1.25;
+        settings.playback_defaults.tempo_scale = 0.95;
+        settings.playback_defaults.fps = 120;
+        settings.telemetry_enabled = true;
+        assert_eq!(
+            settings_fingerprint(&settings).expect("settings fingerprint"),
+            "08ee5d237d7fa694e691f587a0f0dd74fbbd3dbcb01a1dd7da31f1bb681fb0ec"
+        );
+
+        let song = parse_song_json(
+            br#"{"name":"Fingerprint","songNotes":[{"time":0,"key":"Key0"}]}"#,
+            "fingerprint",
+        )
+        .expect("song");
+        let policy =
+            MaterializedTimingPolicy::from_calibration(60, 1.0, 300, "default_transport_300")
+                .expect("policy");
+        let schedule = build_schedule_with_policy(&song, 0.95, &policy).expect("schedule");
+        let config = PlaybackConfigDto {
+            hold_frames: 1.0,
+            tempo_scale: 0.95,
+            fps: 60,
+            dry_run: true,
+        };
+        assert_eq!(
+            plan_fingerprint(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                &config,
+                &schedule,
+                &policy,
+            )
+            .expect("plan fingerprint"),
+            "72c0ea87e7b2df847bc5e568777af5c80c93c79b8b0c0081a36596a3d11c352e"
+        );
+    }
+
+    #[test]
+    fn native_detail_uses_persisted_tempo_scale_for_schedule_and_risk() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-native-tempo-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(
+            root.join("config.json"),
+            r#"{"schema_version":3,"default_tempo_scale":0.95}"#,
+        )
+        .expect("config");
+        fs::write(
+            root.join("songs/demo.json"),
+            r#"{"name":"Demo","songNotes":[{"time":1000,"key":"Key0"}]}"#,
+        )
+        .expect("song");
+        let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
+        let bootstrap = runtime.bootstrap().expect("bootstrap");
+        let search = runtime
+            .search(crate::commands::CatalogSearchRequest {
+                query: "demo".into(),
+                offset: 0,
+                limit: 10,
+                generation: Some(bootstrap.catalog_generation),
+            })
+            .expect("search");
+        let song_id = search.items[0].song_id.clone();
+        let settings = runtime.settings_snapshot().expect("settings");
+        let policy = runtime
+            .timing_policy(
+                settings.playback_defaults.fps,
+                settings.playback_defaults.hold_frames,
+            )
+            .expect("policy");
+        let song = parse_song_json(
+            br#"{"name":"Demo","songNotes":[{"time":1000,"key":"Key0"}]}"#,
+            "demo",
+        )
+        .expect("song");
+        let expected =
+            build_schedule_with_policy(&song, settings.playback_defaults.tempo_scale, &policy)
+                .expect("schedule")
+                .source_duration_us;
+        let detail = runtime
+            .detail(crate::commands::CatalogDetailRequest {
+                song_id,
+                generation: Some(bootstrap.catalog_generation),
+            })
+            .expect("detail");
+        assert_eq!(detail.duration_us, expected);
+        assert_ne!(detail.duration_us, 1_000_000 + policy.min_hold_us);
+        runtime.shutdown();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn native_prepare_preserves_python_validation_failed_contract() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-native-prepare-contract-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        fs::write(
+            root.join("songs/repeat.json"),
+            r#"{"name":"Repeat","songNotes":[{"time":0,"key":"Key0"},{"time":1,"key":"Key0"}]}"#,
+        )
+        .expect("song");
+        let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
+        let bootstrap = runtime
+            .dispatch("app.bootstrap", Value::Object(Default::default()))
+            .expect("bootstrap");
+        let generation = bootstrap["catalog_generation"]
+            .as_u64()
+            .expect("generation");
+        let search = runtime
+            .dispatch(
+                "catalog.search",
+                serde_json::json!({
+                    "query": "repeat",
+                    "offset": 0,
+                    "limit": 10,
+                    "generation": generation
+                }),
+            )
+            .expect("search");
+        let song_id = search["items"][0]["song_id"].as_str().expect("song ID");
+        let prepared = runtime
+            .dispatch(
+                "playback.prepare",
+                serde_json::json!({
+                    "song_id": song_id,
+                    "generation": generation,
+                    "config": {
+                        "hold_frames": 1.0,
+                        "tempo_scale": 1.0,
+                        "fps": 60,
+                        "dry_run": false
+                    }
+                }),
+            )
+            .expect("blocked preparation is a typed DTO");
+        assert_eq!(prepared["admission"], "blocked");
+        assert_eq!(prepared["error_code"], "validation_failed");
+        assert_eq!(
+            prepared["error_message"],
+            "Detected 1 infeasible same-key repeat(s): the authored interval is shorter than the configured hold."
+        );
+        assert_eq!(prepared["prepared_id"], Value::Null);
+        runtime.shutdown();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn event_hub_evicts_snapshots_before_lifecycle_events() {
+        let mut hub = NativeEventHub::default();
+        hub.publish(snapshot("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1))
+            .expect("snapshot");
+        for index in 0..MAX_NATIVE_EVENTS {
+            hub.publish(crate::ui_events::UiEvent::CatalogChanged {
+                v: 1,
+                payload: crate::ui_events::CatalogChangedPayload {
+                    generation: index as u64 + 1,
+                    total: 0,
+                },
+            })
+            .expect("snapshot is evictable");
+        }
+        assert_eq!(hub.buffered.len(), MAX_NATIVE_EVENTS);
+        assert!(
+            !hub.buffered
+                .iter()
+                .any(|event| matches!(event, UiEvent::PlaybackSnapshot { .. }))
+        );
+        assert!(!remove_oldest_snapshot(&mut hub.buffered));
     }
 
     #[test]

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -620,9 +620,72 @@ struct NativePlaybackService {
     prepared: Mutex<VecDeque<(String, NativePreparedPlan)>>,
     active: Arc<Mutex<Option<Arc<NativeActivePlayback>>>>,
     last_terminal: Arc<Mutex<Option<(String, PlaybackSessionState)>>>,
-    diagnostics_enabled: Arc<AtomicBool>,
-    diagnostics_sequence: Arc<AtomicU64>,
+    diagnostics_gate: Arc<DiagnosticsPublicationGate>,
     activity: ActivityCoordinator,
+}
+
+const DIAGNOSTICS_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Default)]
+struct DiagnosticsPublicationState {
+    enabled: bool,
+    epoch: u64,
+    sequence: u64,
+    last_emit_at: Option<Instant>,
+}
+
+struct DiagnosticsPublicationGate {
+    state: Mutex<DiagnosticsPublicationState>,
+}
+
+impl Default for DiagnosticsPublicationGate {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(DiagnosticsPublicationState::default()),
+        }
+    }
+}
+
+impl DiagnosticsPublicationGate {
+    fn set_enabled(&self, enabled: bool) -> Result<bool, String> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "diagnostics publication gate poisoned".to_string())?;
+        state.enabled = enabled;
+        state.epoch = state.epoch.wrapping_add(1);
+        // This is intentionally the Python contract: re-enable starts a
+        // fresh sampling window while sequence IDs remain monotonic.
+        state.last_emit_at = None;
+        Ok(state.enabled)
+    }
+
+    fn try_publish<F>(&self, sample_time: Instant, publish: F) -> Result<bool, String>
+    where
+        F: FnOnce(u64) -> Result<(), String>,
+    {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| "diagnostics publication gate poisoned".to_string())?;
+        if !state.enabled {
+            return Ok(false);
+        }
+        if state
+            .last_emit_at
+            .is_some_and(|last| sample_time.saturating_duration_since(last) < DIAGNOSTICS_INTERVAL)
+        {
+            return Ok(false);
+        }
+        state.last_emit_at = Some(sample_time);
+        state.sequence = state.sequence.wrapping_add(1);
+        let sequence = state.sequence;
+        // Keep the gate held across the bounded event publication. This is
+        // the linearization point that makes a successful disable authoritative
+        // even when a supervisor publication was already in flight.
+        publish(sequence)?;
+        Ok(true)
+    }
 }
 
 #[derive(Clone)]
@@ -917,8 +980,7 @@ impl NativePlaybackService {
             prepared: Mutex::new(VecDeque::new()),
             active: Arc::new(Mutex::new(None)),
             last_terminal: Arc::new(Mutex::new(None)),
-            diagnostics_enabled: Arc::new(AtomicBool::new(false)),
-            diagnostics_sequence: Arc::new(AtomicU64::new(0)),
+            diagnostics_gate: Arc::new(DiagnosticsPublicationGate::default()),
             activity,
         }
     }
@@ -926,12 +988,9 @@ impl NativePlaybackService {
     fn set_diagnostics_enabled(
         &self,
         enabled: bool,
-        events: Arc<Mutex<NativeEventHub>>,
+        _events: Arc<Mutex<NativeEventHub>>,
     ) -> Result<(), String> {
-        self.diagnostics_enabled.store(enabled, Ordering::Release);
-        if enabled {
-            self.publish_diagnostics_snapshot(&events, None)?;
-        }
+        self.diagnostics_gate.set_enabled(enabled)?;
         Ok(())
     }
 
@@ -1251,8 +1310,7 @@ impl NativePlaybackService {
         NativePlaybackServiceHandle {
             active: self.active.clone(),
             last_terminal: self.last_terminal.clone(),
-            diagnostics_enabled: self.diagnostics_enabled.clone(),
-            diagnostics_sequence: self.diagnostics_sequence.clone(),
+            diagnostics_gate: self.diagnostics_gate.clone(),
             activity: self.activity.clone(),
         }
     }
@@ -1437,12 +1495,7 @@ impl NativePlaybackService {
                     cleanup_failed_event_delivery(&active);
                     break;
                 }
-                if self.diagnostics_enabled.load(Ordering::Acquire)
-                    && publish_diagnostics_snapshot_for_active(
-                        &events,
-                        &active,
-                        &self.diagnostics_sequence,
-                    )
+                if publish_diagnostics_snapshot_for_active(&events, &active, &self.diagnostics_gate)
                     .is_err()
                 {
                     cleanup_failed_event_delivery(&active);
@@ -1512,18 +1565,21 @@ impl NativePlaybackService {
             .map_err(|_| "native active-playback lock poisoned".to_string())?
             .clone();
         let Some(active) = active else {
+            let terminal = self
+                .last_terminal
+                .lock()
+                .ok()
+                .and_then(|value| value.clone());
             if method == "playback.stop"
-                && self
-                    .last_terminal
-                    .lock()
-                    .ok()
-                    .and_then(|value| value.clone())
-                    .is_some_and(|(id, _)| id == session_id)
+                && terminal.as_ref().is_some_and(|(id, _)| id == &session_id)
             {
+                let terminal_state = terminal
+                    .map(|(_, state)| state)
+                    .unwrap_or(PlaybackSessionState::Failed);
                 return Ok(PlaybackCommandAckDto {
                     accepted: true,
                     session_id,
-                    state: PlaybackSessionState::Finished,
+                    state: terminal_state,
                     pending_command: None,
                     reason: None,
                 });
@@ -1666,6 +1722,18 @@ impl NativePlaybackService {
                 }
             }
             "playback.skip" => {
+                if !matches!(
+                    current,
+                    PlaybackSessionState::Starting
+                        | PlaybackSessionState::Playing
+                        | PlaybackSessionState::Paused
+                ) {
+                    return Err("skip requires a live playback session".into());
+                }
+                *active
+                    .pending
+                    .lock()
+                    .map_err(|_| "native playback control lock poisoned".to_string())? = None;
                 active.skip_requested.store(true, Ordering::Release);
                 if let Some(player) = &active.player {
                     player.skip()?;
@@ -1702,24 +1770,6 @@ impl NativePlaybackService {
         }
     }
 
-    fn publish_diagnostics_snapshot(
-        &self,
-        events: &Arc<Mutex<NativeEventHub>>,
-        active: Option<Arc<NativeActivePlayback>>,
-    ) -> Result<(), String> {
-        if let Some(active) =
-            active.or_else(|| self.active.lock().ok().and_then(|slot| slot.clone()))
-            && active.player.is_some()
-        {
-            return publish_diagnostics_snapshot_for_active(
-                events,
-                &active,
-                &self.diagnostics_sequence,
-            );
-        }
-        publish_empty_diagnostics_snapshot(events, &self.diagnostics_sequence)
-    }
-
     fn shutdown(&self, events: Arc<Mutex<NativeEventHub>>) {
         let active = self.active.lock().ok().and_then(|slot| slot.clone());
         if let Some(active) = active {
@@ -1748,8 +1798,7 @@ impl NativePlaybackService {
 struct NativePlaybackServiceHandle {
     active: Arc<Mutex<Option<Arc<NativeActivePlayback>>>>,
     last_terminal: Arc<Mutex<Option<(String, PlaybackSessionState)>>>,
-    diagnostics_enabled: Arc<AtomicBool>,
-    diagnostics_sequence: Arc<AtomicU64>,
+    diagnostics_gate: Arc<DiagnosticsPublicationGate>,
     activity: ActivityCoordinator,
 }
 
@@ -1759,8 +1808,7 @@ impl NativePlaybackServiceHandle {
             prepared: Mutex::new(VecDeque::new()),
             active: self.active.clone(),
             last_terminal: self.last_terminal.clone(),
-            diagnostics_enabled: self.diagnostics_enabled.clone(),
-            diagnostics_sequence: self.diagnostics_sequence.clone(),
+            diagnostics_gate: self.diagnostics_gate.clone(),
             activity: self.activity.clone(),
         };
         service.monitor(active, events);
@@ -1770,46 +1818,50 @@ impl NativePlaybackServiceHandle {
 fn publish_diagnostics_snapshot_for_active(
     events: &Arc<Mutex<NativeEventHub>>,
     active: &NativeActivePlayback,
-    sequence: &AtomicU64,
+    gate: &DiagnosticsPublicationGate,
 ) -> Result<(), String> {
     let Some(player) = &active.player else {
         return Ok(());
     };
     let snapshot = player.snapshot_lite();
     let recent = snapshot.recent_latencies_us.as_slice();
-    let payload = crate::ui_events::DiagnosticsSnapshotDto {
-        seq: sequence.fetch_add(1, Ordering::Relaxed) + 1,
-        max_lateness_us: snapshot.max_lateness_us,
-        p50_ms: percentile_ms(recent, 0.50),
-        p95_ms: percentile_ms(recent, 0.95),
-        sigma_onset_ms: population_sigma_ms(recent),
-        late_2ms: snapshot.late_2ms,
-        late_5ms: snapshot.late_5ms,
-        late_10ms: snapshot.late_10ms,
-        active_keys: snapshot.active_count as u64,
-        stuck_keys: snapshot.failed_release_count as u64,
-        keys_dropped: snapshot.keys_dropped,
-        chord_split_events: snapshot.chord_split_events,
-        backend_status: diagnostics_backend_status(
-            snapshot.has_terminal_error,
-            snapshot.last_error.is_some(),
-            snapshot.failed_release_count,
-            snapshot.keys_dropped,
-            snapshot.chord_split_events,
-            snapshot.possibly_active_count,
-            snapshot.active_count,
-        ),
-        release_max_us: (snapshot.release_max_us > 0).then_some(snapshot.release_max_us),
-        release_late_2ms: (snapshot.release_late_2ms > 0).then_some(snapshot.release_late_2ms),
-        session_id: Some(active.session_id.clone()),
-    };
-    events
-        .lock()
-        .map_err(|_| "native event hub lock poisoned".to_string())?
-        .publish(UiEvent::DiagnosticsSnapshot {
-            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
-            payload,
-        })
+    let session_id = active.session_id.clone();
+    let _published = gate.try_publish(Instant::now(), |sequence| {
+        let payload = crate::ui_events::DiagnosticsSnapshotDto {
+            seq: sequence,
+            max_lateness_us: snapshot.max_lateness_us,
+            p50_ms: percentile_ms(recent, 0.50),
+            p95_ms: percentile_ms(recent, 0.95),
+            sigma_onset_ms: population_sigma_ms(recent),
+            late_2ms: snapshot.late_2ms,
+            late_5ms: snapshot.late_5ms,
+            late_10ms: snapshot.late_10ms,
+            active_keys: snapshot.active_count as u64,
+            stuck_keys: snapshot.failed_release_count as u64,
+            keys_dropped: snapshot.keys_dropped,
+            chord_split_events: snapshot.chord_split_events,
+            backend_status: diagnostics_backend_status(
+                snapshot.has_terminal_error,
+                snapshot.last_error.is_some(),
+                snapshot.failed_release_count,
+                snapshot.keys_dropped,
+                snapshot.chord_split_events,
+                snapshot.possibly_active_count,
+                snapshot.active_count,
+            ),
+            release_max_us: (snapshot.release_max_us > 0).then_some(snapshot.release_max_us),
+            release_late_2ms: (snapshot.release_late_2ms > 0).then_some(snapshot.release_late_2ms),
+            session_id: Some(session_id),
+        };
+        events
+            .lock()
+            .map_err(|_| "native event hub lock poisoned".to_string())?
+            .publish(UiEvent::DiagnosticsSnapshot {
+                v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+                payload,
+            })
+    })?;
+    Ok(())
 }
 
 fn diagnostics_backend_status(
@@ -1828,36 +1880,6 @@ fn diagnostics_backend_status(
     } else {
         crate::ui_events::DiagnosticsBackendStatus::Healthy
     }
-}
-
-fn publish_empty_diagnostics_snapshot(
-    events: &Arc<Mutex<NativeEventHub>>,
-    sequence: &AtomicU64,
-) -> Result<(), String> {
-    events
-        .lock()
-        .map_err(|_| "native event hub lock poisoned".to_string())?
-        .publish(UiEvent::DiagnosticsSnapshot {
-            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
-            payload: crate::ui_events::DiagnosticsSnapshotDto {
-                seq: sequence.fetch_add(1, Ordering::Relaxed) + 1,
-                max_lateness_us: 0,
-                p50_ms: 0.0,
-                p95_ms: 0.0,
-                sigma_onset_ms: 0.0,
-                late_2ms: 0,
-                late_5ms: 0,
-                late_10ms: 0,
-                active_keys: 0,
-                stuck_keys: 0,
-                keys_dropped: 0,
-                chord_split_events: 0,
-                backend_status: crate::ui_events::DiagnosticsBackendStatus::Unavailable,
-                release_max_us: None,
-                release_late_2ms: None,
-                session_id: None,
-            },
-        })
 }
 
 fn cleanup_failed_event_delivery(active: &NativeActivePlayback) {
@@ -2375,12 +2397,15 @@ fn remove_oldest_snapshot(buffered: &mut VecDeque<UiEvent>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_NATIVE_EVENTS, MAX_PREPARED_PLANS, MaterializedTimingPolicy, NativeDesktopRuntime,
-        NativeEventHub, diagnostics_backend_status, opaque_native_id, percentile_ms,
-        plan_fingerprint, population_sigma_ms, remove_oldest_snapshot, resolve_install_root,
-        retain_prepared_capacity, settings_fingerprint,
+        DiagnosticsPublicationGate, MAX_NATIVE_EVENTS, MAX_PREPARED_PLANS,
+        MaterializedTimingPolicy, NativeActivePlayback, NativeDesktopRuntime, NativeEventHub,
+        NativePlaybackService, PlaybackPendingControl, diagnostics_backend_status,
+        opaque_native_id, percentile_ms, plan_fingerprint, population_sigma_ms,
+        remove_oldest_snapshot, resolve_install_root, retain_prepared_capacity,
+        settings_fingerprint,
     };
-    use crate::commands::PlaybackConfigDto;
+    use crate::app_state::ActivityCoordinator;
+    use crate::commands::{PlaybackConfigDto, PlaybackSessionState};
     use crate::ui_events::{
         PlaybackEventState, PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload,
         UiEvent,
@@ -2388,7 +2413,42 @@ mod tests {
     use serde_json::Value;
     use sky_app_core::song::{build_schedule_with_policy, parse_song_json};
     use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::atomic::Ordering;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    fn active_for_control(
+        state: PlaybackSessionState,
+        pending: Option<PlaybackPendingControl>,
+    ) -> Arc<NativeActivePlayback> {
+        Arc::new(NativeActivePlayback {
+            session_id: "a".repeat(32),
+            prepared_id: "b".repeat(32),
+            song_id: "c".repeat(32),
+            title: "Fixture".into(),
+            total_us: 1_000_000,
+            config: PlaybackConfigDto {
+                hold_frames: 1.0,
+                tempo_scale: 1.0,
+                fps: 60,
+                dry_run: true,
+            },
+            plan_fingerprint: "d".repeat(64),
+            physical: false,
+            activity_lease: None,
+            target_hwnd: None,
+            state: Mutex::new(state),
+            pending: Mutex::new(pending),
+            player: None,
+            started_at: Instant::now(),
+            paused_since: Mutex::new(None),
+            paused_total: Mutex::new(Duration::ZERO),
+            stop_requested: std::sync::atomic::AtomicBool::new(false),
+            skip_requested: std::sync::atomic::AtomicBool::new(false),
+            done: std::sync::atomic::AtomicBool::new(false),
+            sequence: std::sync::atomic::AtomicU64::new(0),
+        })
+    }
 
     #[test]
     fn debug_install_root_is_repository_root_not_cwd() {
@@ -2531,6 +2591,201 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_gate_matches_python_rate_reset_and_sequence_contract() {
+        let gate = DiagnosticsPublicationGate::default();
+        gate.set_enabled(true).expect("enable");
+        let start = Instant::now();
+        let mut sequences = Vec::new();
+        assert!(
+            gate.try_publish(start, |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            })
+            .expect("first publication")
+        );
+        assert!(
+            !gate
+                .try_publish(start + Duration::from_millis(99), |_| Ok(()))
+                .expect("throttled publication")
+        );
+        assert!(
+            gate.try_publish(start + Duration::from_millis(100), |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            })
+            .expect("second publication")
+        );
+        gate.set_enabled(false).expect("disable");
+        assert!(
+            !gate
+                .try_publish(start + Duration::from_millis(200), |_| Ok(()))
+                .expect("disabled publication")
+        );
+        gate.set_enabled(true).expect("re-enable");
+        assert!(
+            gate.try_publish(start + Duration::from_millis(200), |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            })
+            .expect("fresh sampling window")
+        );
+        assert_eq!(sequences, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn diagnostics_disable_waits_for_in_flight_publication() {
+        let gate = Arc::new(DiagnosticsPublicationGate::default());
+        gate.set_enabled(true).expect("enable");
+        let start = Instant::now();
+        let emitted = Arc::new(Mutex::new(Vec::new()));
+        let (entered_sender, entered_receiver) = std::sync::mpsc::channel();
+        let (release_sender, release_receiver) = std::sync::mpsc::channel();
+        let disabled_returned = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_gate = Arc::clone(&gate);
+        let worker_emitted = Arc::clone(&emitted);
+        let worker_disabled_returned = Arc::clone(&disabled_returned);
+        let worker = std::thread::spawn(move || {
+            worker_gate
+                .try_publish(start, |sequence| {
+                    entered_sender.send(()).expect("entered receiver");
+                    release_receiver.recv().expect("release sender");
+                    assert!(!worker_disabled_returned.load(Ordering::Acquire));
+                    worker_emitted.lock().expect("emitted").push(sequence);
+                    Ok(())
+                })
+                .expect("publication")
+        });
+        entered_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("publisher entered");
+        let disable_gate = Arc::clone(&gate);
+        let disable_returned = Arc::clone(&disabled_returned);
+        let disable = std::thread::spawn(move || {
+            disable_gate.set_enabled(false).expect("disable");
+            disable_returned.store(true, Ordering::Release);
+        });
+        release_sender.send(()).expect("release publisher");
+        assert!(worker.join().expect("publisher thread"));
+        disable.join().expect("disable thread");
+        assert_eq!(*emitted.lock().expect("emitted"), vec![1]);
+        assert!(
+            !gate
+                .try_publish(start + Duration::from_millis(100), |_| Ok(()))
+                .expect("post-disable publication")
+        );
+    }
+
+    #[test]
+    fn terminal_stop_returns_the_stored_terminal_state() {
+        for terminal_state in [PlaybackSessionState::Finished, PlaybackSessionState::Failed] {
+            let service = NativePlaybackService::new(ActivityCoordinator::default());
+            *service.last_terminal.lock().expect("terminal state") =
+                Some(("a".repeat(32), terminal_state));
+            let acknowledgement = service
+                .command(
+                    "playback.stop",
+                    "a".repeat(32),
+                    Arc::new(Mutex::new(NativeEventHub::default())),
+                )
+                .expect("terminal stop is idempotent");
+            assert_eq!(acknowledgement.state, terminal_state);
+            assert!(acknowledgement.accepted);
+        }
+    }
+
+    #[test]
+    fn skip_is_live_only_and_clears_pending_pause_or_resume() {
+        let events = Arc::new(Mutex::new(NativeEventHub::default()));
+        for (state, pending) in [
+            (PlaybackSessionState::Starting, None),
+            (
+                PlaybackSessionState::Playing,
+                Some(PlaybackPendingControl::Pause),
+            ),
+            (
+                PlaybackSessionState::Paused,
+                Some(PlaybackPendingControl::Resume),
+            ),
+        ] {
+            let service = NativePlaybackService::new(ActivityCoordinator::default());
+            let active = active_for_control(state, pending);
+            *service.active.lock().expect("active") = Some(active.clone());
+            let acknowledgement = service
+                .command("playback.skip", active.session_id.clone(), events.clone())
+                .expect("skip in live state");
+            assert!(acknowledgement.accepted);
+            assert_eq!(acknowledgement.pending_command, None);
+            assert!(active.skip_requested.load(Ordering::Acquire));
+        }
+
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let active = active_for_control(PlaybackSessionState::Stopping, None);
+        *service.active.lock().expect("active") = Some(active.clone());
+        let error = service
+            .command("playback.skip", active.session_id.clone(), events)
+            .expect_err("skip after stopping must be rejected");
+        assert!(error.contains("live playback session"));
+    }
+
+    #[test]
+    fn repeated_pending_controls_and_invalid_transitions_match_command_contract() {
+        let events = Arc::new(Mutex::new(NativeEventHub::default()));
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let active = active_for_control(
+            PlaybackSessionState::Playing,
+            Some(PlaybackPendingControl::Pause),
+        );
+        *service.active.lock().expect("active") = Some(active.clone());
+        let repeated = service
+            .command("playback.pause", active.session_id.clone(), events.clone())
+            .expect("repeated pause");
+        assert_eq!(repeated.reason.as_deref(), Some("already_pending"));
+
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let active = active_for_control(
+            PlaybackSessionState::Paused,
+            Some(PlaybackPendingControl::Pause),
+        );
+        *service.active.lock().expect("active") = Some(active.clone());
+        let conflict = service
+            .command("playback.resume", active.session_id.clone(), events.clone())
+            .expect_err("resume conflicts with pending pause");
+        assert!(conflict.contains("another playback control is awaiting acknowledgement"));
+
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let active = active_for_control(
+            PlaybackSessionState::Paused,
+            Some(PlaybackPendingControl::Resume),
+        );
+        *service.active.lock().expect("active") = Some(active.clone());
+        let repeated = service
+            .command("playback.resume", active.session_id.clone(), events.clone())
+            .expect("repeated resume");
+        assert_eq!(repeated.reason.as_deref(), Some("already_pending"));
+
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let active = active_for_control(PlaybackSessionState::Starting, None);
+        *service.active.lock().expect("active") = Some(active.clone());
+        let pause_error = service
+            .command("playback.pause", active.session_id.clone(), events.clone())
+            .expect_err("pause before playing");
+        assert!(pause_error.contains("pause requires a playing session"));
+
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let active = active_for_control(PlaybackSessionState::Playing, None);
+        *service.active.lock().expect("active") = Some(active.clone());
+        let resume_error = service
+            .command("playback.resume", active.session_id.clone(), events.clone())
+            .expect_err("resume before pause");
+        assert!(resume_error.contains("resume requires a paused session"));
+
+        let foreign_error = service
+            .command("playback.stop", "f".repeat(32), events)
+            .expect_err("foreign session");
+        assert!(foreign_error.contains("stale or foreign"));
+    }
+
+    #[test]
     fn direct_native_player_keeps_the_qualified_supervisor_lease() {
         assert_eq!(
             sky_player::engine::DEFAULT_SUPERVISOR_LEASE_TIMEOUT_US,
@@ -2635,60 +2890,69 @@ mod tests {
     }
 
     #[test]
-    fn native_detail_uses_persisted_tempo_scale_for_schedule_and_risk() {
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!("sky-native-tempo-{suffix}"));
-        fs::create_dir_all(root.join("songs")).expect("songs root");
-        fs::write(
-            root.join("config.json"),
-            r#"{"schema_version":3,"default_tempo_scale":0.95}"#,
-        )
-        .expect("config");
-        fs::write(
-            root.join("songs/demo.json"),
-            r#"{"name":"Demo","songNotes":[{"time":1000,"key":"Key0"}]}"#,
-        )
-        .expect("song");
-        let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
-        let bootstrap = runtime.bootstrap().expect("bootstrap");
-        let search = runtime
-            .search(crate::commands::CatalogSearchRequest {
-                query: "demo".into(),
-                offset: 0,
-                limit: 10,
-                generation: Some(bootstrap.catalog_generation),
-            })
-            .expect("search");
-        let song_id = search.items[0].song_id.clone();
-        let settings = runtime.settings_snapshot().expect("settings");
-        let policy = runtime
-            .timing_policy(
-                settings.playback_defaults.fps,
-                settings.playback_defaults.hold_frames,
+    fn native_detail_matches_python_tempo_oracle_corpus() {
+        let fixture: Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/wave3/song_planning.json"
+        ))
+        .expect("tempo fixture");
+        let cases = fixture["detail_tempo_cases"]
+            .as_array()
+            .expect("detail tempo cases");
+        assert_eq!(cases.len(), 5);
+        for case in cases {
+            let tempo = case["tempo_scale"].as_f64().expect("tempo");
+            let suffix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!("sky-native-tempo-{suffix}"));
+            fs::create_dir_all(root.join("songs")).expect("songs root");
+            fs::write(
+                root.join("config.json"),
+                format!(r#"{{"schema_version":3,"default_tempo_scale":{tempo}}}"#),
             )
-            .expect("policy");
-        let song = parse_song_json(
-            br#"{"name":"Demo","songNotes":[{"time":1000,"key":"Key0"}]}"#,
-            "demo",
-        )
-        .expect("song");
-        let expected =
-            build_schedule_with_policy(&song, settings.playback_defaults.tempo_scale, &policy)
-                .expect("schedule")
-                .source_duration_us;
-        let detail = runtime
-            .detail(crate::commands::CatalogDetailRequest {
-                song_id,
-                generation: Some(bootstrap.catalog_generation),
-            })
-            .expect("detail");
-        assert_eq!(detail.duration_us, expected);
-        assert_ne!(detail.duration_us, 1_000_000 + policy.min_hold_us);
-        runtime.shutdown();
-        let _ = fs::remove_dir_all(root);
+            .expect("config");
+            fs::write(
+                root.join("songs/tempo.json"),
+                serde_json::to_vec(&case["raw"]).expect("raw song"),
+            )
+            .expect("song");
+            let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
+            let bootstrap = runtime.bootstrap().expect("bootstrap");
+            let search = runtime
+                .search(crate::commands::CatalogSearchRequest {
+                    query: String::new(),
+                    offset: 0,
+                    limit: 10,
+                    generation: Some(bootstrap.catalog_generation),
+                })
+                .expect("search");
+            let detail = runtime
+                .detail(crate::commands::CatalogDetailRequest {
+                    song_id: search.items[0].song_id.clone(),
+                    generation: Some(bootstrap.catalog_generation),
+                })
+                .expect("detail");
+            let actual = serde_json::to_value(&detail).expect("detail JSON");
+            assert_eq!(actual["duration_us"], case["duration_us"], "tempo {tempo}");
+            assert_eq!(actual["risk"]["level"], case["risk_level"], "tempo {tempo}");
+            assert_eq!(
+                actual["risk"]["recommendations"], case["risk_recommendations"],
+                "tempo {tempo}"
+            );
+            assert_eq!(
+                actual["recommendation"]["recommended_hold_frames"],
+                case["recommendation"]["recommended_hold_frames"],
+                "tempo {tempo}"
+            );
+            assert_eq!(
+                actual["recommendation"]["recommended_tempo_scale"],
+                case["recommendation"]["recommended_tempo_scale"],
+                "tempo {tempo}"
+            );
+            runtime.shutdown();
+            let _ = fs::remove_dir_all(root);
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -1,0 +1,2312 @@
+//! Native desktop application runtime.
+//!
+//! This is the composition root for commands that have crossed the strangler
+//! boundary.  It owns live application state and calls pure app-core services
+//! plus outer adapters.  It never delegates a native-owned command to the
+//! Python Core.
+
+use crate::commands::{
+    BootstrapDto, CatalogDetailRequest, CatalogReloadDto, CatalogRowDto, CatalogSearchDto,
+    CatalogSearchRequest, CatalogViewportDto, CatalogViewportRequest, DiagnosticsEnabledDto,
+    DiagnosticsSetEnabledRequest, PlaybackAdmission, PlaybackCommandAckDto, PlaybackConfigDto,
+    PlaybackDecision, PlaybackDecisionAcceptanceDto, PlaybackDefaultsDto, PlaybackPendingControl,
+    PlaybackPlanVariantDto, PlaybackPrepareRequest, PlaybackSessionDto, PlaybackSessionState,
+    PlaybackStartRequest, PreparedPlaybackDto, RiskDecisionDto, RiskSummaryDto, SettingsDto,
+    SettingsPatch, SongDetailDto, UpdatePreferencesDto, UpdatePreferencesPatch,
+};
+use crate::ui_events::{
+    CatalogChangedPayload, PlaybackEventState, PlaybackFailedPayload, PlaybackFinishedPayload,
+    PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload, PlaybackStateChangedPayload,
+    UiEvent,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use sky_app_core::catalog::{CatalogError, CatalogIndex, SongSource, WRatioRanker};
+use sky_app_core::settings::{
+    ApplicationSettings, PlaybackDefaultsPatch, SettingsError, SettingsService,
+    UpdatePreferencesPatch as CoreUpdatePreferencesPatch,
+};
+use sky_app_core::song::{
+    ActionKind, DOWN_LATE_GRACE_US, MIN_TRANSPORT_MARGIN_US, RiskReport, ScheduleMetadata, Song,
+    analyze_schedule_with_context, build_schedule, frame_us, parse_song_json,
+};
+use sky_native_adapters::{FileCatalogSource, JsonSettingsStore};
+use sky_player::adapter_support::{
+    ActionKind as DispatchActionKind, KeyActionInput, PriorityMode, compile_runtime_intents,
+};
+use sky_player::engine::{
+    BackendConfig, DispatchProfile, EnginePollStatus, FocusOptions, NativeDispatchSession,
+    NativeSessionOptions, PriorityOptions, TelemetryMode, TelemetryOptions, TimingOptions,
+    WaitOptions,
+};
+use smallvec::SmallVec;
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use tauri::ipc::Channel;
+
+pub(crate) const MAX_NATIVE_EVENTS: usize = 128;
+const MAX_PREPARED_PLANS: usize = 64;
+static NEXT_NATIVE_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) struct NativeDesktopRuntime {
+    #[allow(dead_code)]
+    install_root: PathBuf,
+    settings: Mutex<SettingsService<JsonSettingsStore>>,
+    catalog_source: FileCatalogSource,
+    catalog: Mutex<CatalogIndex>,
+    events: Arc<Mutex<NativeEventHub>>,
+    playback: Arc<NativePlaybackService>,
+    closed: AtomicBool,
+}
+
+impl NativeDesktopRuntime {
+    pub(crate) fn for_current_install() -> Result<Self, String> {
+        Self::from_install_root(resolve_install_root()?)
+    }
+
+    pub(crate) fn from_install_root(install_root: PathBuf) -> Result<Self, String> {
+        let settings_path = install_root.join("config.json");
+        let settings_store = JsonSettingsStore::new(settings_path);
+        let settings = SettingsService::load(settings_store)
+            .map_err(|error| format!("native settings startup failed: {error}"))?;
+        let songs_dir = install_root.join(settings.snapshot().songs_dir.clone());
+        Ok(Self {
+            install_root,
+            settings: Mutex::new(settings),
+            catalog_source: FileCatalogSource::new(songs_dir),
+            catalog: Mutex::new(CatalogIndex::default()),
+            events: Arc::new(Mutex::new(NativeEventHub::default())),
+            playback: Arc::new(NativePlaybackService::new()),
+            closed: AtomicBool::new(false),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn install_root(&self) -> &Path {
+        &self.install_root
+    }
+
+    pub(crate) fn dispatch(&self, method: &str, params: Value) -> Result<Value, String> {
+        if self.closed.load(Ordering::Acquire) {
+            return Err("native desktop runtime is shut down".into());
+        }
+        if crate::command_ownership::owner_for(method)
+            != Some(crate::command_ownership::CommandOwner::Native)
+        {
+            return Err(format!(
+                "native runtime does not own desktop command: {method}"
+            ));
+        }
+        match method {
+            "app.bootstrap" => encode_result(self.bootstrap()),
+            "catalog.search" => {
+                let request: CatalogSearchRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.search(request))
+            }
+            "catalog.detail" => {
+                let request: NativeCatalogDetailRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.detail(CatalogDetailRequest {
+                    song_id: request.song_id,
+                    generation: request.generation,
+                }))
+            }
+            "catalog.reload" => encode_result(self.reload()),
+            "catalog.set_viewport" => {
+                let request: NativeCatalogViewportRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.set_viewport(CatalogViewportRequest {
+                    generation: request.generation,
+                    first_index: request.first_index,
+                    last_index: request.last_index,
+                    selected_song_id: request.selected_song_id,
+                }))
+            }
+            "settings.get" => encode_result(self.settings_dto()),
+            "settings.patch" => {
+                let request: NativeSettingsPatch =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.patch_settings(request.into_public()))
+            }
+            "update.preferences.get" => encode_result(self.update_preferences()),
+            "update.preferences.patch" => {
+                let request: NativeUpdatePreferencesPatch =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.patch_update_preferences(request.into_public()))
+            }
+            "playback.prepare" => {
+                let request: NativePlaybackPrepareRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.prepare_playback(request.into_public()))
+            }
+            "playback.start" => {
+                let request: NativePlaybackStartRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.start_playback(request.into_public()))
+            }
+            "playback.stop" | "playback.pause" | "playback.resume" | "playback.skip" => {
+                let request: NativePlaybackSessionRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.playback_command(method, request.session_id))
+            }
+            "diagnostics.set_enabled" => {
+                let request: DiagnosticsSetEnabledRequest =
+                    serde_json::from_value(params).map_err(json_error)?;
+                encode_result(self.set_diagnostics_enabled(request))
+            }
+            _ => Err(format!("native command is not implemented: {method}")),
+        }
+    }
+
+    pub(crate) fn bootstrap(&self) -> Result<BootstrapDto, String> {
+        let snapshot = self.ensure_catalog_loaded()?;
+        let settings = self.settings_snapshot()?;
+        // Core remains the delivery source for `core.ready` while the
+        // transitional Python-owned commands still require its event stream.
+        // Emitting a second CoreReady here would duplicate the stable event on
+        // the shared Native/Core channel. The native bootstrap DTO below is
+        // authoritative for the command response itself.
+        Ok(BootstrapDto {
+            app_version: env!("CARGO_PKG_VERSION").into(),
+            protocol_version: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+            native_build: native_build_dto(),
+            playback_defaults: playback_defaults(&settings),
+            option_sets: crate::commands::PlaybackOptionSetsDto {
+                hold_frames: vec![1.0, 1.25, 1.5],
+                tempo_scales: vec![0.90, 0.95, 1.0, 1.05, 1.10],
+                fps: sky_app_core::settings::VALID_FPS.to_vec(),
+            },
+            theme: settings.theme.clone(),
+            telemetry_enabled: settings.telemetry_enabled,
+            update_preferences: update_preferences_dto(&settings),
+            catalog_generation: snapshot.generation,
+        })
+    }
+
+    fn settings_snapshot(&self) -> Result<ApplicationSettings, String> {
+        let mut service = self
+            .settings
+            .lock()
+            .map_err(|_| "native settings lock poisoned".to_string())?;
+        // Python-owned settings commands update this same file through an
+        // atomic replace, while Core keeps a process-local cache. Reloading
+        // the native shadow before a read prevents native playback and detail
+        // paths from observing stale persisted settings without introducing a
+        // second write authority or Native->Python fallback.
+        service
+            .reload()
+            .map_err(|error| format!("native settings reload failed: {error}"))?;
+        Ok(service.snapshot().clone())
+    }
+
+    fn settings_dto(&self) -> Result<SettingsDto, String> {
+        let settings = self.settings_snapshot()?;
+        Ok(settings_dto(&settings))
+    }
+
+    fn patch_settings(&self, patch: SettingsPatch) -> Result<SettingsDto, String> {
+        let core_patch = sky_app_core::settings::SettingsPatch {
+            theme: patch.theme,
+            telemetry_enabled: patch.telemetry_enabled,
+            verbose_hud: patch.verbose_hud,
+            playback_defaults: patch.playback_defaults.map(|value| PlaybackDefaultsPatch {
+                hold_frames: value.hold_frames,
+                tempo_scale: value.tempo_scale,
+                fps: value.fps,
+            }),
+            update: patch
+                .update_preferences
+                .map(|value| CoreUpdatePreferencesPatch {
+                    auto_check: value.auto_check,
+                    channel: value.channel.map(|channel| match channel {
+                        crate::ui_events::UpdateChannel::Stable => {
+                            sky_app_core::settings::UpdateChannel::Stable
+                        }
+                        crate::ui_events::UpdateChannel::Beta => {
+                            sky_app_core::settings::UpdateChannel::Beta
+                        }
+                    }),
+                    skip_version: value.skip_version,
+                }),
+        };
+        let mut settings = self
+            .settings
+            .lock()
+            .map_err(|_| "native settings lock poisoned".to_string())?;
+        let snapshot = settings.patch(&core_patch).map_err(settings_error)?;
+        self.playback.invalidate_settings();
+        Ok(settings_dto(snapshot))
+    }
+
+    fn update_preferences(&self) -> Result<UpdatePreferencesDto, String> {
+        let settings = self.settings_snapshot()?;
+        Ok(update_preferences_dto(&settings))
+    }
+
+    fn patch_update_preferences(
+        &self,
+        patch: UpdatePreferencesPatch,
+    ) -> Result<UpdatePreferencesDto, String> {
+        let mut settings = self
+            .settings
+            .lock()
+            .map_err(|_| "native settings lock poisoned".to_string())?;
+        let snapshot = settings
+            .patch(&sky_app_core::settings::SettingsPatch {
+                update: Some(CoreUpdatePreferencesPatch {
+                    auto_check: patch.auto_check,
+                    channel: patch.channel.map(|channel| match channel {
+                        crate::ui_events::UpdateChannel::Stable => {
+                            sky_app_core::settings::UpdateChannel::Stable
+                        }
+                        crate::ui_events::UpdateChannel::Beta => {
+                            sky_app_core::settings::UpdateChannel::Beta
+                        }
+                    }),
+                    skip_version: patch.skip_version,
+                }),
+                ..Default::default()
+            })
+            .map_err(settings_error)?;
+        Ok(update_preferences_dto(snapshot))
+    }
+
+    fn ensure_catalog_loaded(&self) -> Result<sky_app_core::catalog::CatalogSnapshot, String> {
+        let mut catalog = self
+            .catalog
+            .lock()
+            .map_err(|_| "native catalog lock poisoned".to_string())?;
+        if catalog.generation() == 0 {
+            let entries = self.catalog_source.entries().map_err(catalog_error)?;
+            catalog.replace_entries(entries).map_err(catalog_error)?;
+        }
+        Ok(catalog.snapshot())
+    }
+
+    fn reload(&self) -> Result<CatalogReloadDto, String> {
+        let entries = self.catalog_source.entries().map_err(catalog_error)?;
+        let snapshot = self
+            .catalog
+            .lock()
+            .map_err(|_| "native catalog lock poisoned".to_string())?
+            .replace_entries(entries)
+            .map_err(catalog_error)?;
+        self.playback.invalidate_catalog(snapshot.generation);
+        self.publish(UiEvent::CatalogChanged {
+            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+            payload: CatalogChangedPayload {
+                generation: snapshot.generation,
+                total: snapshot.total as u64,
+            },
+        })?;
+        Ok(CatalogReloadDto {
+            generation: snapshot.generation,
+            total: snapshot.total as u64,
+        })
+    }
+
+    fn search(&self, request: CatalogSearchRequest) -> Result<CatalogSearchDto, String> {
+        self.ensure_catalog_loaded()?;
+        let catalog = self
+            .catalog
+            .lock()
+            .map_err(|_| "native catalog lock poisoned".to_string())?;
+        let page = catalog
+            .search(
+                &WRatioRanker,
+                &request.query,
+                request.offset as usize,
+                request.limit as usize,
+                request.generation,
+            )
+            .map_err(catalog_error)?;
+        Ok(CatalogSearchDto {
+            items: page
+                .items
+                .into_iter()
+                .map(|row| CatalogRowDto {
+                    song_id: row.song_id,
+                    title: row.title,
+                    duration_us: None,
+                    note_count: None,
+                    risk_level: "unknown".into(),
+                    metadata_state: "pending".into(),
+                })
+                .collect(),
+            offset: request.offset,
+            limit: request.limit,
+            total: page.total as u64,
+            generation: page.generation,
+        })
+    }
+
+    fn detail(&self, request: CatalogDetailRequest) -> Result<SongDetailDto, String> {
+        self.ensure_catalog_loaded()?;
+        let catalog = self
+            .catalog
+            .lock()
+            .map_err(|_| "native catalog lock poisoned".to_string())?;
+        let entry = catalog
+            .entry_for_song_id(&request.song_id, request.generation)
+            .map_err(catalog_error)?;
+        let path = PathBuf::from(&entry.canonical_path);
+        let bytes = fs::read(&path).map_err(|error| format!("song read failed: {error}"))?;
+        let fallback = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&entry.row.title);
+        let song = parse_song_json(&bytes, fallback).map_err(|error| error.to_string())?;
+        let settings = self.settings_snapshot()?;
+        let schedule = build_schedule(
+            &song,
+            settings.playback_defaults.hold_frames,
+            1.0,
+            settings.playback_defaults.fps,
+        )
+        .map_err(|error| error.to_string())?;
+        let risk = analyze_schedule_with_context(
+            &schedule,
+            Some(&song.notes),
+            settings.playback_defaults.hold_frames,
+            1.0,
+        );
+        let risk_level = match risk.severity.as_str() {
+            "low" | "medium" | "high" => risk.severity.clone(),
+            _ => "unknown".into(),
+        };
+        let recommendations = if risk_level == "unknown" {
+            Vec::new()
+        } else {
+            risk.recommendations.clone()
+        };
+        let reasons = if risk_level == "low" {
+            Vec::new()
+        } else {
+            recommendations.clone()
+        };
+        let recommendation =
+            (risk_level != "unknown").then(|| crate::commands::PlaybackRecommendationDto {
+                recommended_hold_frames: risk.suggested_hold_frames,
+                recommended_tempo_scale: risk.suggested_tempo_scale,
+                summary: recommendations
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "Keep the selected settings.".into()),
+            });
+        Ok(SongDetailDto {
+            song_id: entry.row.song_id,
+            title: entry.row.title,
+            duration_us: schedule.source_duration_us,
+            note_count: song.notes.len() as u64,
+            format_label: path
+                .extension()
+                .and_then(|value| value.to_str())
+                .unwrap_or("unknown")
+                .to_ascii_uppercase(),
+            risk: RiskSummaryDto {
+                level: risk_level.clone(),
+                headline: match risk_level.as_str() {
+                    "low" => "Low timing risk".into(),
+                    "medium" => "Medium timing risk".into(),
+                    "high" => "High timing risk".into(),
+                    _ => "Risk unavailable".into(),
+                },
+                reasons,
+                recommendations,
+            },
+            recommendation,
+        })
+    }
+
+    fn set_viewport(&self, request: CatalogViewportRequest) -> Result<CatalogViewportDto, String> {
+        self.ensure_catalog_loaded()?;
+        let catalog = self
+            .catalog
+            .lock()
+            .map_err(|_| "native catalog lock poisoned".to_string())?;
+        let snapshot = catalog.snapshot();
+        if snapshot.generation != request.generation {
+            return Err("catalog generation is stale".into());
+        }
+        if snapshot.total == 0 {
+            if request.first_index != 0
+                || request.last_index != -1
+                || request.selected_song_id.is_some()
+            {
+                return Err("empty catalog viewport must be 0..-1 with no selected song".into());
+            }
+        } else if request.last_index < request.first_index as i64
+            || request.last_index as u64 >= snapshot.total as u64
+            || request
+                .last_index
+                .saturating_sub(request.first_index as i64)
+                .saturating_add(1)
+                > 2_000
+        {
+            return Err("catalog viewport is outside bounded index range".into());
+        }
+        if let Some(song_id) = &request.selected_song_id {
+            catalog
+                .canonical_path_for_song_id(song_id, Some(request.generation))
+                .map_err(catalog_error)?;
+        }
+        Ok(CatalogViewportDto {
+            accepted: true,
+            generation: request.generation,
+            first_index: request.first_index,
+            last_index: request.last_index,
+            selected_song_id: request.selected_song_id,
+        })
+    }
+
+    fn prepare_playback(
+        &self,
+        request: crate::commands::PlaybackPrepareRequest,
+    ) -> Result<PreparedPlaybackDto, String> {
+        self.ensure_catalog_loaded()?;
+        let catalog = self
+            .catalog
+            .lock()
+            .map_err(|_| "native catalog lock poisoned".to_string())?;
+        let entry = catalog
+            .entry_for_song_id(&request.song_id, Some(request.generation))
+            .map_err(catalog_error)?;
+        let path = PathBuf::from(&entry.canonical_path);
+        let bytes = fs::read(&path).map_err(|error| format!("song read failed: {error}"))?;
+        let fallback = path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or(&entry.row.title);
+        let song = parse_song_json(&bytes, fallback).map_err(|error| error.to_string())?;
+        let schedule = build_schedule(
+            &song,
+            request.config.hold_frames,
+            request.config.tempo_scale,
+            request.config.fps,
+        )
+        .map_err(|error| error.to_string())?;
+        let risk = analyze_schedule_with_context(
+            &schedule,
+            Some(&song.notes),
+            request.config.hold_frames,
+            request.config.tempo_scale,
+        );
+        self.playback.prepare(
+            request.song_id,
+            request.generation,
+            request.config,
+            song,
+            schedule,
+            risk,
+        )
+    }
+
+    fn start_playback(
+        &self,
+        request: crate::commands::PlaybackStartRequest,
+    ) -> Result<PlaybackSessionDto, String> {
+        let settings = self.settings_snapshot()?;
+        self.playback.start(request, &settings, self.events.clone())
+    }
+
+    fn playback_command(
+        &self,
+        method: &str,
+        session_id: String,
+    ) -> Result<PlaybackCommandAckDto, String> {
+        self.playback
+            .command(method, session_id, self.events.clone())
+    }
+
+    fn set_diagnostics_enabled(
+        &self,
+        request: DiagnosticsSetEnabledRequest,
+    ) -> Result<DiagnosticsEnabledDto, String> {
+        self.playback
+            .set_diagnostics_enabled(request.enabled, self.events.clone())?;
+        Ok(DiagnosticsEnabledDto {
+            enabled: request.enabled,
+        })
+    }
+
+    pub(crate) fn subscribe(&self, channel: Channel<UiEvent>) -> Result<(), String> {
+        self.events
+            .lock()
+            .map_err(|_| "native event hub lock poisoned".to_string())?
+            .subscribe(channel)
+    }
+
+    fn publish(&self, event: UiEvent) -> Result<(), String> {
+        self.events
+            .lock()
+            .map_err(|_| "native event hub lock poisoned".to_string())?
+            .publish(event)
+    }
+
+    pub(crate) fn shutdown(&self) {
+        if !self.closed.swap(true, Ordering::AcqRel) {
+            self.playback.shutdown(self.events.clone());
+            if let Ok(mut events) = self.events.lock() {
+                events.close();
+            }
+        }
+    }
+}
+
+/// Application-side playback control plane.  The realtime worker remains in
+/// `sky_player`; this service owns prepared-plan admission, the single active
+/// session rule, and the bounded supervisor loop around that worker.
+struct NativePlaybackService {
+    prepared: Mutex<HashMap<String, NativePreparedPlan>>,
+    active: Arc<Mutex<Option<Arc<NativeActivePlayback>>>>,
+    last_terminal: Arc<Mutex<Option<(String, PlaybackSessionState)>>>,
+    diagnostics_enabled: Arc<AtomicBool>,
+    diagnostics_sequence: Arc<AtomicU64>,
+}
+
+#[derive(Clone)]
+struct NativePreparedPlan {
+    song_id: String,
+    generation: u64,
+    song: Song,
+    dto: PreparedPlaybackDto,
+    variants: HashMap<PlaybackDecision, NativePlaybackVariant>,
+}
+
+#[derive(Clone)]
+struct NativePlaybackVariant {
+    config: PlaybackConfigDto,
+    schedule: ScheduleMetadata,
+    fingerprint: String,
+}
+
+struct NativeActivePlayback {
+    session_id: String,
+    prepared_id: String,
+    song_id: String,
+    title: String,
+    total_us: u64,
+    config: PlaybackConfigDto,
+    plan_fingerprint: String,
+    physical: bool,
+    state: Mutex<PlaybackSessionState>,
+    pending: Mutex<Option<PlaybackPendingControl>>,
+    player: Option<Arc<NativeDispatchSession>>,
+    started_at: Instant,
+    paused_since: Mutex<Option<Instant>>,
+    paused_total: Mutex<Duration>,
+    stop_requested: AtomicBool,
+    skip_requested: AtomicBool,
+    done: AtomicBool,
+    sequence: AtomicU64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativePlaybackPrepareRequest {
+    song_id: String,
+    generation: u64,
+    config: PlaybackConfigDto,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativePlaybackStartRequest {
+    prepared_id: String,
+    decisions: Vec<PlaybackDecisionAcceptanceDto>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativePlaybackSessionRequest {
+    session_id: String,
+}
+
+impl NativePlaybackPrepareRequest {
+    fn into_public(self) -> PlaybackPrepareRequest {
+        PlaybackPrepareRequest {
+            song_id: self.song_id,
+            generation: self.generation,
+            config: self.config,
+        }
+    }
+}
+
+impl NativePlaybackStartRequest {
+    fn into_public(self) -> PlaybackStartRequest {
+        PlaybackStartRequest {
+            prepared_id: self.prepared_id,
+            decisions: self.decisions,
+        }
+    }
+}
+
+fn opaque_native_id() -> String {
+    let sequence = NEXT_NATIVE_ID.fetch_add(1, Ordering::Relaxed);
+    let mut hasher = Sha256::new();
+    hasher.update(sequence.to_le_bytes());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    hasher.update(now.as_nanos().to_le_bytes());
+    hasher.update(std::process::id().to_le_bytes());
+    let digest = hasher.finalize();
+    digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn plan_fingerprint(
+    song_id: &str,
+    config: &PlaybackConfigDto,
+    schedule: &ScheduleMetadata,
+) -> Result<String, String> {
+    let frame = frame_us(config.fps).map_err(|error| error.to_string())?;
+    let actions = schedule
+        .actions
+        .iter()
+        .map(|action| {
+            serde_json::json!([
+                match action.kind {
+                    ActionKind::Down => "down",
+                    ActionKind::Up => "up",
+                },
+                action.at_us,
+                action.scan_codes,
+            ])
+        })
+        .collect::<Vec<_>>();
+    let payload = serde_json::json!({
+        "song_id": song_id,
+        "config": config,
+        "policy": {
+            "fps": config.fps,
+            "min_hold_us": ((config.hold_frames * frame as f64).ceil() as u64)
+                .saturating_add(DOWN_LATE_GRACE_US)
+                .saturating_add(MIN_TRANSPORT_MARGIN_US),
+            "min_release_gap_us": frame
+                .saturating_add(DOWN_LATE_GRACE_US)
+                .saturating_add(MIN_TRANSPORT_MARGIN_US),
+        },
+        "actions": actions,
+    });
+    let bytes = serde_json::to_vec(&payload).map_err(json_error)?;
+    let digest = Sha256::digest(bytes);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn risk_summary(risk: &RiskReport) -> RiskSummaryDto {
+    RiskSummaryDto {
+        level: risk.severity.clone(),
+        headline: match risk.severity.as_str() {
+            "low" => "Low timing risk".into(),
+            "medium" => "Medium timing risk".into(),
+            "high" => "High timing risk".into(),
+            _ => risk.reason.clone(),
+        },
+        reasons: if risk.reason.is_empty() {
+            Vec::new()
+        } else {
+            vec![risk.reason.clone()]
+        },
+        recommendations: risk.recommendations.clone(),
+    }
+}
+
+fn song_detail(
+    song_id: &str,
+    song: &Song,
+    schedule: &ScheduleMetadata,
+    risk: &RiskReport,
+) -> SongDetailDto {
+    let recommendation = crate::commands::PlaybackRecommendationDto {
+        recommended_hold_frames: risk.suggested_hold_frames,
+        recommended_tempo_scale: risk.suggested_tempo_scale,
+        summary: risk
+            .recommendations
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "Keep the selected settings.".into()),
+    };
+    SongDetailDto {
+        song_id: song_id.to_owned(),
+        title: song.name.clone(),
+        duration_us: schedule.source_duration_us,
+        note_count: song.notes.len() as u64,
+        format_label: "SHEET".into(),
+        risk: risk_summary(risk),
+        recommendation: Some(recommendation),
+    }
+}
+
+fn compile_dispatch_schedule(
+    schedule: &ScheduleMetadata,
+) -> Result<sky_player::adapter_support::RuntimeSchedule, String> {
+    let actions = schedule
+        .actions
+        .iter()
+        .enumerate()
+        .map(|(index, action)| KeyActionInput {
+            source_action_index: index as u32,
+            kind: match action.kind {
+                ActionKind::Down => DispatchActionKind::Down,
+                ActionKind::Up => DispatchActionKind::Up,
+            },
+            scheduled_us: action.at_us,
+            scan_codes: action
+                .scan_codes
+                .iter()
+                .copied()
+                .collect::<SmallVec<[u16; 4]>>(),
+            reason: Arc::<str>::from(action.reason.as_str()),
+        })
+        .collect::<Vec<_>>();
+    compile_runtime_intents(&actions, &sky_app_core::song::SKY_SCAN_CODES)
+        .map_err(|error| format!("native schedule compilation failed: {error}"))
+}
+
+impl NativePlaybackService {
+    fn new() -> Self {
+        Self {
+            prepared: Mutex::new(HashMap::new()),
+            active: Arc::new(Mutex::new(None)),
+            last_terminal: Arc::new(Mutex::new(None)),
+            diagnostics_enabled: Arc::new(AtomicBool::new(false)),
+            diagnostics_sequence: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn set_diagnostics_enabled(
+        &self,
+        enabled: bool,
+        events: Arc<Mutex<NativeEventHub>>,
+    ) -> Result<(), String> {
+        self.diagnostics_enabled.store(enabled, Ordering::Release);
+        if enabled {
+            self.publish_diagnostics_snapshot(&events, None)?;
+        }
+        Ok(())
+    }
+
+    fn prepare(
+        &self,
+        song_id: String,
+        generation: u64,
+        config: PlaybackConfigDto,
+        song: Song,
+        schedule: ScheduleMetadata,
+        risk: RiskReport,
+    ) -> Result<PreparedPlaybackDto, String> {
+        let detail = song_detail(&song_id, &song, &schedule, &risk);
+        if !config.dry_run && schedule.impossible_same_key_repeats > 0 {
+            return Ok(PreparedPlaybackDto {
+                prepared_id: None,
+                song: detail,
+                config,
+                admission: PlaybackAdmission::Blocked,
+                risk: risk_summary(&risk),
+                decisions: Vec::new(),
+                plan_fingerprint: None,
+                variants: Vec::new(),
+                error_code: Some("physical_infeasible".into()),
+                error_message: Some("playback contains infeasible same-key repeats".into()),
+            });
+        }
+        let fingerprint = plan_fingerprint(&song_id, &config, &schedule)?;
+        let admission = if risk.severity == "low" {
+            PlaybackAdmission::Ready
+        } else {
+            PlaybackAdmission::ConfirmationRequired
+        };
+        let prepared_id = opaque_native_id();
+        let base_variant = NativePlaybackVariant {
+            config: config.clone(),
+            schedule: schedule.clone(),
+            fingerprint: fingerprint.clone(),
+        };
+        let mut decisions = Vec::new();
+        let mut variants = HashMap::from([(PlaybackDecision::Proceed, base_variant)]);
+        let mut variant_dtos = vec![PlaybackPlanVariantDto {
+            decision: PlaybackDecision::Proceed,
+            config: config.clone(),
+            plan_fingerprint: fingerprint.clone(),
+        }];
+        if risk.severity != "low" {
+            decisions.push(RiskDecisionDto {
+                decision: PlaybackDecision::Proceed,
+                label: "Proceed with current settings".into(),
+            });
+            if let (Some(hold_frames), Some(tempo_scale)) =
+                (risk.suggested_hold_frames, risk.suggested_tempo_scale)
+                && (hold_frames != config.hold_frames || tempo_scale != config.tempo_scale)
+                && let Ok(recommended_schedule) =
+                    build_schedule(&song, hold_frames, tempo_scale, config.fps)
+                && (config.dry_run || recommended_schedule.impossible_same_key_repeats == 0)
+            {
+                let recommended_config = PlaybackConfigDto {
+                    hold_frames,
+                    tempo_scale,
+                    fps: config.fps,
+                    dry_run: config.dry_run,
+                };
+                let recommended_fingerprint =
+                    plan_fingerprint(&song_id, &recommended_config, &recommended_schedule)?;
+                variants.insert(
+                    PlaybackDecision::UseRecommended,
+                    NativePlaybackVariant {
+                        config: recommended_config.clone(),
+                        schedule: recommended_schedule,
+                        fingerprint: recommended_fingerprint.clone(),
+                    },
+                );
+                variant_dtos.push(PlaybackPlanVariantDto {
+                    decision: PlaybackDecision::UseRecommended,
+                    config: recommended_config,
+                    plan_fingerprint: recommended_fingerprint,
+                });
+                decisions.push(RiskDecisionDto {
+                    decision: PlaybackDecision::UseRecommended,
+                    label: "Use recommended settings".into(),
+                });
+            }
+            if !config.dry_run {
+                let dry_run_config = PlaybackConfigDto {
+                    dry_run: true,
+                    ..config.clone()
+                };
+                let dry_run_fingerprint = plan_fingerprint(&song_id, &dry_run_config, &schedule)?;
+                variants.insert(
+                    PlaybackDecision::DryRun,
+                    NativePlaybackVariant {
+                        config: dry_run_config.clone(),
+                        schedule: schedule.clone(),
+                        fingerprint: dry_run_fingerprint.clone(),
+                    },
+                );
+                variant_dtos.push(PlaybackPlanVariantDto {
+                    decision: PlaybackDecision::DryRun,
+                    config: dry_run_config,
+                    plan_fingerprint: dry_run_fingerprint,
+                });
+                decisions.push(RiskDecisionDto {
+                    decision: PlaybackDecision::DryRun,
+                    label: "Run a dry-run first".into(),
+                });
+            }
+        }
+        let dto = PreparedPlaybackDto {
+            prepared_id: Some(prepared_id.clone()),
+            song: detail,
+            config,
+            admission,
+            risk: risk_summary(&risk),
+            decisions,
+            plan_fingerprint: Some(fingerprint.clone()),
+            variants: variant_dtos,
+            error_code: None,
+            error_message: None,
+        };
+        let mut prepared = self
+            .prepared
+            .lock()
+            .map_err(|_| "native prepared-plan lock poisoned".to_string())?;
+        prepared.insert(
+            prepared_id,
+            NativePreparedPlan {
+                song_id,
+                generation,
+                song,
+                dto: dto.clone(),
+                variants,
+            },
+        );
+        while prepared.len() > MAX_PREPARED_PLANS {
+            let oldest = prepared.keys().next().cloned();
+            if let Some(oldest) = oldest {
+                prepared.remove(&oldest);
+            }
+        }
+        Ok(dto)
+    }
+
+    fn start(
+        &self,
+        request: PlaybackStartRequest,
+        settings: &ApplicationSettings,
+        events: Arc<Mutex<NativeEventHub>>,
+    ) -> Result<PlaybackSessionDto, String> {
+        let mut active_slot = self
+            .active
+            .lock()
+            .map_err(|_| "native active-playback lock poisoned".to_string())?;
+        if active_slot.is_some() {
+            return Err("another playback session is active".into());
+        }
+        let mut prepared = self
+            .prepared
+            .lock()
+            .map_err(|_| "native prepared-plan lock poisoned".to_string())?;
+        let record = prepared
+            .get(&request.prepared_id)
+            .cloned()
+            .ok_or_else(|| "prepared playback is stale or already consumed".to_string())?;
+        let accepted = request
+            .decisions
+            .iter()
+            .filter(|item| item.accepted)
+            .collect::<Vec<_>>();
+        let required = record
+            .dto
+            .decisions
+            .iter()
+            .map(|item| item.decision)
+            .collect::<Vec<_>>();
+        let selected = if record.dto.admission == PlaybackAdmission::Ready {
+            if !request.decisions.is_empty() {
+                return Err("ready playback accepts no risk decisions".into());
+            }
+            PlaybackDecision::Proceed
+        } else {
+            if accepted.len() != 1
+                || request.decisions.len() != 1
+                || !required.contains(&accepted[0].decision)
+            {
+                return Err("an exact risk decision is required".into());
+            }
+            accepted[0].decision
+        };
+        let variant = record
+            .variants
+            .get(&selected)
+            .cloned()
+            .ok_or_else(|| "selected risk decision has no prepared plan".to_string())?;
+        let player = if variant.config.dry_run {
+            None
+        } else {
+            Some(self.create_native_player(&variant.schedule, &variant.config, settings)?)
+        };
+        let session_id = opaque_native_id();
+        let active = Arc::new(NativeActivePlayback {
+            session_id: session_id.clone(),
+            prepared_id: request.prepared_id.clone(),
+            song_id: record.song_id.clone(),
+            title: record.song.name.clone(),
+            total_us: variant.schedule.duration_us,
+            config: variant.config.clone(),
+            plan_fingerprint: variant.fingerprint.clone(),
+            physical: player.is_some(),
+            state: Mutex::new(PlaybackSessionState::Starting),
+            pending: Mutex::new(None),
+            player,
+            started_at: Instant::now(),
+            paused_since: Mutex::new(None),
+            paused_total: Mutex::new(Duration::ZERO),
+            stop_requested: AtomicBool::new(false),
+            skip_requested: AtomicBool::new(false),
+            done: AtomicBool::new(false),
+            sequence: AtomicU64::new(0),
+        });
+        prepared.remove(&request.prepared_id);
+        *active_slot = Some(active.clone());
+        drop(prepared);
+        drop(active_slot);
+        if let Err(error) =
+            publish_playback_state(&events, &active, PlaybackEventState::Starting, None, None)
+        {
+            if let Some(player) = &active.player {
+                let _ = player.panic_release();
+                let _ = player.quit();
+                let _ = player.join(Duration::from_secs(5));
+            }
+            if let Ok(mut slot) = self.active.lock()
+                && slot
+                    .as_ref()
+                    .is_some_and(|current| Arc::ptr_eq(current, &active))
+            {
+                *slot = None;
+            }
+            if let Ok(mut prepared) = self.prepared.lock() {
+                prepared.insert(request.prepared_id, record);
+            }
+            return Err(error);
+        }
+        let service = Arc::new(self.clone_handle());
+        let active_for_thread = active.clone();
+        let spawn_result = thread::Builder::new()
+            .name("sky-native-playback-supervisor".into())
+            .spawn(move || service.monitor(active_for_thread, events));
+        if let Err(error) = spawn_result {
+            if let Some(player) = &active.player {
+                let _ = player.panic_release();
+                let _ = player.quit();
+                let _ = player.join(Duration::from_secs(5));
+            }
+            if let Ok(mut slot) = self.active.lock()
+                && slot
+                    .as_ref()
+                    .is_some_and(|current| Arc::ptr_eq(current, &active))
+            {
+                *slot = None;
+            }
+            if let Ok(mut prepared) = self.prepared.lock() {
+                prepared.insert(request.prepared_id, record);
+            }
+            return Err(format!(
+                "failed to start native playback supervisor: {error}"
+            ));
+        }
+        Ok(PlaybackSessionDto {
+            session_id,
+            prepared_id: active.prepared_id.clone(),
+            song_id: active.song_id.clone(),
+            state: PlaybackSessionState::Starting,
+            config: active.config.clone(),
+            plan_fingerprint: active.plan_fingerprint.clone(),
+        })
+    }
+
+    fn clone_handle(&self) -> NativePlaybackServiceHandle {
+        NativePlaybackServiceHandle {
+            active: self.active.clone(),
+            last_terminal: self.last_terminal.clone(),
+            diagnostics_enabled: self.diagnostics_enabled.clone(),
+            diagnostics_sequence: self.diagnostics_sequence.clone(),
+        }
+    }
+
+    fn create_native_player(
+        &self,
+        schedule: &ScheduleMetadata,
+        config: &PlaybackConfigDto,
+        settings: &ApplicationSettings,
+    ) -> Result<Arc<NativeDispatchSession>, String> {
+        let runtime_schedule = compile_dispatch_schedule(schedule)?;
+        let target = sky_dispatch_win32::focus::find_sky_window(
+            &settings.sky_process_names,
+            settings.allow_title_fallback,
+        )
+        .ok_or_else(|| "no admissible visible Sky window was found".to_string())?;
+        if !sky_dispatch_win32::focus::focus_window(target) {
+            return Err("validated Sky window could not be focused".into());
+        }
+        let frame = frame_us(config.fps).map_err(|error| error.to_string())?;
+        let player = Arc::new(NativeDispatchSession::new(NativeSessionOptions {
+            schedule: runtime_schedule,
+            backend: BackendConfig::Production,
+            profile: DispatchProfile::Production,
+            timing: TimingOptions {
+                game_fps: config.fps,
+                min_hold_us: ((config.hold_frames * frame as f64).ceil() as u64)
+                    .saturating_add(500)
+                    .saturating_add(300),
+                min_release_gap_us: frame.saturating_add(500).saturating_add(300),
+                down_late_grace_us: 500,
+                strict_timing: false,
+                strict_down_completion_late_us: 2_000,
+                strict_up_completion_late_us: 2_000,
+                input_path_warn_us: 300,
+            },
+            focus: FocusOptions {
+                require_focus: true,
+                focus_restore_grace_us: 100_000,
+            },
+            wait: WaitOptions {
+                enable_waitable_timer: true,
+                enable_event_wait: true,
+                supervisor_lease_timeout_us: 0,
+                #[cfg(feature = "tauri-test")]
+                test_spin_threshold_us: None,
+                #[cfg(feature = "tauri-test")]
+                test_wait_policy: sky_player::engine::TestWaitPolicy::LegacyTestWideSpin,
+            },
+            telemetry: TelemetryOptions {
+                mode: TelemetryMode::Ring,
+                capacity: 64,
+            },
+            priority: PriorityOptions {
+                mode: PriorityMode::Auto,
+            },
+            #[cfg(feature = "tauri-test")]
+            startup_ordering_hook: None,
+            #[cfg(feature = "tauri-test")]
+            restore_race_hook: None,
+            #[cfg(feature = "tauri-test")]
+            timer_lifecycle_context: None,
+        })?);
+        player.set_target_hwnd(target);
+        player.set_focus_hint(true);
+        player.arm(0)?;
+        Ok(player)
+    }
+
+    fn monitor(&self, active: Arc<NativeActivePlayback>, events: Arc<Mutex<NativeEventHub>>) {
+        let mut last_snapshot = Instant::now();
+        let mut last_event_state = PlaybackEventState::Starting;
+        loop {
+            if active.stop_requested.load(Ordering::Acquire) {
+                if let Some(player) = &active.player {
+                    let _ = player.quit();
+                    let _ = player.join(Duration::from_secs(5));
+                }
+                let _ = set_playback_state(&active, PlaybackSessionState::Finished);
+                let outcome = if active.skip_requested.load(Ordering::Acquire) {
+                    "skipped"
+                } else {
+                    "quit"
+                };
+                if publish_playback_finished(&events, &active, outcome, "Playback stopped").is_err()
+                {
+                    cleanup_failed_event_delivery(&active);
+                }
+                break;
+            }
+            let (elapsed, pre_roll_remaining, paused, finished, status) =
+                if let Some(player) = &active.player {
+                    let _ = player.heartbeat();
+                    let state = player.poll_state();
+                    (
+                        state.elapsed_us,
+                        state.pre_roll_remaining_us,
+                        state.is_paused,
+                        state.is_finished,
+                        state.status.as_str(),
+                    )
+                } else {
+                    let elapsed = dry_run_elapsed(&active);
+                    let paused = active
+                        .state
+                        .lock()
+                        .map(|state| *state == PlaybackSessionState::Paused)
+                        .unwrap_or(false);
+                    (
+                        elapsed,
+                        0,
+                        paused,
+                        elapsed >= active.total_us,
+                        if paused { "paused" } else { "playing" },
+                    )
+                };
+            let event_state = if paused {
+                PlaybackEventState::Paused
+            } else if status == EnginePollStatus::Playing.as_str() {
+                PlaybackEventState::Playing
+            } else if matches!(
+                status,
+                "error" | "panicked" | "poisoned" | "invalid" | "quit"
+            ) {
+                PlaybackEventState::Failed
+            } else {
+                PlaybackEventState::Starting
+            };
+            if event_state != last_event_state {
+                let state = match event_state {
+                    PlaybackEventState::Starting => PlaybackSessionState::Starting,
+                    PlaybackEventState::Playing => PlaybackSessionState::Playing,
+                    PlaybackEventState::Paused => PlaybackSessionState::Paused,
+                    PlaybackEventState::Stopping => PlaybackSessionState::Stopping,
+                    PlaybackEventState::Finished => PlaybackSessionState::Finished,
+                    PlaybackEventState::Failed => PlaybackSessionState::Failed,
+                };
+                let _ = set_playback_state(&active, state);
+                if matches!(
+                    (
+                        event_state,
+                        active.pending.lock().ok().and_then(|pending| *pending)
+                    ),
+                    (
+                        PlaybackEventState::Paused,
+                        Some(PlaybackPendingControl::Pause)
+                    ) | (
+                        PlaybackEventState::Playing,
+                        Some(PlaybackPendingControl::Resume)
+                    )
+                ) && let Ok(mut pending) = active.pending.lock()
+                {
+                    *pending = None;
+                }
+                if publish_playback_state(&events, &active, event_state, None, None).is_err() {
+                    cleanup_failed_event_delivery(&active);
+                    break;
+                }
+                last_event_state = event_state;
+            }
+            if last_snapshot.elapsed() >= Duration::from_millis(100) {
+                if publish_playback_snapshot(&events, &active, elapsed, pre_roll_remaining, paused)
+                    .is_err()
+                {
+                    cleanup_failed_event_delivery(&active);
+                    break;
+                }
+                if self.diagnostics_enabled.load(Ordering::Acquire)
+                    && publish_diagnostics_snapshot_for_active(
+                        &events,
+                        &active,
+                        &self.diagnostics_sequence,
+                    )
+                    .is_err()
+                {
+                    cleanup_failed_event_delivery(&active);
+                    break;
+                }
+                last_snapshot = Instant::now();
+            }
+            if finished {
+                let outcome = if status == EnginePollStatus::Skipped.as_str()
+                    || active.skip_requested.load(Ordering::Acquire)
+                {
+                    "skipped"
+                } else {
+                    "finished"
+                };
+                if matches!(status, "error" | "panicked" | "poisoned" | "invalid") {
+                    let _ = set_playback_state(&active, PlaybackSessionState::Failed);
+                    if publish_playback_failed(
+                        &events,
+                        &active,
+                        "native_player_failed",
+                        "Native playback worker failed",
+                    )
+                    .is_err()
+                    {
+                        cleanup_failed_event_delivery(&active);
+                    }
+                } else {
+                    let _ = set_playback_state(&active, PlaybackSessionState::Finished);
+                    if publish_playback_finished(&events, &active, outcome, "Playback finished")
+                        .is_err()
+                    {
+                        cleanup_failed_event_delivery(&active);
+                    }
+                }
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        if let Ok(mut slot) = self.active.lock()
+            && slot
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, &active))
+        {
+            *slot = None;
+        }
+        let terminal_state = active
+            .state
+            .lock()
+            .map(|state| *state)
+            .unwrap_or(PlaybackSessionState::Failed);
+        if let Ok(mut terminal) = self.last_terminal.lock() {
+            *terminal = Some((active.session_id.clone(), terminal_state));
+        }
+        active.done.store(true, Ordering::Release);
+    }
+
+    fn command(
+        &self,
+        method: &str,
+        session_id: String,
+        events: Arc<Mutex<NativeEventHub>>,
+    ) -> Result<PlaybackCommandAckDto, String> {
+        let active = self
+            .active
+            .lock()
+            .map_err(|_| "native active-playback lock poisoned".to_string())?
+            .clone();
+        let Some(active) = active else {
+            if method == "playback.stop"
+                && self
+                    .last_terminal
+                    .lock()
+                    .ok()
+                    .and_then(|value| value.clone())
+                    .is_some_and(|(id, _)| id == session_id)
+            {
+                return Ok(PlaybackCommandAckDto {
+                    accepted: true,
+                    session_id,
+                    state: PlaybackSessionState::Finished,
+                    pending_command: None,
+                    reason: None,
+                });
+            }
+            return Err("there is no active playback session".into());
+        };
+        if active.session_id != session_id {
+            return Err("session_id is stale or foreign".into());
+        }
+        let current = *active
+            .state
+            .lock()
+            .map_err(|_| "native playback state lock poisoned".to_string())?;
+        match method {
+            "playback.stop" => {
+                if !matches!(
+                    current,
+                    PlaybackSessionState::Starting
+                        | PlaybackSessionState::Playing
+                        | PlaybackSessionState::Paused
+                ) {
+                    return Ok(PlaybackCommandAckDto {
+                        accepted: true,
+                        session_id,
+                        state: current,
+                        pending_command: *active
+                            .pending
+                            .lock()
+                            .map_err(|_| "native playback control lock poisoned".to_string())?,
+                        reason: None,
+                    });
+                }
+                active.stop_requested.store(true, Ordering::Release);
+                *active
+                    .pending
+                    .lock()
+                    .map_err(|_| "native playback control lock poisoned".to_string())? = None;
+                let _ = set_playback_state(&active, PlaybackSessionState::Stopping);
+                if let Some(player) = &active.player {
+                    player.quit()?;
+                }
+                publish_playback_state(&events, &active, PlaybackEventState::Stopping, None, None)?;
+            }
+            "playback.pause" => {
+                if current != PlaybackSessionState::Playing {
+                    return Err("pause requires a playing session".into());
+                }
+                let mut pending = active
+                    .pending
+                    .lock()
+                    .map_err(|_| "native playback control lock poisoned".to_string())?;
+                if *pending == Some(PlaybackPendingControl::Pause) {
+                    return Ok(PlaybackCommandAckDto {
+                        accepted: true,
+                        session_id,
+                        state: current,
+                        pending_command: *pending,
+                        reason: Some("already_pending".into()),
+                    });
+                }
+                if pending.is_some() {
+                    return Err("another playback control is awaiting acknowledgement".into());
+                }
+                *pending = Some(PlaybackPendingControl::Pause);
+                drop(pending);
+                if let Some(player) = &active.player {
+                    if let Err(error) = player.pause() {
+                        if let Ok(mut pending) = active.pending.lock() {
+                            *pending = None;
+                        }
+                        return Err(error.to_string());
+                    }
+                } else {
+                    *active
+                        .paused_since
+                        .lock()
+                        .map_err(|_| "native playback pause lock poisoned".to_string())? =
+                        Some(Instant::now());
+                    set_playback_state(&active, PlaybackSessionState::Paused)?;
+                    publish_playback_state(
+                        &events,
+                        &active,
+                        PlaybackEventState::Paused,
+                        None,
+                        None,
+                    )?;
+                }
+            }
+            "playback.resume" => {
+                if current != PlaybackSessionState::Paused {
+                    return Err("resume requires a paused session".into());
+                }
+                let mut pending = active
+                    .pending
+                    .lock()
+                    .map_err(|_| "native playback control lock poisoned".to_string())?;
+                if *pending == Some(PlaybackPendingControl::Resume) {
+                    return Ok(PlaybackCommandAckDto {
+                        accepted: true,
+                        session_id,
+                        state: current,
+                        pending_command: *pending,
+                        reason: Some("already_pending".into()),
+                    });
+                }
+                if pending.is_some() {
+                    return Err("another playback control is awaiting acknowledgement".into());
+                }
+                *pending = Some(PlaybackPendingControl::Resume);
+                drop(pending);
+                if let Some(player) = &active.player {
+                    if let Err(error) = player.resume() {
+                        if let Ok(mut pending) = active.pending.lock() {
+                            *pending = None;
+                        }
+                        return Err(error.to_string());
+                    }
+                } else {
+                    let now = Instant::now();
+                    let paused_since = active
+                        .paused_since
+                        .lock()
+                        .map_err(|_| "native playback pause lock poisoned".to_string())?
+                        .take();
+                    if let Some(paused_since) = paused_since {
+                        *active
+                            .paused_total
+                            .lock()
+                            .map_err(|_| "native playback pause lock poisoned".to_string())? +=
+                            now.saturating_duration_since(paused_since);
+                    }
+                    set_playback_state(&active, PlaybackSessionState::Playing)?;
+                    publish_playback_state(
+                        &events,
+                        &active,
+                        PlaybackEventState::Playing,
+                        None,
+                        None,
+                    )?;
+                }
+            }
+            "playback.skip" => {
+                active.skip_requested.store(true, Ordering::Release);
+                if let Some(player) = &active.player {
+                    player.skip()?;
+                } else {
+                    active.stop_requested.store(true, Ordering::Release);
+                }
+            }
+            _ => return Err(format!("unsupported native playback command: {method}")),
+        }
+        Ok(PlaybackCommandAckDto {
+            accepted: true,
+            session_id,
+            state: *active
+                .state
+                .lock()
+                .map_err(|_| "native playback state lock poisoned".to_string())?,
+            pending_command: *active
+                .pending
+                .lock()
+                .map_err(|_| "native playback control lock poisoned".to_string())?,
+            reason: None,
+        })
+    }
+
+    fn invalidate_catalog(&self, generation: u64) {
+        if let Ok(mut prepared) = self.prepared.lock() {
+            prepared.retain(|_, record| record.generation == generation);
+        }
+    }
+
+    fn invalidate_settings(&self) {
+        if let Ok(mut prepared) = self.prepared.lock() {
+            prepared.clear();
+        }
+    }
+
+    fn publish_diagnostics_snapshot(
+        &self,
+        events: &Arc<Mutex<NativeEventHub>>,
+        active: Option<Arc<NativeActivePlayback>>,
+    ) -> Result<(), String> {
+        if let Some(active) =
+            active.or_else(|| self.active.lock().ok().and_then(|slot| slot.clone()))
+            && active.player.is_some()
+        {
+            return publish_diagnostics_snapshot_for_active(
+                events,
+                &active,
+                &self.diagnostics_sequence,
+            );
+        }
+        publish_empty_diagnostics_snapshot(events, &self.diagnostics_sequence)
+    }
+
+    fn shutdown(&self, events: Arc<Mutex<NativeEventHub>>) {
+        let active = self.active.lock().ok().and_then(|slot| slot.clone());
+        if let Some(active) = active {
+            active.stop_requested.store(true, Ordering::Release);
+            if let Some(player) = &active.player {
+                let _ = player.panic_release();
+                let _ = player.quit();
+                let _ = player.join(Duration::from_secs(5));
+            }
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while !active.done.load(Ordering::Acquire) && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(10));
+            }
+            let _ = publish_playback_state(
+                &events,
+                &active,
+                PlaybackEventState::Finished,
+                Some("shutdown".into()),
+                Some("quit".into()),
+            );
+        }
+    }
+}
+
+#[derive(Clone)]
+struct NativePlaybackServiceHandle {
+    active: Arc<Mutex<Option<Arc<NativeActivePlayback>>>>,
+    last_terminal: Arc<Mutex<Option<(String, PlaybackSessionState)>>>,
+    diagnostics_enabled: Arc<AtomicBool>,
+    diagnostics_sequence: Arc<AtomicU64>,
+}
+
+impl NativePlaybackServiceHandle {
+    fn monitor(&self, active: Arc<NativeActivePlayback>, events: Arc<Mutex<NativeEventHub>>) {
+        let service = NativePlaybackService {
+            prepared: Mutex::new(HashMap::new()),
+            active: self.active.clone(),
+            last_terminal: self.last_terminal.clone(),
+            diagnostics_enabled: self.diagnostics_enabled.clone(),
+            diagnostics_sequence: self.diagnostics_sequence.clone(),
+        };
+        service.monitor(active, events);
+    }
+}
+
+fn publish_diagnostics_snapshot_for_active(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    sequence: &AtomicU64,
+) -> Result<(), String> {
+    let Some(player) = &active.player else {
+        return Ok(());
+    };
+    let snapshot = player.snapshot_lite();
+    let recent = snapshot.recent_latencies_us.as_slice();
+    let payload = crate::ui_events::DiagnosticsSnapshotDto {
+        seq: sequence.fetch_add(1, Ordering::Relaxed) + 1,
+        max_lateness_us: snapshot.max_lateness_us,
+        p50_ms: percentile_ms(recent, 0.50),
+        p95_ms: percentile_ms(recent, 0.95),
+        sigma_onset_ms: population_sigma_ms(recent),
+        late_2ms: snapshot.late_2ms,
+        late_5ms: snapshot.late_5ms,
+        late_10ms: snapshot.late_10ms,
+        active_keys: snapshot.active_count as u64,
+        stuck_keys: snapshot.possibly_active_count as u64,
+        keys_dropped: snapshot.keys_dropped,
+        chord_split_events: snapshot.chord_split_events,
+        backend_status: if snapshot.has_terminal_error {
+            crate::ui_events::DiagnosticsBackendStatus::Error
+        } else {
+            crate::ui_events::DiagnosticsBackendStatus::Healthy
+        },
+        release_max_us: (snapshot.release_max_us > 0).then_some(snapshot.release_max_us),
+        release_late_2ms: (snapshot.release_late_2ms > 0).then_some(snapshot.release_late_2ms),
+        session_id: Some(active.session_id.clone()),
+    };
+    events
+        .lock()
+        .map_err(|_| "native event hub lock poisoned".to_string())?
+        .publish(UiEvent::DiagnosticsSnapshot {
+            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+            payload,
+        })
+}
+
+fn publish_empty_diagnostics_snapshot(
+    events: &Arc<Mutex<NativeEventHub>>,
+    sequence: &AtomicU64,
+) -> Result<(), String> {
+    events
+        .lock()
+        .map_err(|_| "native event hub lock poisoned".to_string())?
+        .publish(UiEvent::DiagnosticsSnapshot {
+            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+            payload: crate::ui_events::DiagnosticsSnapshotDto {
+                seq: sequence.fetch_add(1, Ordering::Relaxed) + 1,
+                max_lateness_us: 0,
+                p50_ms: 0.0,
+                p95_ms: 0.0,
+                sigma_onset_ms: 0.0,
+                late_2ms: 0,
+                late_5ms: 0,
+                late_10ms: 0,
+                active_keys: 0,
+                stuck_keys: 0,
+                keys_dropped: 0,
+                chord_split_events: 0,
+                backend_status: crate::ui_events::DiagnosticsBackendStatus::Unavailable,
+                release_max_us: None,
+                release_late_2ms: None,
+                session_id: None,
+            },
+        })
+}
+
+fn cleanup_failed_event_delivery(active: &NativeActivePlayback) {
+    active.stop_requested.store(true, Ordering::Release);
+    let _ = set_playback_state(active, PlaybackSessionState::Failed);
+    if let Some(player) = &active.player {
+        let _ = player.panic_release();
+        let _ = player.quit();
+        let _ = player.join(Duration::from_secs(5));
+    }
+}
+
+fn set_playback_state(
+    active: &NativeActivePlayback,
+    state: PlaybackSessionState,
+) -> Result<(), String> {
+    *active
+        .state
+        .lock()
+        .map_err(|_| "native playback state lock poisoned".to_string())? = state;
+    Ok(())
+}
+
+fn dry_run_elapsed(active: &NativeActivePlayback) -> u64 {
+    let paused_total = active
+        .paused_total
+        .lock()
+        .map(|value| *value)
+        .unwrap_or_default();
+    let current_pause = active
+        .paused_since
+        .lock()
+        .ok()
+        .and_then(|value| *value)
+        .map(|value| Instant::now().saturating_duration_since(value))
+        .unwrap_or_default();
+    active
+        .started_at
+        .elapsed()
+        .saturating_sub(paused_total)
+        .saturating_sub(current_pause)
+        .as_micros()
+        .min(u128::from(active.total_us)) as u64
+}
+
+fn publish_playback_state(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    state: PlaybackEventState,
+    message: Option<String>,
+    outcome: Option<String>,
+) -> Result<(), String> {
+    let event = UiEvent::PlaybackStateChanged {
+        v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+        payload: PlaybackStateChangedPayload {
+            session_id: active.session_id.clone(),
+            song_id: active.song_id.clone(),
+            state,
+            physical: active.physical,
+            message,
+            outcome,
+        },
+    };
+    events
+        .lock()
+        .map_err(|_| "native event hub lock poisoned".to_string())?
+        .publish(event)
+}
+
+fn publish_playback_snapshot(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    elapsed_us: u64,
+    pre_roll_remaining_us: u64,
+    paused: bool,
+) -> Result<(), String> {
+    let event = UiEvent::PlaybackSnapshot {
+        v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+        payload: PlaybackSnapshotPayload {
+            session_id: active.session_id.clone(),
+            seq: active.sequence.fetch_add(1, Ordering::Relaxed) + 1,
+            state: if paused {
+                PlaybackEventState::Paused
+            } else if pre_roll_remaining_us > 0 {
+                PlaybackEventState::Starting
+            } else {
+                PlaybackEventState::Playing
+            },
+            song_id: active.song_id.clone(),
+            title: active.title.clone(),
+            current_us: elapsed_us,
+            total_us: active.total_us,
+            pre_roll_remaining_us,
+            focus_state: PlaybackFocusState::Focused,
+            health: PlaybackHealthState::Healthy,
+            input_path_degraded: false,
+            message: None,
+        },
+    };
+    events
+        .lock()
+        .map_err(|_| "native event hub lock poisoned".to_string())?
+        .publish(event)
+}
+
+fn publish_playback_failed(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    code: &str,
+    message: &str,
+) -> Result<(), String> {
+    events
+        .lock()
+        .map_err(|_| "native event hub lock poisoned".to_string())?
+        .publish(UiEvent::PlaybackFailed {
+            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+            payload: PlaybackFailedPayload {
+                session_id: active.session_id.clone(),
+                song_id: active.song_id.clone(),
+                code: code.into(),
+                message: message.into(),
+            },
+        })
+}
+
+fn publish_playback_finished(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    outcome: &str,
+    message: &str,
+) -> Result<(), String> {
+    events
+        .lock()
+        .map_err(|_| "native event hub lock poisoned".to_string())?
+        .publish(UiEvent::PlaybackFinished {
+            v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+            payload: PlaybackFinishedPayload {
+                session_id: active.session_id.clone(),
+                song_id: active.song_id.clone(),
+                outcome: outcome.into(),
+                total_us: active.total_us,
+                message: message.into(),
+            },
+        })
+}
+
+fn resolve_install_root() -> Result<PathBuf, String> {
+    if let Some(value) = std::env::var_os("SKY_INSTALL_ROOT") {
+        return fs::canonicalize(value)
+            .map_err(|error| format!("invalid SKY_INSTALL_ROOT: {error}"));
+    }
+    if cfg!(debug_assertions) {
+        let root = std::env::var_os("SKY_DESKTOP_REPOSITORY_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..\\.."));
+        return fs::canonicalize(root)
+            .map_err(|error| format!("invalid debug repository root: {error}"));
+    }
+    let executable =
+        std::env::current_exe().map_err(|error| format!("cannot resolve executable: {error}"))?;
+    executable
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "executable has no install root".into())
+}
+
+fn native_build_dto() -> crate::commands::NativeBuildDto {
+    crate::commands::NativeBuildDto {
+        native_build_commit: option_env!("SKY_NATIVE_BUILD_COMMIT")
+            .unwrap_or("unknown")
+            .into(),
+        native_version: env!("CARGO_PKG_VERSION").into(),
+        schema_version: sky_dispatch_win32::calibration::CALIBRATION_SCHEMA_VERSION as u64,
+        native_abi: option_env!("SKY_NATIVE_ABI")
+            .unwrap_or("native-win32")
+            .into(),
+        rustc_version: option_env!("SKY_RUSTC_VERSION").unwrap_or("unknown").into(),
+        win32_backend: sky_dispatch_win32::win32_available(),
+    }
+}
+
+fn playback_defaults(settings: &ApplicationSettings) -> PlaybackDefaultsDto {
+    PlaybackDefaultsDto {
+        hold_frames: settings.playback_defaults.hold_frames,
+        tempo_scale: settings.playback_defaults.tempo_scale,
+        fps: settings.playback_defaults.fps,
+        dry_run: false,
+    }
+}
+
+fn update_preferences_dto(settings: &ApplicationSettings) -> UpdatePreferencesDto {
+    UpdatePreferencesDto {
+        auto_check: settings.update.auto_check,
+        channel: match settings.update.channel {
+            sky_app_core::settings::UpdateChannel::Stable => {
+                crate::ui_events::UpdateChannel::Stable
+            }
+            sky_app_core::settings::UpdateChannel::Beta => crate::ui_events::UpdateChannel::Beta,
+        },
+        skip_version: settings.update.skip_version.clone(),
+    }
+}
+
+fn settings_dto(settings: &ApplicationSettings) -> SettingsDto {
+    SettingsDto {
+        theme: settings.theme.clone(),
+        ui_background_mode: settings.ui_background_mode.clone(),
+        playback_defaults: playback_defaults(settings),
+        telemetry_enabled: settings.telemetry_enabled,
+        verbose_hud: settings.verbose_hud,
+        update_preferences: update_preferences_dto(settings),
+    }
+}
+
+fn json_error(error: impl std::fmt::Display) -> String {
+    error.to_string()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeCatalogDetailRequest {
+    song_id: String,
+    generation: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeCatalogViewportRequest {
+    generation: u64,
+    first_index: u64,
+    last_index: i64,
+    selected_song_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativePlaybackPatch {
+    hold_frames: Option<f64>,
+    tempo_scale: Option<f64>,
+    fps: Option<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeUpdatePreferencesPatch {
+    auto_check: Option<bool>,
+    channel: Option<crate::ui_events::UpdateChannel>,
+    skip_version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeSettingsPatch {
+    theme: Option<String>,
+    telemetry_enabled: Option<bool>,
+    verbose_hud: Option<bool>,
+    playback_defaults: Option<NativePlaybackPatch>,
+    update_preferences: Option<NativeUpdatePreferencesPatch>,
+}
+
+impl NativeUpdatePreferencesPatch {
+    fn into_public(self) -> UpdatePreferencesPatch {
+        UpdatePreferencesPatch {
+            auto_check: self.auto_check,
+            channel: self.channel,
+            skip_version: self.skip_version,
+        }
+    }
+}
+
+impl NativeSettingsPatch {
+    fn into_public(self) -> SettingsPatch {
+        SettingsPatch {
+            theme: self.theme,
+            telemetry_enabled: self.telemetry_enabled,
+            verbose_hud: self.verbose_hud,
+            playback_defaults: self
+                .playback_defaults
+                .map(|value| crate::commands::PlaybackPatch {
+                    hold_frames: value.hold_frames,
+                    tempo_scale: value.tempo_scale,
+                    fps: value.fps,
+                }),
+            update_preferences: self.update_preferences.map(|value| value.into_public()),
+        }
+    }
+}
+
+fn encode_result<T: serde::Serialize>(result: Result<T, String>) -> Result<Value, String> {
+    result
+        .map_err(|error| error.to_string())
+        .and_then(|value| serde_json::to_value(value).map_err(json_error))
+}
+fn settings_error(error: SettingsError) -> String {
+    error.to_string()
+}
+fn catalog_error(error: CatalogError) -> String {
+    error.to_string()
+}
+
+#[derive(Default)]
+struct NativeEventHub {
+    buffered: VecDeque<UiEvent>,
+    channel: Option<Channel<UiEvent>>,
+    closed: bool,
+}
+
+impl NativeEventHub {
+    fn publish(&mut self, event: UiEvent) -> Result<(), String> {
+        if self.closed {
+            return Err("native event hub is closed".into());
+        }
+        validate_ui_event(&event)?;
+        if let Some(channel) = &self.channel {
+            if let Err(error) = channel.send(event) {
+                // A failed delivery is not a queueing opportunity: buffering
+                // after a subscriber failure would hide the loss of the
+                // delivery contract and let a native worker continue without
+                // a consumer.  Close the hub and let the owner perform its
+                // bounded cleanup path.
+                self.channel = None;
+                self.closed = true;
+                self.buffered.clear();
+                return Err(format!("native UI event delivery failed: {error}"));
+            }
+            return Ok(());
+        }
+        if let Some(key) = snapshot_key(&event) {
+            if let Some(existing) = self
+                .buffered
+                .iter_mut()
+                .find(|candidate| snapshot_key(candidate).as_ref() == Some(&key))
+            {
+                *existing = event;
+                return Ok(());
+            }
+            if self.buffered.len() >= MAX_NATIVE_EVENTS
+                && !remove_oldest_snapshot(&mut self.buffered)
+            {
+                return Err("native event hub lifecycle buffer overflow".into());
+            }
+        } else if self.buffered.len() >= MAX_NATIVE_EVENTS
+            && !remove_oldest_snapshot(&mut self.buffered)
+        {
+            // Lifecycle events are never silently discarded.  The caller must
+            // initiate bounded cleanup when this fail-closed signal occurs.
+            return Err("native event hub lifecycle buffer overflow".into());
+        }
+        self.buffered.push_back(event);
+        Ok(())
+    }
+
+    fn subscribe(&mut self, channel: Channel<UiEvent>) -> Result<(), String> {
+        if self.closed {
+            return Err("native event hub is closed".into());
+        }
+        for event in &self.buffered {
+            if let Err(error) = channel.send(event.clone()) {
+                self.closed = true;
+                self.buffered.clear();
+                return Err(format!("native UI event replay failed: {error}"));
+            }
+        }
+        self.buffered.clear();
+        self.channel = Some(channel);
+        Ok(())
+    }
+
+    fn close(&mut self) {
+        self.closed = true;
+        self.channel = None;
+        self.buffered.clear();
+    }
+}
+
+fn validate_ui_event(event: &UiEvent) -> Result<(), String> {
+    match event {
+        UiEvent::CoreReady { payload, .. } => UiEvent::validate_ready(payload),
+        UiEvent::CoreFatal { payload, .. } => UiEvent::validate_fatal(payload),
+        UiEvent::CatalogChanged { payload, .. } => UiEvent::validate_catalog_changed(payload),
+        UiEvent::PlaybackStateChanged { payload, .. } => {
+            UiEvent::validate_playback_state_changed(payload)
+        }
+        UiEvent::PlaybackSnapshot { payload, .. } => UiEvent::validate_playback_snapshot(payload),
+        UiEvent::PlaybackFinished { payload, .. } => UiEvent::validate_playback_finished(payload),
+        UiEvent::PlaybackFailed { payload, .. } => UiEvent::validate_playback_failed(payload),
+        UiEvent::DiagnosticsSnapshot { payload, .. } => {
+            UiEvent::validate_diagnostics_snapshot(payload)
+        }
+        UiEvent::CalibrationProgress { payload, .. } => {
+            UiEvent::validate_calibration_progress(payload)
+        }
+        UiEvent::CalibrationFinished { payload, .. } => {
+            UiEvent::validate_calibration_finished(payload)
+        }
+        UiEvent::UpdateAvailable { payload, .. } => UiEvent::validate_update_available(payload),
+        UiEvent::UpdateResult { payload, .. } => UiEvent::validate_update_result(payload),
+        UiEvent::UpdateHandoffReady { payload, .. } => UiEvent::validate_update_handoff(payload),
+    }
+}
+
+fn snapshot_key(event: &UiEvent) -> Option<(u8, String)> {
+    match event {
+        UiEvent::PlaybackSnapshot { payload, .. } => Some((1, payload.session_id.clone())),
+        UiEvent::DiagnosticsSnapshot { payload, .. } => {
+            Some((2, payload.session_id.clone().unwrap_or_default()))
+        }
+        UiEvent::CalibrationProgress { payload, .. } => Some((3, payload.operation_id.clone())),
+        _ => None,
+    }
+}
+
+/// Match the Python diagnostics percentile contract.  Python's ``round``
+/// uses ties-to-even, so using `f64::round()` here would diverge for small
+/// sample sets at an exact half index.
+fn percentile_ms(values: &[i64], fraction: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mut ordered = values.to_vec();
+    ordered.sort_unstable();
+    let position = fraction * (ordered.len() - 1) as f64;
+    let lower = position.floor();
+    let fractional = position - lower;
+    let index = if fractional < 0.5 {
+        lower as usize
+    } else if fractional > 0.5 || (lower as usize) % 2 == 1 {
+        (lower as usize + 1).min(ordered.len() - 1)
+    } else {
+        lower as usize
+    };
+    ordered[index] as f64 / 1000.0
+}
+
+fn population_sigma_ms(values: &[i64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let mean = values.iter().map(|value| *value as f64).sum::<f64>() / values.len() as f64;
+    let variance = values
+        .iter()
+        .map(|value| {
+            let delta = *value as f64 - mean;
+            delta * delta
+        })
+        .sum::<f64>()
+        / values.len() as f64;
+    variance.sqrt() / 1000.0
+}
+
+fn remove_oldest_snapshot(buffered: &mut VecDeque<UiEvent>) -> bool {
+    let Some(index) = buffered
+        .iter()
+        .position(|event| snapshot_key(event).is_some())
+    else {
+        return false;
+    };
+    buffered.remove(index).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MAX_NATIVE_EVENTS, NativeDesktopRuntime, NativeEventHub, percentile_ms,
+        population_sigma_ms, resolve_install_root,
+    };
+    use crate::ui_events::{
+        PlaybackEventState, PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload,
+        UiEvent,
+    };
+    use serde_json::Value;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn debug_install_root_is_repository_root_not_cwd() {
+        if cfg!(debug_assertions) {
+            let root = resolve_install_root().expect("root");
+            assert!(root.join("rust").is_dir());
+            assert!(root.join("desktop").is_dir());
+        }
+    }
+
+    #[test]
+    fn native_bootstrap_uses_explicit_install_root_and_returns_plain_dto() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-native-runtime-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
+        let value = runtime
+            .dispatch("app.bootstrap", Value::Object(Default::default()))
+            .expect("bootstrap");
+        assert!(value.get("app_version").is_some());
+        assert!(value.get("Ok").is_none());
+        assert_eq!(runtime.install_root(), root.as_path());
+        assert!(
+            runtime
+                .dispatch("settings.get", Value::Object(Default::default()))
+                .is_err()
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn snapshot(session_id: &str, seq: u64) -> UiEvent {
+        UiEvent::PlaybackSnapshot {
+            v: 1,
+            payload: PlaybackSnapshotPayload {
+                session_id: session_id.into(),
+                seq,
+                state: PlaybackEventState::Playing,
+                song_id: "0123456789abcdef0123456789abcdef".into(),
+                title: "demo".into(),
+                current_us: seq,
+                total_us: 100,
+                pre_roll_remaining_us: 0,
+                focus_state: PlaybackFocusState::Focused,
+                health: PlaybackHealthState::Healthy,
+                input_path_degraded: false,
+                message: None,
+            },
+        }
+    }
+
+    #[test]
+    fn event_hub_coalesces_snapshots_and_fails_closed_for_lifecycle_overflow() {
+        let mut hub = NativeEventHub::default();
+        let session_id = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        hub.publish(snapshot(session_id, 1)).expect("snapshot");
+        hub.publish(snapshot(session_id, 2)).expect("coalesce");
+        assert_eq!(hub.buffered.len(), 1);
+        assert!(
+            matches!(hub.buffered.front(), Some(UiEvent::PlaybackSnapshot { payload, .. }) if payload.seq == 2)
+        );
+
+        for index in 0..MAX_NATIVE_EVENTS {
+            hub.publish(UiEvent::CatalogChanged {
+                v: 1,
+                payload: crate::ui_events::CatalogChangedPayload {
+                    generation: index as u64 + 1,
+                    total: 0,
+                },
+            })
+            .expect("snapshot slot can be evicted before lifecycle fill");
+        }
+        assert!(
+            hub.publish(UiEvent::CatalogChanged {
+                v: 1,
+                payload: crate::ui_events::CatalogChangedPayload {
+                    generation: 999,
+                    total: 0,
+                },
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn diagnostics_statistics_match_python_rounding_and_population_sigma() {
+        assert_eq!(percentile_ms(&[1, 2, 3, 4], 0.50), 0.003);
+        assert_eq!(percentile_ms(&[1, 2, 3, 4], 0.95), 0.004);
+        assert_eq!(
+            population_sigma_ms(&[1, 2, 3, 4]),
+            1.118033988749895 / 1000.0
+        );
+        assert_eq!(percentile_ms(&[], 0.50), 0.0);
+        assert_eq!(population_sigma_ms(&[]), 0.0);
+    }
+
+    #[test]
+    fn settings_and_catalog_changes_invalidate_prepared_native_playback() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-native-state-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        fs::write(
+            root.join("songs/demo.json"),
+            r#"{"name":"Demo","songNotes":[{"time":0,"key":"Key0"}]}"#,
+        )
+        .expect("song");
+        let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
+        let bootstrap = runtime
+            .dispatch("app.bootstrap", Value::Object(Default::default()))
+            .expect("bootstrap");
+        let generation = bootstrap["catalog_generation"]
+            .as_u64()
+            .expect("generation");
+        let search = runtime
+            .dispatch(
+                "catalog.search",
+                serde_json::json!({"query":"demo","offset":0,"limit":10,"generation":generation}),
+            )
+            .expect("search");
+        let song_id = search["items"][0]["song_id"]
+            .as_str()
+            .expect("song ID")
+            .to_owned();
+        let prepared = runtime
+            .dispatch(
+                "playback.prepare",
+                serde_json::json!({
+                    "song_id": song_id,
+                    "generation": generation,
+                    "config": {"hold_frames":1.0,"tempo_scale":1.0,"fps":60,"dry_run":true}
+                }),
+            )
+            .expect("prepare");
+        let prepared_id = prepared["prepared_id"]
+            .as_str()
+            .expect("prepared ID")
+            .to_owned();
+        runtime
+            .patch_settings(crate::commands::SettingsPatch {
+                theme: None,
+                telemetry_enabled: None,
+                verbose_hud: None,
+                playback_defaults: Some(crate::commands::PlaybackPatch {
+                    hold_frames: None,
+                    tempo_scale: Some(0.95),
+                    fps: None,
+                }),
+                update_preferences: None,
+            })
+            .expect("native settings invalidation seam");
+        assert!(
+            runtime
+                .dispatch(
+                    "playback.start",
+                    serde_json::json!({"prepared_id":prepared_id,"decisions":[]}),
+                )
+                .is_err()
+        );
+
+        let prepared = runtime
+            .dispatch(
+                "playback.prepare",
+                serde_json::json!({
+                    "song_id": song_id,
+                    "generation": generation,
+                    "config": {"hold_frames":1.0,"tempo_scale":1.0,"fps":60,"dry_run":true}
+                }),
+            )
+            .expect("prepare after settings patch");
+        let prepared_id = prepared["prepared_id"]
+            .as_str()
+            .expect("prepared ID")
+            .to_owned();
+        runtime
+            .dispatch("catalog.reload", Value::Object(Default::default()))
+            .expect("reload");
+        assert!(
+            runtime
+                .dispatch(
+                    "playback.start",
+                    serde_json::json!({"prepared_id":prepared_id,"decisions":[]}),
+                )
+                .is_err()
+        );
+        runtime.shutdown();
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -16,9 +16,9 @@ use crate::commands::{
     SettingsPatch, SongDetailDto, UpdatePreferencesDto, UpdatePreferencesPatch,
 };
 use crate::ui_events::{
-    CatalogChangedPayload, PlaybackEventState, PlaybackFailedPayload, PlaybackFinishedPayload,
-    PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload, PlaybackStateChangedPayload,
-    UiEvent,
+    CatalogChangedPayload, DiagnosticsBackendStatus, PlaybackEventState, PlaybackFailedPayload,
+    PlaybackFinishedPayload, PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload,
+    PlaybackStateChangedPayload, UiEvent,
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -54,6 +54,7 @@ use tauri::ipc::Channel;
 
 pub(crate) const MAX_NATIVE_EVENTS: usize = 128;
 const MAX_PREPARED_PLANS: usize = 64;
+const MAX_DECISION_COUNT: usize = 8;
 
 pub(crate) struct NativeDesktopRuntime {
     #[allow(dead_code)]
@@ -173,6 +174,7 @@ impl NativeDesktopRuntime {
             "playback.start" => {
                 let request: NativePlaybackStartRequest =
                     serde_json::from_value(params).map_err(json_error)?;
+                validate_playback_start_request(&request)?;
                 encode_result(self.start_playback(request.into_public()))
             }
             "playback.stop" | "playback.pause" | "playback.resume" | "playback.skip" => {
@@ -552,6 +554,7 @@ impl NativeDesktopRuntime {
         &self,
         request: crate::commands::PlaybackStartRequest,
     ) -> Result<PlaybackSessionDto, String> {
+        validate_public_playback_start_request(&request)?;
         let settings = self.settings_snapshot()?;
         self.playback.start(request, &settings, self.events.clone())
     }
@@ -778,6 +781,33 @@ impl NativePlaybackStartRequest {
             decisions: self.decisions,
         }
     }
+}
+
+fn validate_prepared_id(prepared_id: &str) -> Result<(), String> {
+    if prepared_id.len() != 32
+        || !prepared_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("invalid_params: prepared_id is invalid".into());
+    }
+    Ok(())
+}
+
+fn validate_playback_start_request(request: &NativePlaybackStartRequest) -> Result<(), String> {
+    validate_prepared_id(&request.prepared_id)?;
+    if request.decisions.len() > MAX_DECISION_COUNT {
+        return Err("invalid_params: decisions must be a bounded array".into());
+    }
+    Ok(())
+}
+
+fn validate_public_playback_start_request(request: &PlaybackStartRequest) -> Result<(), String> {
+    validate_prepared_id(&request.prepared_id)?;
+    if request.decisions.len() > MAX_DECISION_COUNT {
+        return Err("invalid_params: decisions must be a bounded array".into());
+    }
+    Ok(())
 }
 
 fn opaque_native_id() -> Result<String, String> {
@@ -1218,7 +1248,48 @@ impl NativePlaybackService {
                 settings,
             ) {
                 Ok((player, target)) => (Some(player), Some(target)),
-                Err(error) => return Err(error),
+                Err(error) => {
+                    // Match the Python supervisor's observable failure path:
+                    // a start that cannot pass focus/target admission still
+                    // has an ordered starting -> failed -> failed-event trace.
+                    let failed_active = Arc::new(NativeActivePlayback {
+                        session_id: session_id.clone(),
+                        prepared_id: request.prepared_id.clone(),
+                        song_id: record.song_id.clone(),
+                        title: record.song.name.clone(),
+                        total_us: variant.schedule.duration_us,
+                        config: variant.config.clone(),
+                        plan_fingerprint: variant.fingerprint.clone(),
+                        physical: true,
+                        activity_lease,
+                        target_hwnd: None,
+                        state: Mutex::new(PlaybackSessionState::Starting),
+                        pending: Mutex::new(None),
+                        player: None,
+                        started_at: Instant::now(),
+                        paused_since: Mutex::new(None),
+                        paused_total: Mutex::new(Duration::ZERO),
+                        stop_requested: AtomicBool::new(false),
+                        skip_requested: AtomicBool::new(false),
+                        done: AtomicBool::new(true),
+                        sequence: AtomicU64::new(0),
+                    });
+                    let _ = publish_playback_state(
+                        &events,
+                        &failed_active,
+                        PlaybackEventState::Starting,
+                        None,
+                        None,
+                    );
+                    let mut last_event_state = PlaybackEventState::Starting;
+                    let _ = publish_terminal_poll_result(
+                        &events,
+                        &failed_active,
+                        &mut last_event_state,
+                        EnginePollStatus::Error,
+                    );
+                    return Err(error);
+                }
             }
         };
         let active = Arc::new(NativeActivePlayback {
@@ -1395,13 +1466,19 @@ impl NativePlaybackService {
                     let _ = player.quit();
                     let _ = player.join(Duration::from_secs(5));
                 }
-                let _ = set_playback_state(&active, PlaybackSessionState::Finished);
                 let outcome = if active.skip_requested.load(Ordering::Acquire) {
                     "skipped"
                 } else {
                     "quit"
                 };
-                if publish_playback_finished(&events, &active, outcome, "Playback stopped").is_err()
+                if publish_stopped_completion(
+                    &events,
+                    &active,
+                    &mut last_event_state,
+                    outcome,
+                    "Playback stopped",
+                )
+                .is_err()
                 {
                     cleanup_failed_event_delivery(&active);
                 }
@@ -1415,47 +1492,42 @@ impl NativePlaybackService {
                 let focused = sky_dispatch_win32::focus::foreground_window_matches(target);
                 player.set_focus_hint(focused);
             }
-            let (elapsed, pre_roll_remaining, paused, finished, status) =
-                if let Some(player) = &active.player {
-                    if last_heartbeat.elapsed() >= Duration::from_millis(200) {
-                        let _ = player.heartbeat();
-                        last_heartbeat = Instant::now();
-                    }
-                    let state = player.poll_state();
-                    (
-                        state.elapsed_us,
-                        state.pre_roll_remaining_us,
-                        state.is_paused,
-                        state.is_finished,
-                        state.status.as_str(),
-                    )
-                } else {
-                    let elapsed = dry_run_elapsed(&active);
-                    let paused = active
-                        .state
-                        .lock()
-                        .map(|state| *state == PlaybackSessionState::Paused)
-                        .unwrap_or(false);
-                    (
-                        elapsed,
-                        0,
-                        paused,
-                        elapsed >= active.total_us,
-                        if paused { "paused" } else { "playing" },
-                    )
-                };
-            let event_state = if paused {
-                PlaybackEventState::Paused
-            } else if status == EnginePollStatus::Playing.as_str() {
-                PlaybackEventState::Playing
-            } else if matches!(
-                status,
-                "error" | "panicked" | "poisoned" | "invalid" | "quit"
-            ) {
-                PlaybackEventState::Failed
+            let (elapsed, pre_roll_remaining, status) = if let Some(player) = &active.player {
+                if last_heartbeat.elapsed() >= Duration::from_millis(200) {
+                    let _ = player.heartbeat();
+                    last_heartbeat = Instant::now();
+                }
+                let state = player.poll_state();
+                (state.elapsed_us, state.pre_roll_remaining_us, state.status)
             } else {
-                PlaybackEventState::Starting
+                let elapsed = dry_run_elapsed(&active);
+                let paused = active
+                    .state
+                    .lock()
+                    .map(|state| *state == PlaybackSessionState::Paused)
+                    .unwrap_or(false);
+                (
+                    elapsed,
+                    0,
+                    if elapsed >= active.total_us {
+                        EnginePollStatus::Finished
+                    } else if paused {
+                        EnginePollStatus::Paused
+                    } else {
+                        EnginePollStatus::Playing
+                    },
+                )
             };
+            let paused = status == EnginePollStatus::Paused;
+            let event_state = playback_event_state(status);
+            if is_terminal_status(status) {
+                if publish_terminal_poll_result(&events, &active, &mut last_event_state, status)
+                    .is_err()
+                {
+                    cleanup_failed_event_delivery(&active);
+                }
+                break;
+            }
             if event_state != last_event_state {
                 let state = match event_state {
                     PlaybackEventState::Starting => PlaybackSessionState::Starting,
@@ -1502,36 +1574,6 @@ impl NativePlaybackService {
                     break;
                 }
                 last_snapshot = Instant::now();
-            }
-            if finished {
-                let outcome = if status == EnginePollStatus::Skipped.as_str()
-                    || active.skip_requested.load(Ordering::Acquire)
-                {
-                    "skipped"
-                } else {
-                    "finished"
-                };
-                if matches!(status, "error" | "panicked" | "poisoned" | "invalid") {
-                    let _ = set_playback_state(&active, PlaybackSessionState::Failed);
-                    if publish_playback_failed(
-                        &events,
-                        &active,
-                        "native_player_failed",
-                        "Native playback worker failed",
-                    )
-                    .is_err()
-                    {
-                        cleanup_failed_event_delivery(&active);
-                    }
-                } else {
-                    let _ = set_playback_state(&active, PlaybackSessionState::Finished);
-                    if publish_playback_finished(&events, &active, outcome, "Playback finished")
-                        .is_err()
-                    {
-                        cleanup_failed_event_delivery(&active);
-                    }
-                }
-                break;
             }
             thread::sleep(Duration::from_millis(20));
         }
@@ -1773,7 +1815,30 @@ impl NativePlaybackService {
     fn shutdown(&self, events: Arc<Mutex<NativeEventHub>>) {
         let active = self.active.lock().ok().and_then(|slot| slot.clone());
         if let Some(active) = active {
-            active.stop_requested.store(true, Ordering::Release);
+            let current = active.state.lock().ok().map(|state| *state);
+            if matches!(
+                current,
+                Some(
+                    PlaybackSessionState::Starting
+                        | PlaybackSessionState::Playing
+                        | PlaybackSessionState::Paused
+                )
+            ) {
+                active.stop_requested.store(true, Ordering::Release);
+                if let Ok(mut pending) = active.pending.lock() {
+                    *pending = None;
+                }
+                let _ = set_playback_state(&active, PlaybackSessionState::Stopping);
+                let _ = publish_playback_state(
+                    &events,
+                    &active,
+                    PlaybackEventState::Stopping,
+                    None,
+                    None,
+                );
+            } else {
+                active.stop_requested.store(true, Ordering::Release);
+            }
             if let Some(player) = &active.player {
                 let _ = player.panic_release();
                 let _ = player.quit();
@@ -1783,13 +1848,6 @@ impl NativePlaybackService {
             while !active.done.load(Ordering::Acquire) && Instant::now() < deadline {
                 thread::sleep(Duration::from_millis(10));
             }
-            let _ = publish_playback_state(
-                &events,
-                &active,
-                PlaybackEventState::Finished,
-                Some("shutdown".into()),
-                Some("quit".into()),
-            );
         }
     }
 }
@@ -1815,24 +1873,132 @@ impl NativePlaybackServiceHandle {
     }
 }
 
+fn playback_event_state(status: EnginePollStatus) -> PlaybackEventState {
+    match status {
+        EnginePollStatus::Ready | EnginePollStatus::Preroll => PlaybackEventState::Starting,
+        EnginePollStatus::Playing => PlaybackEventState::Playing,
+        EnginePollStatus::Paused => PlaybackEventState::Paused,
+        EnginePollStatus::Finished | EnginePollStatus::Skipped | EnginePollStatus::Quit => {
+            PlaybackEventState::Finished
+        }
+        EnginePollStatus::Error
+        | EnginePollStatus::Panicked
+        | EnginePollStatus::Poisoned
+        | EnginePollStatus::Invalid => PlaybackEventState::Failed,
+    }
+}
+
+fn is_terminal_status(status: EnginePollStatus) -> bool {
+    matches!(
+        status,
+        EnginePollStatus::Finished
+            | EnginePollStatus::Skipped
+            | EnginePollStatus::Quit
+            | EnginePollStatus::Error
+            | EnginePollStatus::Panicked
+            | EnginePollStatus::Poisoned
+            | EnginePollStatus::Invalid
+    )
+}
+
+fn is_failure_status(status: EnginePollStatus) -> bool {
+    matches!(
+        status,
+        EnginePollStatus::Error
+            | EnginePollStatus::Panicked
+            | EnginePollStatus::Poisoned
+            | EnginePollStatus::Invalid
+    )
+}
+
+fn terminal_success_outcome(status: EnginePollStatus, skip_requested: bool) -> &'static str {
+    match status {
+        EnginePollStatus::Skipped => "skipped",
+        EnginePollStatus::Quit => "quit",
+        EnginePollStatus::Finished if skip_requested => "skipped",
+        _ => "finished",
+    }
+}
+
 fn publish_diagnostics_snapshot_for_active(
     events: &Arc<Mutex<NativeEventHub>>,
     active: &NativeActivePlayback,
     gate: &DiagnosticsPublicationGate,
 ) -> Result<(), String> {
-    let Some(player) = &active.player else {
-        return Ok(());
-    };
-    let snapshot = player.snapshot_lite();
-    let recent = snapshot.recent_latencies_us.as_slice();
+    let sample = active
+        .player
+        .as_ref()
+        .map(|player| NativeDiagnosticsSample::from_player(player))
+        .unwrap_or_else(NativeDiagnosticsSample::unavailable);
     let session_id = active.session_id.clone();
     let _published = gate.try_publish(Instant::now(), |sequence| {
         let payload = crate::ui_events::DiagnosticsSnapshotDto {
             seq: sequence,
+            max_lateness_us: sample.max_lateness_us,
+            p50_ms: percentile_ms(&sample.recent_latencies_us, 0.50),
+            p95_ms: percentile_ms(&sample.recent_latencies_us, 0.95),
+            sigma_onset_ms: population_sigma_ms(&sample.recent_latencies_us),
+            late_2ms: sample.late_2ms,
+            late_5ms: sample.late_5ms,
+            late_10ms: sample.late_10ms,
+            active_keys: sample.active_keys,
+            stuck_keys: sample.stuck_keys,
+            keys_dropped: sample.keys_dropped,
+            chord_split_events: sample.chord_split_events,
+            backend_status: sample.backend_status,
+            release_max_us: sample.release_max_us,
+            release_late_2ms: sample.release_late_2ms,
+            session_id: Some(session_id),
+        };
+        events
+            .lock()
+            .map_err(|_| "native event hub lock poisoned".to_string())?
+            .publish(UiEvent::DiagnosticsSnapshot {
+                v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
+                payload,
+            })
+    })?;
+    Ok(())
+}
+
+struct NativeDiagnosticsSample {
+    max_lateness_us: u64,
+    recent_latencies_us: Vec<i64>,
+    late_2ms: u64,
+    late_5ms: u64,
+    late_10ms: u64,
+    active_keys: u64,
+    stuck_keys: u64,
+    keys_dropped: u64,
+    chord_split_events: u64,
+    backend_status: DiagnosticsBackendStatus,
+    release_max_us: Option<u64>,
+    release_late_2ms: Option<u64>,
+}
+
+impl NativeDiagnosticsSample {
+    fn unavailable() -> Self {
+        Self {
+            max_lateness_us: 0,
+            recent_latencies_us: Vec::new(),
+            late_2ms: 0,
+            late_5ms: 0,
+            late_10ms: 0,
+            active_keys: 0,
+            stuck_keys: 0,
+            keys_dropped: 0,
+            chord_split_events: 0,
+            backend_status: DiagnosticsBackendStatus::Unavailable,
+            release_max_us: None,
+            release_late_2ms: None,
+        }
+    }
+
+    fn from_player(player: &NativeDispatchSession) -> Self {
+        let snapshot = player.snapshot_lite();
+        Self {
             max_lateness_us: snapshot.max_lateness_us,
-            p50_ms: percentile_ms(recent, 0.50),
-            p95_ms: percentile_ms(recent, 0.95),
-            sigma_onset_ms: population_sigma_ms(recent),
+            recent_latencies_us: snapshot.recent_latencies_us,
             late_2ms: snapshot.late_2ms,
             late_5ms: snapshot.late_5ms,
             late_10ms: snapshot.late_10ms,
@@ -1851,17 +2017,8 @@ fn publish_diagnostics_snapshot_for_active(
             ),
             release_max_us: (snapshot.release_max_us > 0).then_some(snapshot.release_max_us),
             release_late_2ms: (snapshot.release_late_2ms > 0).then_some(snapshot.release_late_2ms),
-            session_id: Some(session_id),
-        };
-        events
-            .lock()
-            .map_err(|_| "native event hub lock poisoned".to_string())?
-            .publish(UiEvent::DiagnosticsSnapshot {
-                v: crate::core::protocol::DESKTOP_PROTOCOL_VERSION,
-                payload,
-            })
-    })?;
-    Ok(())
+        }
+    }
 }
 
 fn diagnostics_backend_status(
@@ -2037,6 +2194,72 @@ fn publish_playback_snapshot(
         .lock()
         .map_err(|_| "native event hub lock poisoned".to_string())?
         .publish(event)
+}
+
+fn publish_terminal_poll_result(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    last_event_state: &mut PlaybackEventState,
+    status: EnginePollStatus,
+) -> Result<(), String> {
+    let terminal_state = playback_event_state(status);
+    let is_failure = is_failure_status(status);
+    if *last_event_state != terminal_state {
+        set_playback_state(
+            active,
+            if is_failure {
+                PlaybackSessionState::Failed
+            } else {
+                PlaybackSessionState::Finished
+            },
+        )?;
+        let (message, outcome) = if is_failure {
+            (Some("Native playback worker failed".into()), None)
+        } else {
+            (
+                Some("Playback finished".into()),
+                Some(
+                    terminal_success_outcome(status, active.skip_requested.load(Ordering::Acquire))
+                        .into(),
+                ),
+            )
+        };
+        publish_playback_state(events, active, terminal_state, message, outcome)?;
+        *last_event_state = terminal_state;
+    }
+    if is_failure {
+        publish_playback_failed(
+            events,
+            active,
+            "native_player_failed",
+            "Native playback worker failed",
+        )
+    } else {
+        let outcome =
+            terminal_success_outcome(status, active.skip_requested.load(Ordering::Acquire));
+        publish_playback_finished(events, active, outcome, "Playback finished")
+    }
+}
+
+fn publish_stopped_completion(
+    events: &Arc<Mutex<NativeEventHub>>,
+    active: &NativeActivePlayback,
+    last_event_state: &mut PlaybackEventState,
+    outcome: &str,
+    message: &str,
+) -> Result<(), String> {
+    set_playback_state(active, PlaybackSessionState::Finished)?;
+    if *last_event_state != PlaybackEventState::Finished {
+        publish_playback_state(
+            events,
+            active,
+            PlaybackEventState::Finished,
+            Some(message.into()),
+            Some(outcome.into()),
+        )?;
+        *last_event_state = PlaybackEventState::Finished;
+    }
+    publish_playback_finished(events, active, outcome, message)
 }
 
 fn publish_playback_failed(
@@ -2397,20 +2620,23 @@ fn remove_oldest_snapshot(buffered: &mut VecDeque<UiEvent>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        DiagnosticsPublicationGate, MAX_NATIVE_EVENTS, MAX_PREPARED_PLANS,
-        MaterializedTimingPolicy, NativeActivePlayback, NativeDesktopRuntime, NativeEventHub,
-        NativePlaybackService, PlaybackPendingControl, diagnostics_backend_status,
-        opaque_native_id, percentile_ms, plan_fingerprint, population_sigma_ms,
-        remove_oldest_snapshot, resolve_install_root, retain_prepared_capacity,
-        settings_fingerprint,
+        DiagnosticsPublicationGate, MAX_DECISION_COUNT, MAX_NATIVE_EVENTS, MAX_PREPARED_PLANS,
+        MaterializedTimingPolicy, NativeActivePlayback, NativeDesktopRuntime,
+        NativeDiagnosticsSample, NativeEventHub, NativePlaybackService, PlaybackPendingControl,
+        diagnostics_backend_status, opaque_native_id, percentile_ms, plan_fingerprint,
+        population_sigma_ms, publish_diagnostics_snapshot_for_active, publish_playback_state,
+        publish_stopped_completion, publish_terminal_poll_result, remove_oldest_snapshot,
+        resolve_install_root, retain_prepared_capacity, settings_fingerprint,
+        validate_playback_start_request,
     };
     use crate::app_state::ActivityCoordinator;
     use crate::commands::{PlaybackConfigDto, PlaybackSessionState};
     use crate::ui_events::{
-        PlaybackEventState, PlaybackFocusState, PlaybackHealthState, PlaybackSnapshotPayload,
-        UiEvent,
+        DiagnosticsBackendStatus, PlaybackEventState, PlaybackFocusState, PlaybackHealthState,
+        PlaybackSnapshotPayload, UiEvent,
     };
     use serde_json::Value;
+    use sky_app_core::settings::ApplicationSettings;
     use sky_app_core::song::{build_schedule_with_policy, parse_song_json};
     use std::fs;
     use std::sync::atomic::Ordering;
@@ -2420,6 +2646,14 @@ mod tests {
     fn active_for_control(
         state: PlaybackSessionState,
         pending: Option<PlaybackPendingControl>,
+    ) -> Arc<NativeActivePlayback> {
+        active_for_control_with_physical(state, pending, false)
+    }
+
+    fn active_for_control_with_physical(
+        state: PlaybackSessionState,
+        pending: Option<PlaybackPendingControl>,
+        physical: bool,
     ) -> Arc<NativeActivePlayback> {
         Arc::new(NativeActivePlayback {
             session_id: "a".repeat(32),
@@ -2434,7 +2668,7 @@ mod tests {
                 dry_run: true,
             },
             plan_fingerprint: "d".repeat(64),
-            physical: false,
+            physical,
             activity_lease: None,
             target_hwnd: None,
             state: Mutex::new(state),
@@ -2448,6 +2682,25 @@ mod tests {
             done: std::sync::atomic::AtomicBool::new(false),
             sequence: std::sync::atomic::AtomicU64::new(0),
         })
+    }
+
+    fn playback_trace(events: &Arc<Mutex<NativeEventHub>>) -> Vec<String> {
+        events
+            .lock()
+            .expect("event hub")
+            .buffered
+            .iter()
+            .filter_map(|event| match event {
+                UiEvent::PlaybackStateChanged { payload, .. } => {
+                    Some(format!("state:{}", payload.state.as_str()))
+                }
+                UiEvent::PlaybackFinished { payload, .. } => {
+                    Some(format!("finished:{}", payload.outcome))
+                }
+                UiEvent::PlaybackFailed { payload, .. } => Some(format!("failed:{}", payload.code)),
+                _ => None,
+            })
+            .collect()
     }
 
     #[test]
@@ -2676,6 +2929,79 @@ mod tests {
     }
 
     #[test]
+    fn diagnostics_dry_run_publishes_unavailable_snapshot() {
+        let events = Arc::new(Mutex::new(NativeEventHub::default()));
+        let gate = DiagnosticsPublicationGate::default();
+        gate.set_enabled(true).expect("enable");
+        let active = active_for_control(PlaybackSessionState::Playing, None);
+
+        publish_diagnostics_snapshot_for_active(&events, &active, &gate)
+            .expect("dry-run diagnostics");
+        let hub = events.lock().expect("event hub");
+        assert_eq!(hub.buffered.len(), 1);
+        let UiEvent::DiagnosticsSnapshot { payload, .. } = &hub.buffered[0] else {
+            panic!("expected diagnostics snapshot");
+        };
+        assert_eq!(payload.session_id.as_deref(), Some("a".repeat(32).as_str()));
+        assert_eq!(
+            payload.backend_status,
+            DiagnosticsBackendStatus::Unavailable
+        );
+        assert_eq!(payload.active_keys, 0);
+        assert_eq!(payload.stuck_keys, 0);
+        assert_eq!(payload.keys_dropped, 0);
+        assert_eq!(payload.chord_split_events, 0);
+        assert_eq!(payload.release_max_us, None);
+        assert_eq!(payload.release_late_2ms, None);
+        assert_eq!(payload.seq, 1);
+    }
+
+    #[test]
+    fn diagnostics_unavailable_path_keeps_rate_gate_and_monotonic_sequence() {
+        let gate = DiagnosticsPublicationGate::default();
+        gate.set_enabled(true).expect("enable");
+        let start = Instant::now();
+        let mut sequences = Vec::new();
+        for offset in [0, 1, 99, 100, 101] {
+            assert!(
+                gate.try_publish(start + Duration::from_millis(offset), |sequence| {
+                    sequences.push(sequence);
+                    Ok(())
+                })
+                .is_ok()
+            );
+        }
+        assert_eq!(sequences, vec![1, 2]);
+        gate.set_enabled(false).expect("disable");
+        assert!(
+            !gate
+                .try_publish(start + Duration::from_millis(200), |_| Ok(()))
+                .expect("disabled publication")
+        );
+        gate.set_enabled(true).expect("re-enable");
+        assert!(
+            gate.try_publish(start + Duration::from_millis(200), |sequence| {
+                sequences.push(sequence);
+                Ok(())
+            })
+            .expect("re-enabled publication")
+        );
+        assert_eq!(sequences, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn diagnostics_physical_healthy_status_remains_healthy() {
+        assert_eq!(
+            diagnostics_backend_status(false, false, 0, 0, 0, 0, 0),
+            DiagnosticsBackendStatus::Healthy
+        );
+        assert_eq!(
+            NativeDiagnosticsSample::unavailable().backend_status,
+            DiagnosticsBackendStatus::Unavailable
+        );
+    }
+
+    #[test]
     fn terminal_stop_returns_the_stored_terminal_state() {
         for terminal_state in [PlaybackSessionState::Finished, PlaybackSessionState::Failed] {
             let service = NativePlaybackService::new(ActivityCoordinator::default());
@@ -2691,6 +3017,304 @@ mod tests {
             assert_eq!(acknowledgement.state, terminal_state);
             assert!(acknowledgement.accepted);
         }
+    }
+
+    #[test]
+    fn terminal_player_statuses_publish_state_before_terminal_event() {
+        use sky_player::engine::EnginePollStatus;
+
+        for (status, expected) in [
+            (
+                EnginePollStatus::Finished,
+                vec!["state:finished", "finished:finished"],
+            ),
+            (
+                EnginePollStatus::Skipped,
+                vec!["state:finished", "finished:skipped"],
+            ),
+            (
+                EnginePollStatus::Quit,
+                vec!["state:finished", "finished:quit"],
+            ),
+            (
+                EnginePollStatus::Error,
+                vec!["state:failed", "failed:native_player_failed"],
+            ),
+            (
+                EnginePollStatus::Panicked,
+                vec!["state:failed", "failed:native_player_failed"],
+            ),
+            (
+                EnginePollStatus::Poisoned,
+                vec!["state:failed", "failed:native_player_failed"],
+            ),
+            (
+                EnginePollStatus::Invalid,
+                vec!["state:failed", "failed:native_player_failed"],
+            ),
+        ] {
+            let events = Arc::new(Mutex::new(NativeEventHub::default()));
+            let active =
+                active_for_control_with_physical(PlaybackSessionState::Playing, None, true);
+            let mut last_event_state = PlaybackEventState::Playing;
+            publish_terminal_poll_result(&events, &active, &mut last_event_state, status)
+                .expect("terminal event trace");
+            assert_eq!(
+                playback_trace(&events),
+                expected.into_iter().map(str::to_owned).collect::<Vec<_>>(),
+                "status {}",
+                status.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn focus_rejection_publishes_starting_then_failed_trace() {
+        use sky_player::engine::EnginePollStatus;
+
+        let events = Arc::new(Mutex::new(NativeEventHub::default()));
+        let active = active_for_control_with_physical(PlaybackSessionState::Starting, None, true);
+        publish_playback_state(&events, &active, PlaybackEventState::Starting, None, None)
+            .expect("starting event");
+        let mut last_event_state = PlaybackEventState::Starting;
+        publish_terminal_poll_result(
+            &events,
+            &active,
+            &mut last_event_state,
+            EnginePollStatus::Error,
+        )
+        .expect("focus rejection trace");
+        assert_eq!(
+            playback_trace(&events),
+            [
+                "state:starting",
+                "state:failed",
+                "failed:native_player_failed"
+            ]
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dry_run_completion_publishes_finished_before_terminal_event() {
+        use sky_player::engine::EnginePollStatus;
+
+        let events = Arc::new(Mutex::new(NativeEventHub::default()));
+        let active = active_for_control(PlaybackSessionState::Playing, None);
+        let mut last_event_state = PlaybackEventState::Playing;
+        publish_terminal_poll_result(
+            &events,
+            &active,
+            &mut last_event_state,
+            EnginePollStatus::Finished,
+        )
+        .expect("dry-run completion trace");
+        assert_eq!(
+            playback_trace(&events),
+            ["state:finished", "finished:finished"]
+                .into_iter()
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn stop_paths_publish_stopping_finished_then_finished_event() {
+        for initial_state in [
+            PlaybackSessionState::Starting,
+            PlaybackSessionState::Playing,
+            PlaybackSessionState::Paused,
+        ] {
+            let events = Arc::new(Mutex::new(NativeEventHub::default()));
+            let service = NativePlaybackService::new(ActivityCoordinator::default());
+            let active = active_for_control_with_physical(initial_state, None, true);
+            *service.active.lock().expect("active") = Some(active.clone());
+            service
+                .command("playback.stop", active.session_id.clone(), events.clone())
+                .expect("stop");
+            let mut last_event_state = match initial_state {
+                PlaybackSessionState::Starting => PlaybackEventState::Starting,
+                PlaybackSessionState::Playing => PlaybackEventState::Playing,
+                PlaybackSessionState::Paused => PlaybackEventState::Paused,
+                _ => unreachable!(),
+            };
+            publish_stopped_completion(
+                &events,
+                &active,
+                &mut last_event_state,
+                "quit",
+                "Playback stopped",
+            )
+            .expect("stop terminal event trace");
+            assert_eq!(
+                playback_trace(&events),
+                ["state:stopping", "state:finished", "finished:quit"]
+            );
+        }
+    }
+
+    #[test]
+    fn shutdown_completion_uses_the_same_terminal_event_sequence() {
+        let events = Arc::new(Mutex::new(NativeEventHub::default()));
+        let active = active_for_control(PlaybackSessionState::Starting, None);
+        let mut last_event_state = PlaybackEventState::Starting;
+        publish_playback_state(&events, &active, PlaybackEventState::Stopping, None, None)
+            .expect("stopping event");
+        publish_stopped_completion(
+            &events,
+            &active,
+            &mut last_event_state,
+            "quit",
+            "Playback stopped",
+        )
+        .expect("shutdown terminal event trace");
+        assert_eq!(
+            playback_trace(&events),
+            ["state:stopping", "state:finished", "finished:quit"]
+        );
+    }
+
+    #[test]
+    fn playback_start_validation_distinguishes_malformed_and_stale_ids() {
+        let malformed = super::NativePlaybackStartRequest {
+            prepared_id: "A".repeat(32),
+            decisions: Vec::new(),
+        };
+        let error = validate_playback_start_request(&malformed).expect_err("invalid ID");
+        assert!(error.starts_with("invalid_params:"));
+
+        let well_formed_stale = super::NativePlaybackStartRequest {
+            prepared_id: "a".repeat(32),
+            decisions: Vec::new(),
+        };
+        validate_playback_start_request(&well_formed_stale).expect("well-formed ID");
+        let service = NativePlaybackService::new(ActivityCoordinator::default());
+        let error = service
+            .start(
+                well_formed_stale.into_public(),
+                &ApplicationSettings::default(),
+                Arc::new(Mutex::new(NativeEventHub::default())),
+            )
+            .expect_err("stale ID");
+        assert!(error.contains("stale or already consumed"));
+    }
+
+    #[test]
+    fn playback_start_validation_bounds_decisions_before_admission() {
+        let oversized = super::NativePlaybackStartRequest {
+            prepared_id: "a".repeat(32),
+            decisions: vec![
+                crate::commands::PlaybackDecisionAcceptanceDto {
+                    decision: crate::commands::PlaybackDecision::Proceed,
+                    accepted: false,
+                };
+                super::MAX_DECISION_COUNT + 1
+            ],
+        };
+        let error = validate_playback_start_request(&oversized).expect_err("bounded decisions");
+        assert!(error.contains("decisions must be a bounded array"));
+    }
+
+    #[test]
+    fn routed_playback_start_validates_input_before_confirmation_and_lookup() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("sky-native-start-validation-{suffix}"));
+        fs::create_dir_all(root.join("songs")).expect("songs root");
+        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("config");
+        fs::write(
+            root.join("songs/ready.json"),
+            r#"{"name":"Ready","songNotes":[{"time":0,"key":"Key0"}]}"#,
+        )
+        .expect("song");
+        let runtime = NativeDesktopRuntime::from_install_root(root.clone()).expect("runtime");
+        let bootstrap = runtime
+            .dispatch("app.bootstrap", Value::Object(Default::default()))
+            .expect("bootstrap");
+        let generation = bootstrap["catalog_generation"]
+            .as_u64()
+            .expect("generation");
+        let search = runtime
+            .dispatch(
+                "catalog.search",
+                serde_json::json!({
+                    "query": "ready",
+                    "offset": 0,
+                    "limit": 10,
+                    "generation": generation
+                }),
+            )
+            .expect("search");
+        let song_id = search["items"][0]["song_id"]
+            .as_str()
+            .expect("song ID")
+            .to_owned();
+        let prepared = runtime
+            .dispatch(
+                "playback.prepare",
+                serde_json::json!({
+                    "song_id": song_id,
+                    "generation": generation,
+                    "config": {"hold_frames":1.0,"tempo_scale":1.0,"fps":60,"dry_run":true}
+                }),
+            )
+            .expect("prepare");
+        let prepared_id = prepared["prepared_id"]
+            .as_str()
+            .expect("prepared ID")
+            .to_owned();
+
+        let malformed = runtime.dispatch(
+            "playback.start",
+            serde_json::json!({"prepared_id":"A".repeat(32),"decisions":[]}),
+        );
+        assert!(
+            malformed
+                .expect_err("malformed ID")
+                .contains("invalid_params: prepared_id is invalid")
+        );
+
+        let oversized = runtime.dispatch(
+            "playback.start",
+            serde_json::json!({
+                "prepared_id": prepared_id,
+                "decisions": (0..=MAX_DECISION_COUNT)
+                    .map(|_| serde_json::json!({"decision":"proceed","accepted":false}))
+                    .collect::<Vec<_>>()
+            }),
+        );
+        assert!(
+            oversized
+                .expect_err("oversized decisions")
+                .contains("decisions must be a bounded array")
+        );
+
+        let wrong_confirmation = runtime.dispatch(
+            "playback.start",
+            serde_json::json!({
+                "prepared_id": prepared_id,
+                "decisions": [{"decision":"proceed","accepted":true}]
+            }),
+        );
+        assert!(
+            wrong_confirmation
+                .expect_err("ready plan must reject confirmation")
+                .contains("ready playback accepts no risk decisions")
+        );
+
+        let valid = runtime
+            .dispatch(
+                "playback.start",
+                serde_json::json!({"prepared_id":prepared_id,"decisions":[]}),
+            )
+            .expect("valid ready start");
+        assert_eq!(valid["state"], "starting");
+        runtime.shutdown();
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/desktop/src-tauri/tests/fixtures/fake_core.py
+++ b/desktop/src-tauri/tests/fixtures/fake_core.py
@@ -98,6 +98,24 @@ def command_result(item: dict[str, Any]) -> Any:
         }
     if method == "update.preferences.get":
         return {"auto_check": True, "channel": "stable", "skip_version": ""}
+    if method in {"settings.get", "settings.patch"}:
+        return {
+            "theme": "slate" if method == "settings.patch" else "aurora",
+            "ui_background_mode": "transparent",
+            "playback_defaults": {
+                "hold_frames": 1.0,
+                "tempo_scale": 0.95 if method == "settings.patch" else 1.0,
+                "fps": 60,
+                "dry_run": False,
+            },
+            "telemetry_enabled": False,
+            "verbose_hud": False,
+            "update_preferences": {
+                "auto_check": True,
+                "channel": "stable",
+                "skip_version": "",
+            },
+        }
     if method == "update.preferences.patch":
         params = item.get("params", {})
         return {

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,6 +24,8 @@ sources.
   invariants; current runtime remains in `architecture.md` until each phase passes.
 - [wave2-native-application-services.md](wave2-native-application-services.md) — current Wave 2
   application-core, adapter, ownership, event, and deliberate cutover boundaries.
+- [wave3-native-desktop-ownership.md](wave3-native-desktop-ownership.md) — current Wave 3 native
+  command ownership, composition, parity evidence, and remaining Python boundaries.
 - [rt-dispatch-architecture.md](rt-dispatch-architecture.md) — current native real-time dispatch
   contract and runtime boundary.
 - [timing-principles.md](timing-principles.md) — timing semantics, targets, measurement domains, and

--- a/docs/wave3-native-desktop-ownership.md
+++ b/docs/wave3-native-desktop-ownership.md
@@ -90,8 +90,10 @@ The labels below are intentionally conservative:
 * `UiEventHub` is bounded, coalesces latest-wins snapshot traffic, preserves
   lifecycle events, validates payload bounds, and fails closed on lifecycle
   overflow. Native events and decoded Core events use the same Tauri delivery
-  channel; per-source order is preserved, while no unproven global
-  cross-source order is promised.
+  channel. CoreSupervisor backlog, observer installation, AppState transition,
+  and live Core delivery share ordered queues, so per-Core-producer order is
+  preserved across the transition; no global Native/Core cross-source order is
+  promised.
 * Native playback uses the direct Rust player boundary. Ordinary tests use
   dry-run or safe seams; the direct supervisor retains the qualified
   3,000,000 µs lease, 20/200/100 ms control/focus/heartbeat/snapshot cadence,

--- a/docs/wave3-native-desktop-ownership.md
+++ b/docs/wave3-native-desktop-ownership.md
@@ -53,50 +53,88 @@ contract.
 
 ## Evidence status
 
+The labels below are intentionally conservative:
+
+* **PROVEN PARITY** means a committed Python-oracle or direct contract test
+  covers the stated behavior.
+* **NATIVE IMPLEMENTATION** means Rust owns the executable path, without
+  implying complete cross-runtime parity for every related behavior.
+* **TRANSITIONAL CROSS-OWNER BRIDGE** means Python remains authoritative while
+  the shell performs explicit synchronization or event relay.
+* **EXPLICITLY UNMIGRATED** means the behavior is intentionally still Python
+  or legacy owned.
+
 ### Proven parity
 
 * Persisted settings normalization and migration are exercised through the
   real `JsonSettingsStore -> SettingsService` path and committed Python
-  fixtures.
+  fixtures. Live settings commands remain Python-owned; the shell invalidates
+  native prepared plans under a shared coherence lock after a successful
+  Python patch.
 * Catalog IDs, canonical path handling, generation checks, Unicode NFKD/mark
   removal/`đ` replacement/casefold normalization, stable ordering, substring
   behavior, bounds, and the committed WRatio reference corpus are tested in
-  pure Rust.
-* Song parser, scheduler, and risk fixtures are generated from the current
-  Python implementation and consumed by Rust tests. The corpus is immutable in
-  normal CI.
+  pure Rust. The native catalog uses the bounded WRatio-compatible ranker;
+  rich detail and live authority are separately called out below.
+* The committed corpus covers the current Python song parser, scheduler, risk,
+  calibrated-policy, and canonical fingerprint cases exercised by this slice.
+  It is generated from the current implementation and immutable in normal CI;
+  the full playback state-machine and focus-loss trace corpus remains a
+  native implementation/qualification surface, not a blanket parity claim.
 * Update channel and retry policy behavior is fixture-backed.
 
 ### Native implementation
 
-* The native runtime owns the 13 commands listed above.
+* The native runtime owns the 13 commands listed above. Handler completeness
+  is checked against the dispatch branches, not only the policy matrix.
 * `UiEventHub` is bounded, coalesces latest-wins snapshot traffic, preserves
   lifecycle events, validates payload bounds, and fails closed on lifecycle
-  overflow. Native events and the remaining Core event stream use the same
-  Tauri delivery channel; per-source order is preserved, while no unproven
-  global cross-source order is promised.
+  overflow. Native events and decoded Core events use the same Tauri delivery
+  channel; per-source order is preserved, while no unproven global
+  cross-source order is promised.
 * Native playback uses the direct Rust player boundary. Ordinary tests use
-  dry-run or safe seams; physical-input qualification remains in the existing
-  native/player evidence paths.
+  dry-run or safe seams; the direct supervisor retains the qualified
+  3,000,000 µs lease, 20/200/100 ms control/focus/heartbeat/snapshot cadence,
+  exact-HWND verification, calibrated timing policy, and physical-input
+  worker final gate. The realtime worker itself remains unchanged. Full
+  prepare/control/shutdown trace parity remains an explicit Native
+  implementation qualification surface.
 * Update policy and preferences remain Python-owned as one coherent family
   until the hardened gateway boundary and Core cache can move together.
 
+The shell-level `ActivityCoordinator` is the single non-realtime gate for
+Native physical playback and Python calibration. It is atomic in either request
+ordering and is released on terminal, failure, cancellation, Core-failure,
+and shutdown paths. Successful calibration events also invalidate native
+prepared plans before being delivered.
+
+### Transitional cross-owner bridges
+
+* `settings.get` and `settings.patch` remain Python-owned because Core retains
+  a process-local settings cache. Successful Python settings patches are
+  serialized with native playback start and invalidate native prepared state.
+* `calibration.start` and `calibration.cancel` remain Python-owned. Their
+  admission is coordinated with native physical playback and Core terminal
+  events are relayed through the native event hub.
+
 ### Explicitly unmigrated
 
-* RapidFuzz WRatio is represented by a bounded pure-Rust compatibility ranker
-  and checked against the committed reference corpus, but rich catalog detail
-  and any live Python catalog authority outside the native route are not
-  removed from the repository.
+* Catalog WRatio/index/detail behavior is native only where the corresponding
+  contract is implemented; the Python catalog remains the oracle and no
+  independent Python generation is used for the native route.
 * Update network orchestration, exact handoff, and all calibration process /
   evidence-validation / cancellation behavior remain Python-owned.
-* Python source, Textual, PyO3/maturin, `sky_player_rs`, and Python tests are
-  retained as oracle and rollback material. They are not deleted or declared
-  obsolete by Wave 3.
+* The remaining eight Python command routes are the complete update family,
+  complete settings family, and calibration start/cancel as listed above.
+* Python rich catalog authority, any behavior not covered by the committed
+  native substring/WRatio fixtures, and the PyO3 wheel remain rollback/oracle
+  surfaces. Python source, Textual, and `sky_player_rs` are retained and are
+  not deleted or declared obsolete by Wave 3.
 
 ## Packaging status
 
 The existing portable release still includes `Sky-Auto-Player-Core.exe` and
 its Python `_internal` runtime because eight desktop command methods still
 depend on Core. Sidecar retirement is not claimed. It is safe to remove those
-files only after all remaining update and calibration ownership has moved and
-the native event/startup/shutdown retirement gate is independently proven.
+files only after the remaining Python-owned routes, event/startup/shutdown
+retirement gate, and full cross-owner parity are independently proven.

--- a/docs/wave3-native-desktop-ownership.md
+++ b/docs/wave3-native-desktop-ownership.md
@@ -1,0 +1,102 @@
+# Wave 3 native desktop ownership
+
+Wave 3 is the native desktop strangler boundary on top of the accepted Wave 2
+baseline. The Tauri command names, request/response DTOs, generated frontend
+contract, and serialized `UiEvent` shape remain unchanged.
+
+## Current ownership
+
+The delivery matrix is explicit and has one owner per command:
+
+```text
+Native: 13
+Python: 8
+```
+
+Native owns bootstrap/shutdown, catalog index/detail/reload/viewport, playback
+prepare/start/stop/pause/resume/skip, and diagnostics enablement. Python still
+owns the complete settings family, the complete update family, and calibration:
+`settings.get`, `settings.patch`, `update.check`, `update.preferences.get`,
+`update.preferences.patch`, `update.begin_handoff`, `calibration.start`, and
+`calibration.cancel`.
+
+Settings remain Python-owned deliberately: Core's process-local `AppConfig`
+cache is still live. Native services read the same atomically persisted store
+before native use, but no second Native write authority or Native-to-Python
+fallback is introduced.
+
+There is no production native-to-Python fallback. A failure is returned by the
+selected owner. The Python Core process is therefore still required by the
+normal GUI path and remains in the portable artifact during this wave.
+
+## Composition and safety boundaries
+
+```text
+Tauri delivery
+    -> NativeDesktopRuntime
+        -> sky_app_core / sky_native_adapters
+        -> sky_player -> dispatch crates
+        -> sky_updater (hardened outer implementation)
+    -> CoreSupervisor only for the eight explicit Python routes
+```
+
+`sky_app_core` remains inward and forbids Tauri, PyO3, Win32, the desktop
+shell, player, and concrete adapters. Filesystem access stays in
+`sky_native_adapters`; the production install root is derived from the running
+executable's parent, not the process working directory.
+
+The qualified `sky_player` realtime worker remains authoritative for physical
+input. Wave 3 changes its non-realtime application/control-plane caller only;
+it does not change QPC timing, MMCSS/priority behavior, SendInput, focus
+admission, bounded queues, release-all cleanup, or the hard-path allocation
+contract.
+
+## Evidence status
+
+### Proven parity
+
+* Persisted settings normalization and migration are exercised through the
+  real `JsonSettingsStore -> SettingsService` path and committed Python
+  fixtures.
+* Catalog IDs, canonical path handling, generation checks, Unicode NFKD/mark
+  removal/`đ` replacement/casefold normalization, stable ordering, substring
+  behavior, bounds, and the committed WRatio reference corpus are tested in
+  pure Rust.
+* Song parser, scheduler, and risk fixtures are generated from the current
+  Python implementation and consumed by Rust tests. The corpus is immutable in
+  normal CI.
+* Update channel and retry policy behavior is fixture-backed.
+
+### Native implementation
+
+* The native runtime owns the 13 commands listed above.
+* `UiEventHub` is bounded, coalesces latest-wins snapshot traffic, preserves
+  lifecycle events, validates payload bounds, and fails closed on lifecycle
+  overflow. Native events and the remaining Core event stream use the same
+  Tauri delivery channel; per-source order is preserved, while no unproven
+  global cross-source order is promised.
+* Native playback uses the direct Rust player boundary. Ordinary tests use
+  dry-run or safe seams; physical-input qualification remains in the existing
+  native/player evidence paths.
+* Update policy and preferences remain Python-owned as one coherent family
+  until the hardened gateway boundary and Core cache can move together.
+
+### Explicitly unmigrated
+
+* RapidFuzz WRatio is represented by a bounded pure-Rust compatibility ranker
+  and checked against the committed reference corpus, but rich catalog detail
+  and any live Python catalog authority outside the native route are not
+  removed from the repository.
+* Update network orchestration, exact handoff, and all calibration process /
+  evidence-validation / cancellation behavior remain Python-owned.
+* Python source, Textual, PyO3/maturin, `sky_player_rs`, and Python tests are
+  retained as oracle and rollback material. They are not deleted or declared
+  obsolete by Wave 3.
+
+## Packaging status
+
+The existing portable release still includes `Sky-Auto-Player-Core.exe` and
+its Python `_internal` runtime because eight desktop command methods still
+depend on Core. Sidecar retirement is not claimed. It is safe to remove those
+files only after all remaining update and calibration ownership has moved and
+the native event/startup/shutdown retirement gate is independently proven.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3072,6 +3072,7 @@ dependencies = [
 name = "sky_desktop_shell"
 version = "3.5.0"
 dependencies = [
+ "getrandom 0.3.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3116,6 +3117,7 @@ version = "0.1.0"
 dependencies = [
  "serde_json",
  "sky_app_core",
+ "sky_player",
  "windows-sys 0.61.2",
 ]
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3074,8 +3074,13 @@ version = "3.5.0"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2 0.11.0",
+ "sky_app_core",
  "sky_dispatch_win32",
+ "sky_native_adapters",
+ "sky_player",
  "sky_updater",
+ "smallvec",
  "tauri",
  "tauri-build",
  "thiserror 2.0.20",

--- a/rust/crates/sky_app_core/Cargo.toml
+++ b/rust/crates/sky_app_core/Cargo.toml
@@ -10,9 +10,7 @@ name = "sky_app_core"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
+serde_json = "1"
 thiserror = "2"
 unicode-casefold = "0.2"
 unicode-normalization = "0.1.24"
-
-[dev-dependencies]
-serde_json = "1"

--- a/rust/crates/sky_app_core/src/catalog.rs
+++ b/rust/crates/sky_app_core/src/catalog.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::Path;
 use unicode_casefold::UnicodeCaseFold;
 use unicode_normalization::{UnicodeNormalization, char::is_combining_mark};
@@ -28,6 +28,14 @@ pub struct CatalogSourceEntry {
 pub struct CatalogRow {
     pub song_id: String,
     pub title: String,
+}
+
+/// Trusted in-process lookup returned to outer adapters.  The canonical path
+/// never crosses the delivery DTO boundary; it is only used for file access.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogEntryView {
+    pub row: CatalogRow,
+    pub canonical_path: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,6 +91,40 @@ pub trait FuzzyRanker {
     fn rank(&self, query: &str, search_keys: &[String], score_cutoff: f64) -> Vec<usize>;
 }
 
+/// Bounded WRatio-compatible ranker for the native index.
+///
+/// RapidFuzz's WRatio is a composition of normalized Levenshtein, partial,
+/// token-sort, and token-set ratios.  The native implementation keeps the
+/// same score selection/cutoff policy while operating on the already
+/// normalized catalog keys.  It is deliberately allocation-bounded by the
+/// catalog query and entry caps; it is not used from the realtime thread.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WRatioRanker;
+
+impl FuzzyRanker for WRatioRanker {
+    fn rank(&self, query: &str, search_keys: &[String], score_cutoff: f64) -> Vec<usize> {
+        let mut matches = search_keys
+            .iter()
+            .enumerate()
+            .filter_map(|(index, key)| {
+                let score = if key.contains(query) {
+                    100.0
+                } else {
+                    wratio_score(query, key)
+                };
+                (score >= score_cutoff).then_some((index, score))
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by(|left, right| {
+            right
+                .1
+                .total_cmp(&left.1)
+                .then_with(|| left.0.cmp(&right.0))
+        });
+        matches.into_iter().map(|(index, _)| index).collect()
+    }
+}
+
 pub trait SongSource {
     fn entries(&self) -> Result<Vec<CatalogSourceEntry>, CatalogError>;
 }
@@ -113,13 +155,10 @@ impl CatalogIndex {
             if !is_supported_path(&source.canonical_path) {
                 return Err(CatalogError::UnsupportedExtension);
             }
-            if seen_paths
-                .insert(source.canonical_path.clone(), ())
-                .is_some()
-            {
+            let normalized_path = normalized_canonical_path(&source.canonical_path);
+            if seen_paths.insert(normalized_path.clone(), ()).is_some() {
                 continue;
             }
-            let normalized_path = normalized_canonical_path(&source.canonical_path);
             let song_id = song_id_for_canonical_path(&source.canonical_path);
             if let Some(previous) = by_id.get(&song_id) {
                 if normalized_canonical_path(&entries[*previous].canonical_path) != normalized_path
@@ -282,6 +321,22 @@ impl CatalogIndex {
             .ok_or(CatalogError::UnknownSongId)
     }
 
+    pub fn entry_for_song_id(
+        &self,
+        song_id: &str,
+        generation: Option<u64>,
+    ) -> Result<CatalogEntryView, CatalogError> {
+        self.check_generation(generation)?;
+        let path = self
+            .canonical_path_for_song_id(song_id, generation)?
+            .to_owned();
+        let index = self.by_id.get(song_id).ok_or(CatalogError::UnknownSongId)?;
+        Ok(CatalogEntryView {
+            row: self.entries[*index].row.clone(),
+            canonical_path: path,
+        })
+    }
+
     fn check_generation(&self, generation: Option<u64>) -> Result<(), CatalogError> {
         if generation.is_some_and(|value| value != self.generation) {
             Err(CatalogError::StaleGeneration)
@@ -356,6 +411,194 @@ fn validate_window(query: &str, _offset: usize, limit: usize) -> Result<(), Cata
     Ok(())
 }
 
+/// Return the RapidFuzz-compatible WRatio score for two normalized catalog
+/// keys. This is a non-realtime search operation and is intentionally kept
+/// separate from the realtime/player crates.
+pub fn wratio_score(query: &str, candidate: &str) -> f64 {
+    if query.is_empty() || candidate.is_empty() {
+        return 0.0;
+    }
+    let query_len = query.chars().count();
+    let candidate_len = candidate.chars().count();
+    let length_ratio = query_len.max(candidate_len) as f64 / query_len.min(candidate_len) as f64;
+    let end_ratio = ratio(query, candidate);
+    if length_ratio < 1.5 {
+        return end_ratio.max(token_ratio(query, candidate) * 0.95);
+    }
+    let partial_scale = if length_ratio <= 8.0 { 0.9 } else { 0.6 };
+    let partial = end_ratio.max(partial_ratio(query, candidate) * partial_scale);
+    partial.max(partial_token_ratio(query, candidate) * 0.95 * partial_scale)
+}
+
+fn ratio(left: &str, right: &str) -> f64 {
+    let left = left.chars().collect::<Vec<_>>();
+    let right = right.chars().collect::<Vec<_>>();
+    if left.is_empty() && right.is_empty() {
+        return 100.0;
+    }
+    indel_ratio(&left, &right)
+}
+
+fn partial_ratio(left: &str, right: &str) -> f64 {
+    let left = left.chars().collect::<Vec<_>>();
+    let right = right.chars().collect::<Vec<_>>();
+    let (short, long) = if left.len() <= right.len() {
+        (&left, &right)
+    } else {
+        (&right, &left)
+    };
+    if short.is_empty() {
+        return 0.0;
+    }
+    let mut best = partial_ratio_impl(short, long);
+    if left.len() == right.len() && best < 100.0 {
+        best = best.max(partial_ratio_impl(long, short));
+    }
+    best
+}
+
+/// RapidFuzz's bounded short-needle candidate selection using the same Indel
+/// score. The upstream implementation uses a bit-parallel optimization; the
+/// direct candidate evaluation keeps the score semantics while staying off
+/// the realtime path.
+fn partial_ratio_impl(short: &[char], long: &[char]) -> f64 {
+    debug_assert!(short.len() <= long.len());
+    let mut best: f64 = 0.0;
+    for end in 1..short.len() {
+        best = best.max(indel_ratio(short, &long[..end]));
+    }
+    for start in 0..long.len().saturating_sub(short.len()) {
+        best = best.max(indel_ratio(short, &long[start..start + short.len()]));
+    }
+    for start in long.len().saturating_sub(short.len())..long.len() {
+        best = best.max(indel_ratio(short, &long[start..]));
+    }
+    best
+}
+
+fn token_sort_ratio(left: &str, right: &str) -> f64 {
+    ratio(&sorted_tokens(left), &sorted_tokens(right))
+}
+
+fn token_set_ratio(left: &str, right: &str) -> f64 {
+    let (left, right) = token_sets(left, right);
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+    let intersection = left.intersection(&right).cloned().collect::<Vec<_>>();
+    let left_rest = left.difference(&right).cloned().collect::<Vec<_>>();
+    let right_rest = right.difference(&left).cloned().collect::<Vec<_>>();
+    if intersection.is_empty() {
+        return ratio(&join_tokens(&left), &join_tokens(&right));
+    }
+    if left_rest.is_empty() || right_rest.is_empty() {
+        return 100.0;
+    }
+    let sect_len = join_tokens(&intersection).chars().count();
+    let left_rest = join_tokens(&left_rest);
+    let right_rest = join_tokens(&right_rest);
+    let left_len = sect_len + usize::from(sect_len != 0) + left_rest.chars().count();
+    let right_len = sect_len + usize::from(sect_len != 0) + right_rest.chars().count();
+    let diff_ratio = ratio(&left_rest, &right_rest);
+    let left_ratio = 100.0
+        - 100.0 * (usize::from(sect_len != 0) + left_rest.chars().count()) as f64
+            / (sect_len + left_len) as f64;
+    let right_ratio = 100.0
+        - 100.0 * (usize::from(sect_len != 0) + right_rest.chars().count()) as f64
+            / (sect_len + right_len) as f64;
+    diff_ratio.max(left_ratio).max(right_ratio)
+}
+
+fn partial_token_sort_ratio(left: &str, right: &str) -> f64 {
+    partial_ratio(&sorted_tokens(left), &sorted_tokens(right))
+}
+
+fn partial_token_set_ratio(left: &str, right: &str) -> f64 {
+    let (left, right) = token_sets(left, right);
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+    if left.intersection(&right).next().is_some() {
+        return 100.0;
+    }
+    let left_rest = left.difference(&right).cloned().collect::<Vec<_>>();
+    let right_rest = right.difference(&left).cloned().collect::<Vec<_>>();
+    partial_ratio(&join_tokens(left_rest), &join_tokens(right_rest))
+}
+
+fn token_ratio(left: &str, right: &str) -> f64 {
+    token_set_ratio(left, right).max(token_sort_ratio(left, right))
+}
+
+fn partial_token_ratio(left: &str, right: &str) -> f64 {
+    let result = partial_token_sort_ratio(left, right);
+    let (left_set, right_set) = token_sets(left, right);
+    if left_set.is_empty() || right_set.is_empty() {
+        return result;
+    }
+    if left_set.intersection(&right_set).next().is_some() {
+        return 100.0;
+    }
+    let left_difference = left_set.difference(&right_set).cloned().collect::<Vec<_>>();
+    let right_difference = right_set.difference(&left_set).cloned().collect::<Vec<_>>();
+    let left_token_count = left.split_whitespace().count();
+    let right_token_count = right.split_whitespace().count();
+    if left_token_count == left_difference.len() && right_token_count == right_difference.len() {
+        return result;
+    }
+    result.max(partial_token_set_ratio(left, right))
+}
+
+fn token_sets(left: &str, right: &str) -> (BTreeSet<String>, BTreeSet<String>) {
+    (
+        left.split_whitespace().map(str::to_owned).collect(),
+        right.split_whitespace().map(str::to_owned).collect(),
+    )
+}
+
+fn join_tokens<T, I>(tokens: I) -> String
+where
+    I: IntoIterator<Item = T>,
+    T: AsRef<str>,
+{
+    tokens
+        .into_iter()
+        .map(|token| token.as_ref().to_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn indel_ratio(left: &[char], right: &[char]) -> f64 {
+    let length_sum = left.len() + right.len();
+    if length_sum == 0 {
+        return 100.0;
+    }
+    200.0 * lcs_length(left, right) as f64 / length_sum as f64
+}
+
+fn lcs_length(left: &[char], right: &[char]) -> usize {
+    let mut previous = vec![0usize; right.len() + 1];
+    let mut current = vec![0usize; right.len() + 1];
+    for left_char in left {
+        for (index, right_char) in right.iter().enumerate() {
+            current[index + 1] = if left_char == right_char {
+                previous[index] + 1
+            } else {
+                previous[index + 1].max(current[index])
+            };
+        }
+        std::mem::swap(&mut previous, &mut current);
+        current.fill(0);
+    }
+    previous[right.len()]
+}
+
+fn sorted_tokens(value: &str) -> String {
+    let mut tokens = value.split_whitespace().collect::<Vec<_>>();
+    tokens.sort_unstable();
+    tokens.join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,5 +657,80 @@ mod tests {
             catalog.search_substrings("", 0, 201, Some(1)).unwrap_err(),
             CatalogError::InvalidLimit
         );
+    }
+
+    #[test]
+    fn normalization_uses_unicode_casefold_not_only_lowercase() {
+        assert_eq!(normalize_search_text("Straße"), "strasse");
+        assert_eq!(normalize_search_text("ΟΣ"), normalize_search_text("οσ"));
+        assert_eq!(normalize_search_text("ĐÀN"), "dan");
+    }
+
+    #[test]
+    fn query_bounds_count_unicode_scalars_and_allow_large_offsets() {
+        let mut catalog = CatalogIndex::default();
+        catalog
+            .replace_entries([entry("C:/songs/a.json", "Alpha")])
+            .expect("index");
+        let valid = "é".repeat(MAX_QUERY_LENGTH);
+        assert!(catalog.search_substrings(&valid, 0, 10, Some(1)).is_ok());
+        let invalid = "é".repeat(MAX_QUERY_LENGTH + 1);
+        assert_eq!(
+            catalog
+                .search_substrings(&invalid, 0, 10, Some(1))
+                .unwrap_err(),
+            CatalogError::QueryTooLong
+        );
+        assert!(
+            catalog
+                .search_substrings("", 1_000_000_001, 10, Some(1))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn wratio_ranker_preserves_stable_ties_after_cutoff() {
+        let ranker = WRatioRanker;
+        let keys = vec!["sky child".into(), "sky child".into(), "unrelated".into()];
+        assert_eq!(
+            ranker.rank("sky child", &keys, FUZZY_SCORE_CUTOFF),
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn wratio_matches_rapidfuzz_reference_vectors() {
+        let cases = [
+            (("this is a test", "this is a test!"), 96.55172413793103),
+            (("fuzzy was a bear", "fuzzy fuzzy was a bear"), 95.0),
+            (
+                (
+                    "fuzzy was a bear but not a dog",
+                    "fuzzy was a bear but not a cat",
+                ),
+                90.0,
+            ),
+            (("abcd", "xxabceyy"), 67.5),
+            (("strasse", "straße"), 76.92307692307692),
+            (("sky child", "sky children of the light"), 90.0),
+            (("alpha beta", "beta alpha"), 95.0),
+            (("abc", "xyzabcq"), 90.0),
+            (("a b c", "a a b c"), 95.0),
+            (("xabcdy", "abcd"), 90.0),
+            (("abc", "zab"), 66.66666666666667),
+            (("abc", "qabc"), 85.71428571428572),
+            (("a b", "x a b y"), 90.0),
+            (("foo bar", "foo baz qux"), 85.5),
+            (("testing", "test"), 90.0),
+            (("aa bb aa", "bb aa"), 90.0),
+            (("a", "bbbbba"), 90.0),
+        ];
+        for ((left, right), expected) in cases {
+            let actual = wratio_score(left, right);
+            assert!(
+                (actual - expected).abs() < 1e-9,
+                "{left:?} vs {right:?}: expected {expected}, got {actual}"
+            );
+        }
     }
 }

--- a/rust/crates/sky_app_core/src/lib.rs
+++ b/rust/crates/sky_app_core/src/lib.rs
@@ -9,4 +9,5 @@
 
 pub mod catalog;
 pub mod settings;
+pub mod song;
 pub mod update;

--- a/rust/crates/sky_app_core/src/lib.rs
+++ b/rust/crates/sky_app_core/src/lib.rs
@@ -10,4 +10,5 @@
 pub mod catalog;
 pub mod settings;
 pub mod song;
+pub mod timing;
 pub mod update;

--- a/rust/crates/sky_app_core/src/song.rs
+++ b/rust/crates/sky_app_core/src/song.rs
@@ -196,6 +196,8 @@ pub struct ScheduleMetadata {
     pub max_polyphony: usize,
     pub shortest_same_key_interval_us: Option<u64>,
     pub min_same_key_up_gap_us: Option<u64>,
+    pub recommended_hold_frames: Option<f64>,
+    pub recommended_tempo_scale: Option<f64>,
     pub warnings: Vec<String>,
 }
 
@@ -238,20 +240,31 @@ pub fn build_schedule(
     tempo_scale: f64,
     fps: u16,
 ) -> Result<ScheduleMetadata, SongError> {
+    let policy = crate::timing::MaterializedTimingPolicy::from_calibration(
+        fps,
+        hold_frames,
+        MIN_TRANSPORT_MARGIN_US,
+        "default_transport_300",
+    )?;
+    build_schedule_with_policy(song, tempo_scale, &policy)
+}
+
+pub fn build_schedule_with_policy(
+    song: &Song,
+    tempo_scale: f64,
+    policy: &crate::timing::MaterializedTimingPolicy,
+) -> Result<ScheduleMetadata, SongError> {
     if !tempo_scale.is_finite() || tempo_scale <= 0.0 {
         return Err(SongError::InvalidTempo);
     }
-    if !hold_frames.is_finite() || !HOLD_FRAMES.contains(&hold_frames) {
-        return Err(SongError::InvalidHold);
-    }
-    let frame = frame_us(fps)?;
-    let base_hold = (hold_frames * frame as f64).ceil() as u64;
-    let hold_us = base_hold
-        .saturating_add(DOWN_LATE_GRACE_US)
-        .saturating_add(MIN_TRANSPORT_MARGIN_US);
-    let release_gap = frame
-        .saturating_add(DOWN_LATE_GRACE_US)
-        .saturating_add(MIN_TRANSPORT_MARGIN_US);
+    // The current materialized policy intentionally uses the same effective
+    // value for target and minimum hold. Keep both names here because the
+    // Python contract distinguishes them when a policy supplies a compressed
+    // hold, and doing so prevents this loop from silently regressing to an
+    // always-uncompressed implementation.
+    let target_hold_us = policy.min_hold_us;
+    let min_hold_us = policy.min_hold_us;
+    let release_gap = policy.min_release_gap_us;
 
     let mut drafts = Vec::with_capacity(song.notes.len());
     for note in &song.notes {
@@ -274,9 +287,9 @@ pub fn build_schedule(
     }
 
     let mut actions = Vec::with_capacity(drafts.len() * 2);
-    let compressed = 0;
+    let mut compressed = 0;
     let mut impossible = 0;
-    let risky = 0;
+    let mut risky = 0;
     let mut shortest = None;
     let mut min_up_gap = None;
     for (at, scan, source_index) in &drafts {
@@ -285,14 +298,23 @@ pub fn build_schedule(
             let interval = next_at.saturating_sub(*at);
             shortest = Some(shortest.map_or(interval, |current: u64| current.min(interval)));
             let max_hold = interval.saturating_sub(release_gap);
-            if max_hold < hold_us {
+            if max_hold < min_hold_us {
                 impossible += 1;
-                hold_us
+                min_hold_us
+            } else if max_hold < target_hold_us {
+                // Keep this branch explicit: if a future policy materializes
+                // a target hold distinct from its minimum hold, Python's
+                // scheduler compresses the hold while preserving the full
+                // release gap.  The current policy normally makes these
+                // values equal, but the behavior is part of the contract.
+                risky += 1;
+                compressed += 1;
+                max_hold
             } else {
-                hold_us
+                target_hold_us
             }
         } else {
-            hold_us
+            target_hold_us
         };
         if let Some(next_at) = next_at {
             let gap = next_at.saturating_sub(*at).saturating_sub(actual_hold);
@@ -348,6 +370,21 @@ pub fn build_schedule(
         .last()
         .map(|action| action.at_us)
         .unwrap_or_default();
+    let (recommended_hold_frames, recommended_tempo_scale) = if impossible > 0 {
+        if let Some(shortest) = shortest {
+            let min_cycle = min_hold_us.saturating_add(release_gap);
+            let suggested = if min_cycle == 0 {
+                tempo_scale
+            } else {
+                tempo_scale * shortest as f64 / min_cycle as f64
+            };
+            (Some(1.0), Some(python_round_two(suggested).clamp(0.1, 1.0)))
+        } else {
+            (Some(1.0), None)
+        }
+    } else {
+        (None, None)
+    };
     Ok(ScheduleMetadata {
         actions: final_actions,
         source_duration_us: drafts
@@ -355,7 +392,7 @@ pub fn build_schedule(
             .map(|(at, _, _)| *at)
             .max()
             .unwrap_or_default()
-            .saturating_add(hold_us),
+            .saturating_add(target_hold_us),
         playback_duration_us: duration,
         duration_us: duration,
         note_count: song.notes.len(),
@@ -367,6 +404,8 @@ pub fn build_schedule(
         max_polyphony,
         shortest_same_key_interval_us: shortest,
         min_same_key_up_gap_us: min_up_gap,
+        recommended_hold_frames,
+        recommended_tempo_scale,
         warnings: Vec::new(),
     })
 }
@@ -388,6 +427,23 @@ fn python_round_nonnegative(value: f64) -> u64 {
         lower
     };
     rounded as u64
+}
+
+fn python_round_two(value: f64) -> f64 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    let scaled = value * 100.0;
+    let lower = scaled.floor();
+    let fraction = scaled - lower;
+    let rounded = if fraction < 0.5 {
+        lower
+    } else if fraction > 0.5 || (lower as i64) % 2 != 0 {
+        lower + 1.0
+    } else {
+        lower
+    };
+    rounded / 100.0
 }
 
 fn max_polyphony(actions: &[KeyAction]) -> usize {

--- a/rust/crates/sky_app_core/src/song.rs
+++ b/rust/crates/sky_app_core/src/song.rs
@@ -1,0 +1,717 @@
+//! Pure song parsing, deterministic scheduling, and bounded risk analysis.
+//!
+//! This module deliberately owns no filesystem, delivery, Win32, Python, or
+//! realtime-player concerns.  A caller supplies bytes and receives an
+//! immutable plan that an outer native adapter may hand to the qualified
+//! realtime engine.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+pub const SKY_SCAN_CODES: [u16; 15] = [
+    0x15, 0x16, 0x17, 0x18, 0x19, 0x23, 0x24, 0x25, 0x26, 0x27, 0x31, 0x32, 0x33, 0x34, 0x35,
+];
+pub const KEY_NAMES: [&str; 15] = [
+    "Key0", "Key1", "Key2", "Key3", "Key4", "Key5", "Key6", "Key7", "Key8", "Key9", "Key10",
+    "Key11", "Key12", "Key13", "Key14",
+];
+pub const VALID_FPS: [u16; 7] = [30, 60, 90, 120, 144, 165, 240];
+pub const HOLD_FRAMES: [f64; 3] = [1.0, 1.25, 1.5];
+pub const MIN_TRANSPORT_MARGIN_US: u64 = 300;
+pub const DOWN_LATE_GRACE_US: u64 = 500;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Note {
+    pub time_ms: i64,
+    pub key: String,
+    pub source_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Song {
+    pub name: String,
+    pub notes: Vec<Note>,
+}
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum SongError {
+    #[error("invalid JSON: {0}")]
+    InvalidJson(String),
+    #[error("song root must be an object")]
+    InvalidRoot,
+    #[error("song list is empty")]
+    EmptySongList,
+    #[error("songNotes is missing")]
+    MissingNotes,
+    #[error("songNotes must be an array")]
+    InvalidNotes,
+    #[error("note {index} must be an object")]
+    InvalidNote { index: usize },
+    #[error("note {index} is missing time")]
+    MissingTime { index: usize },
+    #[error("note {index} is missing key")]
+    MissingKey { index: usize },
+    #[error("note {index} has invalid time")]
+    InvalidTime { index: usize },
+    #[error("note {index} has negative time")]
+    NegativeTime { index: usize },
+    #[error("note {index} has an unmapped key: {key}")]
+    UnmappedKey { index: usize, key: String },
+    #[error("schedule tempo must be finite and positive")]
+    InvalidTempo,
+    #[error("schedule FPS is unsupported")]
+    InvalidFps,
+    #[error("schedule hold frame value is unsupported")]
+    InvalidHold,
+    #[error("same-key repeat is infeasible: {interval_us}us")]
+    ImpossibleRepeat { interval_us: u64 },
+    #[error("schedule contains no actions")]
+    EmptySchedule,
+}
+
+pub fn parse_song_json(bytes: &[u8], fallback_name: &str) -> Result<Song, SongError> {
+    let value: Value =
+        serde_json::from_slice(bytes).map_err(|error| SongError::InvalidJson(error.to_string()))?;
+    let object = match value {
+        Value::Array(values) => values.into_iter().next().ok_or(SongError::EmptySongList)?,
+        other => other,
+    };
+    let object = object.as_object().ok_or(SongError::InvalidRoot)?;
+    let notes_value = object.get("songNotes").ok_or(SongError::MissingNotes)?;
+    let notes = notes_value.as_array().ok_or(SongError::InvalidNotes)?;
+    let name = object
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback_name)
+        .to_owned();
+    let mut parsed = Vec::with_capacity(notes.len());
+    for (index, raw) in notes.iter().enumerate() {
+        let note = raw.as_object().ok_or(SongError::InvalidNote { index })?;
+        let raw_time = note.get("time").ok_or(SongError::MissingTime { index })?;
+        let time_ms = python_int(raw_time).ok_or(SongError::InvalidTime { index })?;
+        if time_ms < 0 {
+            return Err(SongError::NegativeTime { index });
+        }
+        let raw_key = note.get("key").ok_or(SongError::MissingKey { index })?;
+        let key = raw_key
+            .as_str()
+            .map(str::to_owned)
+            .ok_or_else(|| SongError::UnmappedKey {
+                index,
+                key: python_string(raw_key),
+            })?;
+        if scan_code_for_key(&key).is_none() {
+            return Err(SongError::UnmappedKey { index, key });
+        }
+        parsed.push(Note {
+            time_ms,
+            key,
+            source_index: index,
+        });
+    }
+    parsed.sort_by_key(|note| note.time_ms);
+    Ok(Song {
+        name,
+        notes: parsed,
+    })
+}
+
+fn python_int(value: &Value) -> Option<i64> {
+    match value {
+        Value::Bool(value) => Some(i64::from(*value)),
+        Value::Number(number) => number
+            .as_i64()
+            .or_else(|| number.as_u64().and_then(|value| i64::try_from(value).ok()))
+            .or_else(|| {
+                number
+                    .as_f64()
+                    .map(f64::trunc)
+                    .filter(|value| value.is_finite())
+                    .and_then(|value| i64::try_from(value as i128).ok())
+            }),
+        Value::String(value) => value.trim().parse::<i64>().ok(),
+        _ => None,
+    }
+}
+
+fn python_string(value: &Value) -> String {
+    match value {
+        Value::Null => "None".into(),
+        Value::Bool(value) => value.to_string().to_ascii_lowercase(),
+        Value::String(value) => value.clone(),
+        Value::Number(value) => value.to_string(),
+        Value::Array(values) => format!(
+            "[{}]",
+            values
+                .iter()
+                .map(python_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        Value::Object(_) => "{...}".into(),
+    }
+}
+
+pub fn scan_code_for_key(key: &str) -> Option<u16> {
+    let key = key
+        .strip_prefix("1Key")
+        .or_else(|| key.strip_prefix("2Key"))
+        .or_else(|| key.strip_prefix("3Key"))
+        .map(|suffix| format!("Key{suffix}"))
+        .unwrap_or_else(|| key.to_owned());
+    KEY_NAMES
+        .iter()
+        .position(|candidate| *candidate == key)
+        .map(|index| SKY_SCAN_CODES[index])
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionKind {
+    Down,
+    Up,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyAction {
+    pub at_us: u64,
+    pub scan_codes: Vec<u16>,
+    pub kind: ActionKind,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduleMetadata {
+    pub actions: Vec<KeyAction>,
+    pub source_duration_us: u64,
+    pub playback_duration_us: u64,
+    pub duration_us: u64,
+    pub note_count: usize,
+    pub deduplicated_note_count: usize,
+    pub duplicate_note_count: usize,
+    pub compressed_holds: usize,
+    pub impossible_same_key_repeats: usize,
+    pub risky_same_key_repeats: usize,
+    pub max_polyphony: usize,
+    pub shortest_same_key_interval_us: Option<u64>,
+    pub min_same_key_up_gap_us: Option<u64>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DenseCluster {
+    pub start_us: u64,
+    pub end_us: u64,
+    pub note_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RiskReport {
+    pub severity: String,
+    pub reason: String,
+    pub recommendations: Vec<String>,
+    pub dense_clusters: Vec<DenseCluster>,
+    pub average_notes_per_second: f64,
+    pub peak_notes_per_second_1s: f64,
+    pub max_polyphony: usize,
+    pub max_chord_size: usize,
+    pub chords_count: usize,
+    pub timing_stress_rate: f64,
+    pub min_any_note_gap_us: Option<u64>,
+    pub min_same_key_gap_us: Option<u64>,
+    pub suggested_hold_frames: Option<f64>,
+    pub suggested_tempo_scale: Option<f64>,
+}
+
+pub fn frame_us(fps: u16) -> Result<u64, SongError> {
+    if VALID_FPS.contains(&fps) {
+        Ok(1_000_000_u64.div_ceil(u64::from(fps)))
+    } else {
+        Err(SongError::InvalidFps)
+    }
+}
+
+pub fn build_schedule(
+    song: &Song,
+    hold_frames: f64,
+    tempo_scale: f64,
+    fps: u16,
+) -> Result<ScheduleMetadata, SongError> {
+    if !tempo_scale.is_finite() || tempo_scale <= 0.0 {
+        return Err(SongError::InvalidTempo);
+    }
+    if !hold_frames.is_finite() || !HOLD_FRAMES.contains(&hold_frames) {
+        return Err(SongError::InvalidHold);
+    }
+    let frame = frame_us(fps)?;
+    let base_hold = (hold_frames * frame as f64).ceil() as u64;
+    let hold_us = base_hold
+        .saturating_add(DOWN_LATE_GRACE_US)
+        .saturating_add(MIN_TRANSPORT_MARGIN_US);
+    let release_gap = frame
+        .saturating_add(DOWN_LATE_GRACE_US)
+        .saturating_add(MIN_TRANSPORT_MARGIN_US);
+
+    let mut drafts = Vec::with_capacity(song.notes.len());
+    for note in &song.notes {
+        let scan_code = scan_code_for_key(&note.key).ok_or_else(|| SongError::UnmappedKey {
+            index: note.source_index,
+            key: note.key.clone(),
+        })?;
+        let at_us = python_round_nonnegative((note.time_ms as f64) * 1_000.0 / tempo_scale);
+        drafts.push((at_us, scan_code, note.source_index));
+    }
+    let raw_count = drafts.len();
+    let mut seen = BTreeSet::new();
+    drafts.retain(|(at, scan, _)| seen.insert((*at, *scan)));
+
+    let mut next_by_source = HashMap::<usize, Option<u64>>::new();
+    let mut next = HashMap::<u16, u64>::new();
+    for (at, scan, source_index) in drafts.iter().rev() {
+        next_by_source.insert(*source_index, next.get(scan).copied());
+        next.insert(*scan, *at);
+    }
+
+    let mut actions = Vec::with_capacity(drafts.len() * 2);
+    let compressed = 0;
+    let mut impossible = 0;
+    let risky = 0;
+    let mut shortest = None;
+    let mut min_up_gap = None;
+    for (at, scan, source_index) in &drafts {
+        let next_at = next_by_source.get(source_index).copied().flatten();
+        let actual_hold = if let Some(next_at) = next_at {
+            let interval = next_at.saturating_sub(*at);
+            shortest = Some(shortest.map_or(interval, |current: u64| current.min(interval)));
+            let max_hold = interval.saturating_sub(release_gap);
+            if max_hold < hold_us {
+                impossible += 1;
+                hold_us
+            } else {
+                hold_us
+            }
+        } else {
+            hold_us
+        };
+        if let Some(next_at) = next_at {
+            let gap = next_at.saturating_sub(*at).saturating_sub(actual_hold);
+            min_up_gap = Some(min_up_gap.map_or(gap, |current: u64| current.min(gap)));
+        }
+        actions.push(KeyAction {
+            at_us: *at,
+            scan_codes: vec![*scan],
+            kind: ActionKind::Down,
+            reason: "onset".into(),
+        });
+        actions.push(KeyAction {
+            at_us: at.saturating_add(actual_hold),
+            scan_codes: vec![*scan],
+            kind: ActionKind::Up,
+            reason: if next_at.is_some() {
+                "repeat_release".into()
+            } else {
+                "release".into()
+            },
+        });
+    }
+    let mut grouped = BTreeMap::<(u64, ActionKind), (Vec<u16>, BTreeSet<String>)>::new();
+    for action in actions {
+        let entry = grouped.entry((action.at_us, action.kind)).or_default();
+        entry.0.extend(action.scan_codes);
+        entry.1.insert(action.reason);
+    }
+    let mut final_actions = grouped
+        .into_iter()
+        .map(|((at_us, kind), (mut scans, reasons))| {
+            let mut unique_scans = Vec::with_capacity(scans.len());
+            for scan in scans.drain(..) {
+                if !unique_scans.contains(&scan) {
+                    unique_scans.push(scan);
+                }
+            }
+            KeyAction {
+                at_us,
+                scan_codes: unique_scans,
+                kind,
+                reason: if reasons.len() == 1 {
+                    reasons.into_iter().next().unwrap_or_default()
+                } else {
+                    "mixed".into()
+                },
+            }
+        })
+        .collect::<Vec<_>>();
+    final_actions.sort_by_key(|action| (action.at_us, matches!(action.kind, ActionKind::Down)));
+    let max_polyphony = max_polyphony(&final_actions);
+    let duration = final_actions
+        .last()
+        .map(|action| action.at_us)
+        .unwrap_or_default();
+    Ok(ScheduleMetadata {
+        actions: final_actions,
+        source_duration_us: drafts
+            .iter()
+            .map(|(at, _, _)| *at)
+            .max()
+            .unwrap_or_default()
+            .saturating_add(hold_us),
+        playback_duration_us: duration,
+        duration_us: duration,
+        note_count: song.notes.len(),
+        deduplicated_note_count: drafts.len(),
+        duplicate_note_count: raw_count.saturating_sub(drafts.len()),
+        compressed_holds: compressed,
+        impossible_same_key_repeats: impossible,
+        risky_same_key_repeats: risky,
+        max_polyphony,
+        shortest_same_key_interval_us: shortest,
+        min_same_key_up_gap_us: min_up_gap,
+        warnings: Vec::new(),
+    })
+}
+
+/// Python's `round(float)` uses bankers rounding.  Schedule timestamps are
+/// non-negative, so this small helper mirrors that observable rule without
+/// pulling floating-point tie behavior from Rust's `round()`.
+fn python_round_nonnegative(value: f64) -> u64 {
+    if !value.is_finite() || value <= 0.0 {
+        return 0;
+    }
+    let lower = value.floor();
+    let fraction = value - lower;
+    let rounded = if fraction < 0.5 {
+        lower
+    } else if fraction > 0.5 || (lower as u64) % 2 == 1 {
+        lower + 1.0
+    } else {
+        lower
+    };
+    rounded as u64
+}
+
+fn max_polyphony(actions: &[KeyAction]) -> usize {
+    let mut active = BTreeSet::new();
+    let mut maximum = 0;
+    for action in actions {
+        match action.kind {
+            ActionKind::Down => {
+                active.extend(action.scan_codes.iter().copied());
+                maximum = maximum.max(active.len());
+            }
+            ActionKind::Up => {
+                for scan in &action.scan_codes {
+                    active.remove(scan);
+                }
+            }
+        }
+    }
+    maximum
+}
+
+pub fn analyze_schedule(schedule: &ScheduleMetadata) -> RiskReport {
+    analyze_schedule_with_context(schedule, None, 1.0, 1.0)
+}
+
+/// Analyze executable schedule metrics while retaining the raw authored notes
+/// for the two Python-visible gap metrics.  The scheduler deliberately
+/// deduplicates executable slots, but the Python analyzer computes minimum
+/// onset gaps from the raw note stream when it is available.
+pub fn analyze_schedule_with_notes(schedule: &ScheduleMetadata, raw_notes: &[Note]) -> RiskReport {
+    analyze_schedule_with_context(schedule, Some(raw_notes), 1.0, 1.0)
+}
+
+pub fn analyze_schedule_with_context(
+    schedule: &ScheduleMetadata,
+    raw_notes: Option<&[Note]>,
+    current_hold_frames: f64,
+    current_tempo_scale: f64,
+) -> RiskReport {
+    let downs = schedule
+        .actions
+        .iter()
+        .filter(|action| matches!(action.kind, ActionKind::Down))
+        .collect::<Vec<_>>();
+    let mut dense: Vec<DenseCluster> = Vec::new();
+    let mut left = 0usize;
+    for right in 0..downs.len() {
+        while downs[right].at_us.saturating_sub(downs[left].at_us) > 100_000 {
+            left += 1;
+        }
+        let count = right - left + 1;
+        if count > 6 {
+            let start = downs[left].at_us;
+            let end = downs[right].at_us;
+            if let Some(previous) = dense.last_mut()
+                && start <= previous.end_us.saturating_add(50_000)
+            {
+                previous.end_us = end;
+                previous.note_count = previous.note_count.max(count);
+                continue;
+            }
+            dense.push(DenseCluster {
+                start_us: start,
+                end_us: end,
+                note_count: count,
+            });
+        }
+    }
+    let mut recommendations = Vec::new();
+    let mut reasons = Vec::new();
+    let mut severity = "low";
+    if schedule.impossible_same_key_repeats > 0 {
+        severity = "high";
+        reasons.push("infeasible same-key repeats");
+        recommendations.push(format!(
+            "{} same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+            schedule.impossible_same_key_repeats
+        ));
+        recommendations.push(
+            "Reduce tempo or edit the arrangement so the same key has more time between downs."
+                .into(),
+        );
+    }
+    if schedule.risky_same_key_repeats > 0 {
+        if severity == "low" {
+            severity = "medium";
+        }
+        reasons.push("same-key hold compression");
+        recommendations.push(format!(
+            "Compressed {} same-key hold(s) to release before the next down.",
+            schedule.risky_same_key_repeats
+        ));
+    }
+    if schedule.compressed_holds > 5 {
+        if severity == "low" {
+            severity = "medium";
+        }
+        reasons.push("compressed holds");
+        recommendations.push(format!(
+            "{} note holds were compressed due to dense scheduling.",
+            schedule.compressed_holds
+        ));
+    }
+    if dense.len() > 5 {
+        if severity != "high" {
+            severity = if dense.len() > 15 { "high" } else { "medium" };
+        }
+        reasons.push("dense clusters");
+        recommendations.push(format!(
+            "Detected {} distinct dense cluster(s) (more than 6 notes in 100ms).",
+            dense.len()
+        ));
+    }
+    if schedule.max_polyphony > 8 {
+        severity = if severity == "low" {
+            "medium"
+        } else {
+            severity
+        };
+        reasons.push("high polyphony");
+        recommendations.push(format!(
+            "High polyphony detected (max {} simultaneous keys).",
+            schedule.max_polyphony
+        ));
+    }
+    if let Some(interval) = schedule.shortest_same_key_interval_us {
+        recommendations.push(format!(
+            "Shortest same-key repeat interval: {:.1}ms.",
+            interval as f64 / 1_000.0
+        ));
+    }
+    let (suggested_hold_frames, suggested_tempo_scale) = if schedule.impossible_same_key_repeats > 0
+    {
+        (Some(1.0), Some(current_tempo_scale.min(0.92)))
+    } else if schedule.risky_same_key_repeats > 5 || schedule.compressed_holds > 10 {
+        (Some(1.0), Some(current_tempo_scale.min(0.95)))
+    } else if schedule.max_polyphony >= 5 || (!dense.is_empty() && severity != "low") {
+        (
+            Some(1.5),
+            Some(if severity != "low" {
+                current_tempo_scale.min(0.95)
+            } else {
+                current_tempo_scale
+            }),
+        )
+    } else if severity == "medium" {
+        (Some(1.25), Some(current_tempo_scale.min(0.95)))
+    } else {
+        (Some(current_hold_frames), Some(current_tempo_scale))
+    };
+    if schedule.impossible_same_key_repeats > 0 {
+        recommendations.push(
+            "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+                .into(),
+        );
+    }
+    if recommendations.is_empty() {
+        recommendations.push("No timing conflicts detected. Keep the selected hold.".into());
+    }
+    let mut min_any = downs
+        .windows(2)
+        .map(|pair| pair[1].at_us.saturating_sub(pair[0].at_us))
+        .min();
+    let mut min_same = schedule.shortest_same_key_interval_us;
+    if let Some(raw_notes) = raw_notes {
+        let mut onsets = raw_notes
+            .iter()
+            .map(|note| note.time_ms)
+            .collect::<Vec<_>>();
+        onsets.sort_unstable();
+        onsets.dedup();
+        min_any = onsets
+            .windows(2)
+            .map(|pair| pair[1].saturating_sub(pair[0]) as u64 * 1_000)
+            .min()
+            .or(min_any);
+
+        let mut last_by_key = HashMap::<&str, i64>::new();
+        for note in raw_notes {
+            if let Some(previous) = last_by_key.insert(note.key.as_str(), note.time_ms) {
+                let gap = note.time_ms.saturating_sub(previous) as u64 * 1_000;
+                min_same = Some(min_same.map_or(gap, |current| current.min(gap)));
+            }
+        }
+    }
+    let duration = schedule.source_duration_us as f64 / 1_000_000.0;
+    let average = if duration > 0.0 {
+        downs.len() as f64 / duration
+    } else {
+        0.0
+    };
+    RiskReport {
+        severity: severity.into(),
+        reason: if reasons.is_empty() {
+            "No timing conflicts detected.".into()
+        } else {
+            format!("{} detected", reasons.join(" and "))
+        },
+        recommendations,
+        dense_clusters: dense,
+        average_notes_per_second: average,
+        peak_notes_per_second_1s: peak_density(&downs),
+        max_polyphony: schedule.max_polyphony,
+        max_chord_size: downs
+            .iter()
+            .map(|action| action.scan_codes.len())
+            .max()
+            .unwrap_or_default(),
+        chords_count: downs
+            .iter()
+            .filter(|action| action.scan_codes.len() > 1)
+            .count(),
+        timing_stress_rate: if schedule.note_count == 0 {
+            0.0
+        } else {
+            schedule.impossible_same_key_repeats as f64 / schedule.note_count as f64 * 100.0
+        },
+        min_any_note_gap_us: min_any,
+        min_same_key_gap_us: min_same,
+        suggested_hold_frames,
+        suggested_tempo_scale,
+    }
+}
+
+fn peak_density(downs: &[&KeyAction]) -> f64 {
+    let mut peak = 0usize;
+    for (index, action) in downs.iter().enumerate() {
+        let count = downs[index..]
+            .iter()
+            .take_while(|next| next.at_us.saturating_sub(action.at_us) <= 1_000_000)
+            .count();
+        peak = peak.max(count);
+    }
+    peak as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parser_accepts_legacy_aliases_and_stably_sorts() {
+        let song = parse_song_json(br#"{"name":"Demo","songNotes":[{"time":20,"key":"1Key1"},{"time":"10","key":"Key0"}]}"#, "fallback").unwrap();
+        assert_eq!(song.notes[0].time_ms, 10);
+        assert_eq!(scan_code_for_key(&song.notes[1].key), Some(0x16));
+    }
+
+    #[test]
+    fn schedule_preserves_chords_and_deduplicates_same_key_timestamp() {
+        let song = Song {
+            name: "Demo".into(),
+            notes: vec![
+                Note {
+                    time_ms: 0,
+                    key: "Key0".into(),
+                    source_index: 0,
+                },
+                Note {
+                    time_ms: 0,
+                    key: "Key1".into(),
+                    source_index: 1,
+                },
+                Note {
+                    time_ms: 0,
+                    key: "Key1".into(),
+                    source_index: 2,
+                },
+            ],
+        };
+        let schedule = build_schedule(&song, 1.0, 1.0, 60).unwrap();
+        assert_eq!(schedule.duplicate_note_count, 1);
+        assert_eq!(schedule.actions[0].scan_codes, vec![0x15, 0x16]);
+    }
+
+    #[test]
+    fn schedule_preserves_authored_chord_scan_order() {
+        let song = Song {
+            name: "Demo".into(),
+            notes: vec![
+                Note {
+                    time_ms: 0,
+                    key: "Key1".into(),
+                    source_index: 0,
+                },
+                Note {
+                    time_ms: 0,
+                    key: "Key0".into(),
+                    source_index: 1,
+                },
+            ],
+        };
+        let schedule = build_schedule(&song, 1.0, 1.0, 60).unwrap();
+        assert_eq!(schedule.actions[0].scan_codes, vec![0x16, 0x15]);
+    }
+
+    #[test]
+    fn empty_song_matches_python_empty_schedule_behavior() {
+        let schedule = build_schedule(
+            &Song {
+                name: "Empty".into(),
+                notes: Vec::new(),
+            },
+            1.0,
+            1.0,
+            60,
+        )
+        .expect("empty songs produce an empty schedule");
+        assert!(schedule.actions.is_empty());
+        assert_eq!(schedule.source_duration_us, 17_467);
+    }
+
+    #[test]
+    fn risk_reports_dense_cluster() {
+        let song = Song {
+            name: "Dense".into(),
+            notes: (0usize..7)
+                .map(|index| Note {
+                    time_ms: index as i64,
+                    key: KEY_NAMES[index].into(),
+                    source_index: index,
+                })
+                .collect(),
+        };
+        let report = analyze_schedule(&build_schedule(&song, 1.0, 1.0, 60).unwrap());
+        assert_eq!(report.dense_clusters.len(), 1);
+    }
+}

--- a/rust/crates/sky_app_core/src/timing.rs
+++ b/rust/crates/sky_app_core/src/timing.rs
@@ -1,0 +1,78 @@
+//! Materialized playback timing policy shared by planning and execution.
+//!
+//! The policy is an application value, not a cache loader.  An outer adapter
+//! resolves the calibration evidence and constructs this value once; callers
+//! then pass the same value through analysis, fingerprinting and the native
+//! session boundary.
+
+use crate::song::SongError;
+
+pub const DEFAULT_DOWN_LATE_GRACE_US: u64 = 500;
+pub const DEFAULT_TRANSPORT_MARGIN_US: u64 = 300;
+pub const DEFAULT_FOCUS_RESTORE_GRACE_US: u64 = 100_000;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MaterializedTimingPolicy {
+    pub fps: u16,
+    pub frame_us: u64,
+    pub hold_frames: f64,
+    pub frame_base_hold_us: u64,
+    pub down_late_grace_us: u64,
+    pub transport_margin_us: u64,
+    pub transport_margin_source: String,
+    pub min_hold_us: u64,
+    pub min_release_gap_us: u64,
+    pub focus_restore_grace_us: u64,
+}
+
+impl MaterializedTimingPolicy {
+    pub fn from_calibration(
+        fps: u16,
+        hold_frames: f64,
+        transport_margin_us: u64,
+        transport_margin_source: impl Into<String>,
+    ) -> Result<Self, SongError> {
+        let frame_us = crate::song::frame_us(fps)?;
+        if !hold_frames.is_finite() || !crate::settings::HOLD_FRAME_OPTIONS.contains(&hold_frames) {
+            return Err(SongError::InvalidHold);
+        }
+        let frame_base_hold_us = (hold_frames * frame_us as f64).ceil() as u64;
+        Ok(Self {
+            fps,
+            frame_us,
+            hold_frames,
+            frame_base_hold_us,
+            down_late_grace_us: DEFAULT_DOWN_LATE_GRACE_US,
+            transport_margin_us,
+            transport_margin_source: transport_margin_source.into(),
+            min_hold_us: frame_base_hold_us
+                .saturating_add(DEFAULT_DOWN_LATE_GRACE_US)
+                .saturating_add(transport_margin_us),
+            min_release_gap_us: frame_us
+                .saturating_add(DEFAULT_DOWN_LATE_GRACE_US)
+                .saturating_add(transport_margin_us),
+            focus_restore_grace_us: DEFAULT_FOCUS_RESTORE_GRACE_US,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MaterializedTimingPolicy;
+
+    #[test]
+    fn calibration_margin_materializes_once_for_planning_and_execution() {
+        let policy = MaterializedTimingPolicy::from_calibration(60, 1.0, 777, "device_cache")
+            .expect("valid policy");
+        assert_eq!(policy.frame_us, 16_667);
+        assert_eq!(policy.frame_base_hold_us, 16_667);
+        assert_eq!(policy.down_late_grace_us, 500);
+        assert_eq!(policy.transport_margin_us, 777);
+        assert_eq!(policy.min_hold_us, 17_944);
+        assert_eq!(policy.min_release_gap_us, 17_944);
+        assert_eq!(policy.transport_margin_source, "device_cache");
+
+        let cloned = policy.clone();
+        assert_eq!(cloned, policy);
+    }
+}

--- a/rust/crates/sky_app_core/tests/wave2_fixtures.rs
+++ b/rust/crates/sky_app_core/tests/wave2_fixtures.rs
@@ -156,6 +156,16 @@ fn catalog_fixture_preserves_ids_order_normalization_and_generation() {
             other => panic!("unexpected catalog fixture status {other}"),
         }
     }
+    for case in raw["fuzzy_cases"].as_array().unwrap() {
+        let query = case["query"].as_str().unwrap();
+        let candidate = case["candidate"].as_str().unwrap();
+        let expected = case["score"].as_f64().unwrap();
+        let actual = sky_app_core::catalog::wratio_score(query, candidate);
+        assert!(
+            (actual - expected).abs() < 1e-9,
+            "WRatio fixture {query:?} vs {candidate:?}: expected {expected}, got {actual}"
+        );
+    }
     assert!(
         index
             .search_substrings("", 1_000_000_001, 1, Some(1))

--- a/rust/crates/sky_app_core/tests/wave3_song_fixtures.rs
+++ b/rust/crates/sky_app_core/tests/wave3_song_fixtures.rs
@@ -1,7 +1,8 @@
 use serde_json::Value;
 use sky_app_core::song::{
-    ActionKind, analyze_schedule_with_context, build_schedule, parse_song_json,
+    ActionKind, analyze_schedule_with_context, build_schedule_with_policy, parse_song_json,
 };
+use sky_app_core::timing::MaterializedTimingPolicy;
 
 fn fixture() -> Value {
     serde_json::from_str(include_str!(
@@ -47,13 +48,16 @@ fn schedule_and_risk_cases_match_python_oracle_fields() {
     for case in cases {
         let bytes = serde_json::to_vec(&case["raw"]).unwrap();
         let song = parse_song_json(&bytes, "fixture").expect("valid schedule fixture");
-        let schedule = build_schedule(
-            &song,
-            case["hold_frames"].as_f64().unwrap(),
-            case["tempo_scale"].as_f64().unwrap(),
+        let policy = MaterializedTimingPolicy::from_calibration(
             case["fps"].as_u64().unwrap() as u16,
+            case["hold_frames"].as_f64().unwrap(),
+            case["transport_margin_us"].as_u64().unwrap(),
+            case["transport_margin_source"].as_str().unwrap(),
         )
-        .expect("schedule oracle case");
+        .expect("timing policy oracle case");
+        let schedule =
+            build_schedule_with_policy(&song, case["tempo_scale"].as_f64().unwrap(), &policy)
+                .expect("schedule oracle case");
         let expected = &case["schedule"];
         let actual = serde_json::to_value(&schedule).unwrap();
         for field in [
@@ -70,6 +74,8 @@ fn schedule_and_risk_cases_match_python_oracle_fields() {
             "max_polyphony",
             "shortest_same_key_interval_us",
             "min_same_key_up_gap_us",
+            "recommended_hold_frames",
+            "recommended_tempo_scale",
         ] {
             assert_eq!(
                 actual[field], expected[field],
@@ -111,4 +117,57 @@ fn schedule_and_risk_cases_match_python_oracle_fields() {
 fn action_kind_wire_names_remain_stable() {
     assert_eq!(serde_json::to_value(ActionKind::Down).unwrap(), "down");
     assert_eq!(serde_json::to_value(ActionKind::Up).unwrap(), "up");
+}
+
+#[test]
+fn calibrated_policy_cases_match_the_python_production_resolver() {
+    let raw = fixture();
+    let cases = raw["timing_policy_cases"]
+        .as_array()
+        .expect("timing policy oracle cases");
+    assert!(cases.len() >= 4);
+    for case in cases {
+        let policy = MaterializedTimingPolicy::from_calibration(
+            case["fps"].as_u64().unwrap() as u16,
+            case["hold_frames"].as_f64().unwrap(),
+            case["transport_margin_us"].as_u64().unwrap(),
+            case["transport_margin_source"].as_str().unwrap(),
+        )
+        .expect("materialized policy oracle case");
+        assert_eq!(
+            policy.frame_us,
+            case["frame_us"].as_u64().unwrap(),
+            "{case}"
+        );
+        assert_eq!(
+            policy.frame_base_hold_us,
+            case["frame_base_hold_us"].as_u64().unwrap(),
+            "{case}"
+        );
+        assert_eq!(
+            policy.down_late_grace_us,
+            case["down_late_grace_us"].as_u64().unwrap(),
+            "{case}"
+        );
+        assert_eq!(
+            policy.min_hold_us,
+            case["min_hold_us"].as_u64().unwrap(),
+            "{case}"
+        );
+        assert_eq!(
+            policy.min_release_gap_us,
+            case["min_release_gap_us"].as_u64().unwrap(),
+            "{case}"
+        );
+        assert_eq!(
+            policy.focus_restore_grace_us,
+            case["focus_restore_grace_us"].as_u64().unwrap(),
+            "{case}"
+        );
+        assert_eq!(
+            policy.transport_margin_source,
+            case["transport_margin_source"].as_str().unwrap(),
+            "{case}"
+        );
+    }
 }

--- a/rust/crates/sky_app_core/tests/wave3_song_fixtures.rs
+++ b/rust/crates/sky_app_core/tests/wave3_song_fixtures.rs
@@ -1,0 +1,114 @@
+use serde_json::Value;
+use sky_app_core::song::{
+    ActionKind, analyze_schedule_with_context, build_schedule, parse_song_json,
+};
+
+fn fixture() -> Value {
+    serde_json::from_str(include_str!(
+        "../../../../tests/fixtures/wave3/song_planning.json"
+    ))
+    .expect("valid committed Wave 3 song fixture")
+}
+
+#[test]
+fn parser_cases_are_generated_by_the_current_python_oracle() {
+    let raw = fixture();
+    let cases = raw["parser_cases"].as_array().unwrap();
+    assert!(cases.len() >= 10);
+    for case in cases {
+        let bytes = serde_json::to_vec(&case["raw"]).unwrap();
+        match case["status"].as_str().unwrap() {
+            "ok" => {
+                let expected = &case["song"];
+                let actual = parse_song_json(&bytes, "fixture").expect("valid oracle case");
+                assert_eq!(actual.name, expected["name"].as_str().unwrap(), "{case}");
+                let expected_notes = expected["notes"].as_array().unwrap();
+                assert_eq!(actual.notes.len(), expected_notes.len(), "{case}");
+                for (actual, expected) in actual.notes.iter().zip(expected_notes) {
+                    assert_eq!(
+                        actual.time_ms,
+                        expected["time_ms"].as_i64().unwrap(),
+                        "{case}"
+                    );
+                    assert_eq!(actual.key, expected["key"].as_str().unwrap(), "{case}");
+                }
+            }
+            "error" => assert!(parse_song_json(&bytes, "fixture").is_err(), "{case}"),
+            other => panic!("unexpected parser status {other}"),
+        }
+    }
+}
+
+#[test]
+fn schedule_and_risk_cases_match_python_oracle_fields() {
+    let raw = fixture();
+    let cases = raw["schedule_cases"].as_array().unwrap();
+    assert!(cases.len() >= 4);
+    for case in cases {
+        let bytes = serde_json::to_vec(&case["raw"]).unwrap();
+        let song = parse_song_json(&bytes, "fixture").expect("valid schedule fixture");
+        let schedule = build_schedule(
+            &song,
+            case["hold_frames"].as_f64().unwrap(),
+            case["tempo_scale"].as_f64().unwrap(),
+            case["fps"].as_u64().unwrap() as u16,
+        )
+        .expect("schedule oracle case");
+        let expected = &case["schedule"];
+        let actual = serde_json::to_value(&schedule).unwrap();
+        for field in [
+            "actions",
+            "source_duration_us",
+            "playback_duration_us",
+            "duration_us",
+            "note_count",
+            "deduplicated_note_count",
+            "duplicate_note_count",
+            "compressed_holds",
+            "impossible_same_key_repeats",
+            "risky_same_key_repeats",
+            "max_polyphony",
+            "shortest_same_key_interval_us",
+            "min_same_key_up_gap_us",
+        ] {
+            assert_eq!(
+                actual[field], expected[field],
+                "schedule field {field}: {case}"
+            );
+        }
+
+        let risk = analyze_schedule_with_context(
+            &schedule,
+            Some(&song.notes),
+            case["hold_frames"].as_f64().unwrap(),
+            case["tempo_scale"].as_f64().unwrap(),
+        );
+        let expected_risk = &case["risk"];
+        let actual_risk = serde_json::to_value(&risk).unwrap();
+        for field in [
+            "severity",
+            "reason",
+            "recommendations",
+            "dense_clusters",
+            "max_polyphony",
+            "max_chord_size",
+            "chords_count",
+            "timing_stress_rate",
+            "min_any_note_gap_us",
+            "min_same_key_gap_us",
+            "suggested_hold_frames",
+            "suggested_tempo_scale",
+        ] {
+            assert_eq!(
+                actual_risk[field], expected_risk[field],
+                "risk field {field}: {case}"
+            );
+        }
+    }
+}
+
+#[test]
+fn action_kind_wire_names_remain_stable() {
+    assert_eq!(serde_json::to_value(ActionKind::Down).unwrap(), "down");
+    assert_eq!(serde_json::to_value(ActionKind::Up).unwrap(), "up");
+}

--- a/rust/crates/sky_dispatch_win32/src/focus.rs
+++ b/rust/crates/sky_dispatch_win32/src/focus.rs
@@ -70,3 +70,119 @@ pub fn foreground_window_matches(target_hwnd: isize) -> bool {
         false
     }
 }
+
+/// Resolve the visible Sky window using the same title/process admission
+/// boundary as the legacy desktop target adapter.  This is deliberately kept
+/// in the Win32 crate so application code never has to own unsafe window API
+/// calls.  The returned HWND is only a target hint; the realtime worker still
+/// performs the final foreground admission before every physical down.
+#[cfg(windows)]
+pub fn find_sky_window(process_names: &[String], allow_title_fallback: bool) -> Option<isize> {
+    use windows_sys::Win32::Foundation::{CloseHandle, HWND, LPARAM};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, QueryFullProcessImageNameW,
+    };
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowTextLengthW, GetWindowTextW, GetWindowThreadProcessId,
+        IsWindowVisible,
+    };
+
+    struct Search {
+        names: Vec<String>,
+        allow_title_fallback: bool,
+        target: Option<isize>,
+    }
+
+    unsafe extern "system" fn visit(hwnd: HWND, context: LPARAM) -> i32 {
+        let search = unsafe { &mut *(context as *mut Search) };
+        if unsafe { IsWindowVisible(hwnd) } == 0 {
+            return 1;
+        }
+        let length = unsafe { GetWindowTextLengthW(hwnd) };
+        if length <= 0 {
+            return 1;
+        }
+        let mut title = vec![0u16; length as usize + 1];
+        let written = unsafe { GetWindowTextW(hwnd, title.as_mut_ptr(), title.len() as i32) };
+        if written <= 0 {
+            return 1;
+        }
+        let title = String::from_utf16_lossy(&title[..written as usize]);
+        if title != "Sky" && !title.starts_with("Sky") {
+            return 1;
+        }
+        let mut pid = 0u32;
+        if unsafe { GetWindowThreadProcessId(hwnd, &mut pid) } == 0 {
+            return 1;
+        }
+        let mut process_name = None;
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if !handle.is_null() {
+            let mut buffer = [0u16; 4096];
+            let mut size = buffer.len() as u32;
+            if unsafe { QueryFullProcessImageNameW(handle, 0, buffer.as_mut_ptr(), &mut size) } != 0
+            {
+                process_name = String::from_utf16(&buffer[..size as usize])
+                    .ok()
+                    .and_then(|path| {
+                        std::path::Path::new(&path)
+                            .file_name()
+                            .map(|name| name.to_string_lossy().into_owned())
+                    });
+            }
+            unsafe {
+                CloseHandle(handle);
+            }
+        }
+        if search.allow_title_fallback
+            || search.names.is_empty()
+            || process_name
+                .as_deref()
+                .is_some_and(|name| search.names.iter().any(|expected| expected == name))
+        {
+            search.target = Some(hwnd as isize);
+            return 0;
+        }
+        1
+    }
+
+    let mut search = Search {
+        names: process_names.to_vec(),
+        allow_title_fallback,
+        target: None,
+    };
+    // The callback does not outlive this synchronous EnumWindows call. The
+    // search owns its process-name strings, so the callback context has no
+    // fabricated reference lifetime.
+    let context = &mut search as *mut Search as LPARAM;
+    unsafe {
+        EnumWindows(Some(visit), context);
+    }
+    search.target
+}
+
+#[cfg(not(windows))]
+pub fn find_sky_window(_process_names: &[String], _allow_title_fallback: bool) -> Option<isize> {
+    None
+}
+
+/// Perform only the documented minimal foreground request.  No input queue
+/// attachment, z-order forcing, or repeated activation is performed here.
+#[cfg(windows)]
+pub fn focus_window(hwnd: isize) -> bool {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        SW_RESTORE, SetForegroundWindow, ShowWindow,
+    };
+    if hwnd == 0 {
+        return false;
+    }
+    unsafe {
+        ShowWindow(hwnd as _, SW_RESTORE);
+        SetForegroundWindow(hwnd as _) != 0
+    }
+}
+
+#[cfg(not(windows))]
+pub fn focus_window(_hwnd: isize) -> bool {
+    false
+}

--- a/rust/crates/sky_dispatch_win32/src/focus.rs
+++ b/rust/crates/sky_dispatch_win32/src/focus.rs
@@ -186,3 +186,22 @@ pub fn focus_window(hwnd: isize) -> bool {
 pub fn focus_window(_hwnd: isize) -> bool {
     false
 }
+
+/// Request the documented minimal focus change and verify the exact HWND for
+/// a bounded interval before a physical worker is armed.  The polling is
+/// read-only and intentionally does not attach input queues or force z-order.
+pub fn focus_window_and_verify(hwnd: isize, budget: std::time::Duration) -> bool {
+    if !focus_window(hwnd) {
+        return false;
+    }
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if foreground_window_matches(hwnd) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}

--- a/rust/crates/sky_native_adapters/Cargo.toml
+++ b/rust/crates/sky_native_adapters/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 [dependencies]
 serde_json = "1"
 sky_app_core = { path = "../sky_app_core" }
+sky_player = { path = "../sky_player" }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "=0.61.2", features = [

--- a/rust/crates/sky_native_adapters/src/lib.rs
+++ b/rust/crates/sky_native_adapters/src/lib.rs
@@ -16,6 +16,394 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+pub const DEFAULT_TRANSPORT_MARGIN_US: u64 = 300;
+pub const CALIBRATION_MARGIN_SOURCE_DEFAULT: &str = "default_transport_300";
+pub const CALIBRATION_MARGIN_SOURCE_DEVICE: &str = "device_cache";
+pub const CALIBRATION_MARGIN_SOURCE_INVALID: &str = "invalid_cache_transport_300";
+pub const CALIBRATION_MARGIN_SOURCE_INCOMPATIBLE: &str = "incompatible_host_transport_300";
+pub const CALIBRATION_MARGIN_SOURCE_OUT_OF_ENVELOPE: &str = "out_of_envelope_transport_300";
+
+const CALIBRATION_CACHE_VERSION: u64 = 8;
+const CALIBRATION_EVIDENCE_KIND: &str = "sender_completion_hold_shrink";
+const CALIBRATION_ARTIFACT_SCHEMA_VERSION: u64 = 11;
+const CALIBRATION_NATIVE_VERSION: u64 = 15;
+const CALIBRATION_MEASUREMENT_PROTOCOL_VERSION: u64 = 10;
+const CALIBRATION_SOURCE_FORMULA_VERSION: u64 = 6;
+const CALIBRATION_HOST_FINGERPRINT_VERSION: u64 = 2;
+const CALIBRATION_SAMPLE_COUNT: u64 = 100;
+const CALIBRATION_MAX_SHRINK_US: i64 = 100_000;
+const CALIBRATION_REQUIRED_BUCKETS: [&str; 6] =
+    ["1/hot", "1/cold", "5/hot", "5/cold", "15/hot", "15/cold"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalibrationResolution {
+    pub margin_us: u64,
+    pub source: String,
+}
+
+/// Read the publishable sender-calibration result using the same fail-closed
+/// categories as the Python loader.  The cache is evidence, not a source of
+/// arbitrary timing values: only the current schema/formula/constants and a
+/// valid applied margin are accepted.
+pub fn load_calibration_resolution(path: impl AsRef<Path>) -> CalibrationResolution {
+    let fallback = |source: &str| CalibrationResolution {
+        margin_us: DEFAULT_TRANSPORT_MARGIN_US,
+        source: source.into(),
+    };
+    let Ok(text) = fs::read_to_string(path) else {
+        return fallback(CALIBRATION_MARGIN_SOURCE_DEFAULT);
+    };
+    let Ok(Value::Object(root)) = serde_json::from_str::<Value>(&text) else {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+    };
+    if root.get("version").and_then(Value::as_u64) != Some(CALIBRATION_CACHE_VERSION)
+        || root.get("evidence_kind").and_then(Value::as_str) != Some(CALIBRATION_EVIDENCE_KIND)
+        || root.get("artifact_schema_version").and_then(Value::as_u64)
+            != Some(CALIBRATION_ARTIFACT_SCHEMA_VERSION)
+        || root
+            .get("native_calibration_version")
+            .and_then(Value::as_u64)
+            != Some(CALIBRATION_NATIVE_VERSION)
+        || root
+            .get("measurement_protocol_version")
+            .and_then(Value::as_u64)
+            != Some(CALIBRATION_MEASUREMENT_PROTOCOL_VERSION)
+        || root.get("source").and_then(Value::as_str) != Some("device_cache")
+        || root.get("source_formula_version").and_then(Value::as_u64)
+            != Some(CALIBRATION_SOURCE_FORMULA_VERSION)
+    {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INCOMPATIBLE);
+    }
+    let Some(qualification) = root.get("qualification").and_then(Value::as_object) else {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+    };
+    let Some(host) = valid_host_fingerprint(root.get("host_fingerprint")) else {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+    };
+    if !valid_provenance(&root) || !valid_scheduling_aids(root.get("scheduling_aids")) {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+    }
+    let Some((global_transport, worst_bucket)) = valid_pair_buckets(&root) else {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+    };
+    let (expected_status, candidate, applied) = qualification_values(global_transport);
+    let status = qualification
+        .get("status")
+        .and_then(Value::as_str)
+        .or_else(|| root.get("status").and_then(Value::as_str));
+    if status == Some("out_of_envelope") {
+        if !qualification_matches(
+            &root,
+            qualification,
+            QualificationValues {
+                status,
+                worst_bucket: &worst_bucket,
+                global_transport,
+                candidate,
+                applied,
+                expected_status,
+            },
+        ) {
+            return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+        }
+        return fallback(CALIBRATION_MARGIN_SOURCE_OUT_OF_ENVELOPE);
+    }
+    if !qualification_matches(
+        &root,
+        qualification,
+        QualificationValues {
+            status,
+            worst_bucket: &worst_bucket,
+            global_transport,
+            candidate,
+            applied,
+            expected_status,
+        },
+    ) || status != Some("valid")
+    {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INVALID);
+    }
+    let margin = applied.expect("valid qualification has an applied margin");
+    #[cfg(windows)]
+    if !host_matches_current(host) {
+        return fallback(CALIBRATION_MARGIN_SOURCE_INCOMPATIBLE);
+    }
+    CalibrationResolution {
+        margin_us: margin,
+        source: CALIBRATION_MARGIN_SOURCE_DEVICE.into(),
+    }
+}
+
+fn object(value: Option<&Value>) -> Option<&Map<String, Value>> {
+    value?.as_object()
+}
+
+fn unsigned(object: &Map<String, Value>, key: &str) -> Option<u64> {
+    object.get(key)?.as_u64()
+}
+
+fn signed(object: &Map<String, Value>, key: &str) -> Option<i64> {
+    object.get(key)?.as_i64()
+}
+
+fn nonempty_string(object: &Map<String, Value>, key: &str) -> bool {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.trim().is_empty() && value != "unknown")
+}
+
+fn valid_host_fingerprint(value: Option<&Value>) -> Option<&Map<String, Value>> {
+    let host = object(value)?;
+    if unsigned(host, "host_fingerprint_version") != Some(CALIBRATION_HOST_FINGERPRINT_VERSION)
+        || unsigned(host, "qpc_frequency_hz").is_none()
+        || !nonempty_string(host, "win32_build")
+        || !nonempty_string(host, "processor_architecture")
+        || !nonempty_string(host, "cpu_vendor")
+        || [
+            "cpu_family",
+            "cpu_model",
+            "cpu_stepping",
+            "logical_processor_count",
+            "processor_group_count",
+        ]
+        .iter()
+        .any(|key| unsigned(host, key).is_none())
+    {
+        return None;
+    }
+    let efficiency = host.get("cpu_set_efficiency_classes")?.as_array()?;
+    if efficiency.iter().any(|value| value.as_u64().is_none()) {
+        return None;
+    }
+    for key in ["highest_efficiency_class", "lowest_efficiency_class"] {
+        if host
+            .get(key)
+            .is_some_and(|value| !value.is_null() && value.as_u64().is_none())
+        {
+            return None;
+        }
+    }
+    if host
+        .get("sampled_at_us")
+        .is_some_and(|value| !value.is_null() && value.as_u64().is_none())
+    {
+        return None;
+    }
+    Some(host)
+}
+
+fn valid_provenance(root: &Map<String, Value>) -> bool {
+    [
+        "source_git_sha",
+        "native_build_id",
+        "native_source_fingerprint",
+        "rustc_version",
+    ]
+    .iter()
+    .all(|key| nonempty_string(root, key))
+        && root.get("source_git_sha") == root.get("native_build_id")
+        && root.get("dirty_worktree") == Some(&Value::Bool(false))
+}
+
+fn valid_scheduling_aids(value: Option<&Value>) -> bool {
+    let Some(aids) = object(value) else {
+        return false;
+    };
+    let Some(mmcss) = aids.get("mmcss_acquired").and_then(Value::as_str) else {
+        return false;
+    };
+    let Some(mmcss_active) = aids.get("mmcss_active").and_then(Value::as_bool) else {
+        return false;
+    };
+    let Some(_power_active) = aids.get("power_throttling_active").and_then(Value::as_bool) else {
+        return false;
+    };
+    let Some(waiter_mode) = aids.get("waiter_mode").and_then(Value::as_str) else {
+        return false;
+    };
+    [
+        "off",
+        "mmcss:Games",
+        "thread:highest",
+        "thread:time_critical",
+    ]
+    .contains(&mmcss)
+        && mmcss_active == (mmcss != "off")
+        && [
+            "event+high_resolution_timer",
+            "high_resolution_timer",
+            "event+timer_resolution_fallback",
+            "timer_resolution_fallback",
+        ]
+        .contains(&waiter_mode)
+        && ["off", "mmcss:Games", "thread:highest"].contains(&mmcss)
+        && waiter_mode == "event+high_resolution_timer"
+}
+
+fn valid_signed_quantiles(value: Option<&Value>, unsigned_values: bool) -> bool {
+    let Some(values) = object(value) else {
+        return false;
+    };
+    let fields = ["min", "p50", "p90", "p95", "p99", "max", "mean"];
+    let Some(parsed) = fields
+        .iter()
+        .map(|key| signed(values, key))
+        .collect::<Option<Vec<_>>>()
+    else {
+        return false;
+    };
+    let ordered = &parsed[..6];
+    ordered.windows(2).all(|pair| pair[0] <= pair[1])
+        && parsed[0] <= parsed[6]
+        && parsed[6] <= parsed[5]
+        && ordered.iter().all(|value| {
+            (unsigned_values && *value >= 0)
+                || (!unsigned_values && value.abs() <= CALIBRATION_MAX_SHRINK_US)
+        })
+}
+
+fn valid_pair_buckets(root: &Map<String, Value>) -> Option<(i64, String)> {
+    let required = root.get("required_buckets")?.as_array()?;
+    if required.len() != CALIBRATION_REQUIRED_BUCKETS.len()
+        || required
+            .iter()
+            .zip(CALIBRATION_REQUIRED_BUCKETS)
+            .any(|(actual, expected)| actual.as_str() != Some(expected))
+    {
+        return None;
+    }
+    let buckets = object(root.get("pair_buckets"))?;
+    if buckets.len() != CALIBRATION_REQUIRED_BUCKETS.len()
+        || CALIBRATION_REQUIRED_BUCKETS
+            .iter()
+            .any(|key| !buckets.contains_key(*key))
+    {
+        return None;
+    }
+    let mut global = 0_i64;
+    let mut worst = CALIBRATION_REQUIRED_BUCKETS[0];
+    for key in CALIBRATION_REQUIRED_BUCKETS {
+        let bucket = object(buckets.get(key))?;
+        let attempted = unsigned(bucket, "attempted")?;
+        let clean = unsigned(bucket, "clean_pair_count")?;
+        let rejected = unsigned(bucket, "rejected")?;
+        if !(CALIBRATION_SAMPLE_COUNT..=CALIBRATION_SAMPLE_COUNT * 2).contains(&attempted)
+            || clean != CALIBRATION_SAMPLE_COUNT
+            || rejected != attempted.saturating_sub(clean)
+            || unsigned(bucket, "anomaly_count")? != rejected
+            || unsigned(bucket, "class_mismatch_count")? != rejected
+            || unsigned(bucket, "timeout_count")? != 0
+            || unsigned(bucket, "partial_send")? != 0
+            || !valid_signed_quantiles(bucket.get("pair_sender_hold_shrink_us"), false)
+            || !valid_signed_quantiles(bucket.get("scheduler_shrink_us"), false)
+            || !valid_signed_quantiles(bucket.get("sendinput_shrink_us"), false)
+            || !valid_signed_quantiles(bucket.get("down_call_duration_us"), true)
+            || !valid_signed_quantiles(bucket.get("up_call_duration_us"), true)
+        {
+            return None;
+        }
+        let bucket_max = signed(object(bucket.get("sendinput_shrink_us"))?, "max")?;
+        if bucket_max > global {
+            global = bucket_max;
+            worst = key;
+        }
+    }
+    Some((global.max(0), worst.into()))
+}
+
+fn qualification_values(global_transport: i64) -> (&'static str, u64, Option<u64>) {
+    let candidate = global_transport as u64 + 100;
+    if candidate > 2_000 {
+        ("out_of_envelope", candidate, None)
+    } else {
+        ("valid", candidate, Some(300_u64.max(candidate)))
+    }
+}
+
+struct QualificationValues<'a> {
+    status: Option<&'a str>,
+    worst_bucket: &'a str,
+    global_transport: i64,
+    candidate: u64,
+    applied: Option<u64>,
+    expected_status: &'a str,
+}
+
+fn qualification_matches(
+    root: &Map<String, Value>,
+    qualification: &Map<String, Value>,
+    values: QualificationValues<'_>,
+) -> bool {
+    let Some(worst_serialized) = qualification.get("worst_bucket").and_then(Value::as_str) else {
+        return false;
+    };
+    qualification.get("basis").and_then(Value::as_str)
+        == Some("max_required_bucket_max_positive_sendinput_shrink")
+        && worst_serialized == values.worst_bucket
+        && qualification
+            .get("transport_worst_positive_us")
+            .and_then(Value::as_i64)
+            == Some(values.global_transport)
+        && qualification.get("guard_us").and_then(Value::as_u64) == Some(100)
+        && qualification.get("floor_us").and_then(Value::as_u64) == Some(300)
+        && qualification.get("ceiling_us").and_then(Value::as_u64) == Some(2_000)
+        && qualification
+            .get("candidate_transport_margin_us")
+            .and_then(Value::as_u64)
+            == Some(values.candidate)
+        && qualification
+            .get("applied_transport_margin_us")
+            .and_then(Value::as_u64)
+            == values.applied
+        && values.status == Some(values.expected_status)
+        && root.get("status").and_then(Value::as_str) == values.status
+        && root.get("transport_margin_us").and_then(Value::as_u64) == values.applied
+        && root.get("transport_margin_source").and_then(Value::as_str)
+            == Some(CALIBRATION_MARGIN_SOURCE_DEVICE)
+        && root
+            .get("transport_worst_positive_us")
+            .and_then(Value::as_i64)
+            == Some(values.global_transport)
+        && root.get("transport_guard_us").and_then(Value::as_u64) == Some(100)
+        && root.get("transport_floor_us").and_then(Value::as_u64) == Some(300)
+        && root.get("transport_ceiling_us").and_then(Value::as_u64) == Some(2_000)
+        && root
+            .get("calibration_timing_qualified")
+            .and_then(Value::as_bool)
+            == Some(values.expected_status == "valid")
+}
+
+#[cfg(windows)]
+fn host_matches_current(host: &Map<String, Value>) -> bool {
+    let Ok(current) = sky_player::adapter_support::build_host_fingerprint() else {
+        return false;
+    };
+    let Ok(current) = serde_json::to_value(current) else {
+        return false;
+    };
+    let Some(current) = current.as_object() else {
+        return false;
+    };
+    [
+        "host_fingerprint_version",
+        "qpc_frequency_hz",
+        "win32_build",
+        "processor_architecture",
+        "cpu_vendor",
+        "cpu_family",
+        "cpu_model",
+        "cpu_stepping",
+        "logical_processor_count",
+        "processor_group_count",
+        "cpu_set_efficiency_classes",
+        "highest_efficiency_class",
+        "lowest_efficiency_class",
+    ]
+    .iter()
+    .all(|key| host.get(*key) == current.get(*key))
+}
+
 #[derive(Clone)]
 pub struct JsonSettingsStore {
     path: PathBuf,
@@ -659,6 +1047,152 @@ mod tests {
         assert_eq!(raw["future"], true);
         assert!(raw.get("default_timing_profile").is_none());
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn calibration_resolution_accepts_only_publishable_current_cache() {
+        let root =
+            std::env::temp_dir().join(format!("sky-w3-calibration-{}-{}", std::process::id(), 1));
+        fs::create_dir_all(root.parent().expect("temp parent")).expect("temp parent");
+        let path = root.with_extension("json");
+        fs::write(&path, valid_calibration_cache(677).to_string()).expect("cache");
+        assert_eq!(
+            load_calibration_resolution(&path),
+            CalibrationResolution {
+                margin_us: 777,
+                source: CALIBRATION_MARGIN_SOURCE_DEVICE.into()
+            }
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn calibration_resolution_fails_closed_for_invalid_and_unhealthy_cache() {
+        let path = std::env::temp_dir().join(format!(
+            "sky-w3-invalid-calibration-{}.json",
+            std::process::id()
+        ));
+        fs::write(&path, b"{not-json").expect("cache");
+        assert_eq!(
+            load_calibration_resolution(&path).source,
+            CALIBRATION_MARGIN_SOURCE_INVALID
+        );
+        fs::write(&path, valid_calibration_cache(2_500).to_string()).expect("cache");
+        assert_eq!(
+            load_calibration_resolution(&path).source,
+            CALIBRATION_MARGIN_SOURCE_OUT_OF_ENVELOPE
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    fn quantiles(min: i64, max: i64) -> Value {
+        serde_json::json!({
+            "min": min,
+            "p50": min,
+            "p90": min.max(0),
+            "p95": min.max(0),
+            "p99": max,
+            "max": max,
+            "mean": min.max(0)
+        })
+    }
+
+    fn calibration_host() -> Value {
+        #[cfg(windows)]
+        {
+            serde_json::to_value(
+                sky_player::adapter_support::build_host_fingerprint().expect("host fingerprint"),
+            )
+            .expect("host JSON")
+        }
+        #[cfg(not(windows))]
+        serde_json::json!({
+            "host_fingerprint_version": 2,
+            "qpc_frequency_hz": 10_000_000,
+            "win32_build": "Windows test",
+            "processor_architecture": "AMD64",
+            "cpu_vendor": "test",
+            "cpu_family": 6,
+            "cpu_model": 1,
+            "cpu_stepping": 1,
+            "logical_processor_count": 1,
+            "processor_group_count": 1,
+            "cpu_set_efficiency_classes": [0],
+            "highest_efficiency_class": 0,
+            "lowest_efficiency_class": 0,
+            "sampled_at_us": 1
+        })
+    }
+
+    fn valid_calibration_cache(sendinput_max: i64) -> Value {
+        let mut pair_buckets = serde_json::Map::new();
+        for key in CALIBRATION_REQUIRED_BUCKETS {
+            pair_buckets.insert(
+                key.into(),
+                serde_json::json!({
+                    "attempted": 100,
+                    "clean_pair_count": 100,
+                    "rejected": 0,
+                    "anomaly_count": 0,
+                    "class_mismatch_count": 0,
+                    "timeout_count": 0,
+                    "partial_send": 0,
+                    "pair_sender_hold_shrink_us": quantiles(-4, sendinput_max),
+                    "scheduler_shrink_us": quantiles(-4, 8),
+                    "sendinput_shrink_us": quantiles(-4, sendinput_max),
+                    "down_call_duration_us": quantiles(1, 3),
+                    "up_call_duration_us": quantiles(1, 3)
+                }),
+            );
+        }
+        let status = if sendinput_max + 100 > 2_000 {
+            "out_of_envelope"
+        } else {
+            "valid"
+        };
+        let applied =
+            (300_i64.max(sendinput_max + 100) <= 2_000).then_some(300_i64.max(sendinput_max + 100));
+        serde_json::json!({
+            "version": 8,
+            "evidence_kind": "sender_completion_hold_shrink",
+            "artifact_schema_version": 11,
+            "native_calibration_version": 15,
+            "measurement_protocol_version": 10,
+            "source": "device_cache",
+            "source_formula_version": 6,
+            "status": status,
+            "source_git_sha": "test-sha",
+            "native_build_id": "test-sha",
+            "native_source_fingerprint": "test-fingerprint",
+            "rustc_version": "rustc test",
+            "dirty_worktree": false,
+            "host_fingerprint": calibration_host(),
+            "scheduling_aids": {
+                "mmcss_acquired": "mmcss:Games",
+                "mmcss_active": true,
+                "power_throttling_active": true,
+                "waiter_mode": "event+high_resolution_timer"
+            },
+            "required_buckets": CALIBRATION_REQUIRED_BUCKETS,
+            "pair_buckets": pair_buckets,
+            "transport_margin_us": applied,
+            "transport_margin_source": "device_cache",
+            "transport_worst_positive_us": sendinput_max,
+            "transport_guard_us": 100,
+            "transport_floor_us": 300,
+            "transport_ceiling_us": 2000,
+            "calibration_timing_qualified": status == "valid",
+            "qualification": {
+                "basis": "max_required_bucket_max_positive_sendinput_shrink",
+                "worst_bucket": "1/hot",
+                "transport_worst_positive_us": sendinput_max,
+                "guard_us": 100,
+                "floor_us": 300,
+                "ceiling_us": 2000,
+                "candidate_transport_margin_us": sendinput_max + 100,
+                "applied_transport_margin_us": applied
+            }
+        })
     }
 
     #[test]

--- a/rust/crates/sky_player/src/engine.rs
+++ b/rust/crates/sky_player/src/engine.rs
@@ -16,8 +16,8 @@ pub use config::StartupOrderingHook;
 pub use config::TestWaitPolicy;
 use config::WorkerConfig;
 pub use config::{
-    BackendConfig, FocusOptions, NativeSessionOptions, PriorityOptions, TelemetryOptions,
-    TimingOptions, WaitOptions,
+    BackendConfig, DEFAULT_SUPERVISOR_LEASE_TIMEOUT_US, FocusOptions, NativeSessionOptions,
+    PriorityOptions, TelemetryOptions, TimingOptions, WaitOptions,
 };
 pub use session::NativeDispatchSession;
 pub use snapshot::{EnginePollSnapshot, EnginePollStatus, EngineProgressSnapshot, EngineSnapshot};

--- a/rust/crates/sky_player/src/engine/config.rs
+++ b/rust/crates/sky_player/src/engine/config.rs
@@ -9,6 +9,10 @@ pub(crate) const CALIBRATION_SAFETY_MARGIN_US: u64 = 50;
 pub(crate) const CALIBRATION_SAMPLES: usize = 6;
 pub(crate) const CALIBRATION_MAX_STARTUP_BUDGET_US: u64 = 20_000;
 pub(crate) const MIN_PRODUCTION_PREROLL_US: u64 = 50_000;
+/// Maximum interval for the non-realtime supervisor to prove it is still
+/// alive.  Both the temporary PyO3 adapter and the direct desktop adapter
+/// consume this same qualified safety boundary.
+pub const DEFAULT_SUPERVISOR_LEASE_TIMEOUT_US: u64 = 3_000_000;
 
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/crates/sky_player/src/engine/tests.rs
+++ b/rust/crates/sky_player/src/engine/tests.rs
@@ -3992,6 +3992,87 @@ fn supervisor_lease_preserves_fresh_boundary_and_expiration() {
 }
 
 #[test]
+fn supervisor_heartbeat_keeps_worker_alive_and_expiry_runs_cleanup() {
+    let actions = vec![
+        KeyActionInput {
+            source_action_index: 0,
+            kind: ActionKind::Down,
+            scheduled_us: 200_000,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "lease-down".to_string().into(),
+        },
+        KeyActionInput {
+            source_action_index: 1,
+            kind: ActionKind::Up,
+            scheduled_us: 300_000,
+            scan_codes: smallvec::smallvec![0x15],
+            reason: "lease-up".to_string().into(),
+        },
+    ];
+    let schedule = sky_dispatch_core::compile::compile_runtime_intents(&actions, &[0x15])
+        .expect("valid lease lifecycle schedule");
+
+    let mut heartbeat_options = test_session_options(
+        schedule.clone(),
+        1,
+        BackendConfig::Mock {
+            latency_base_us: 0,
+            latency_per_key_us: 0,
+            fault_script: FaultInjectionScript::none(),
+        },
+    );
+    heartbeat_options.wait.supervisor_lease_timeout_us = 50_000;
+    let heartbeat_session =
+        NativeDispatchSession::new(heartbeat_options).expect("heartbeat session admission");
+    heartbeat_session.arm(0).expect("heartbeat session arm");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !heartbeat_session.snapshot().is_finished && Instant::now() < deadline {
+        heartbeat_session.heartbeat().expect("supervisor heartbeat");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        heartbeat_session
+            .join(Duration::from_secs(2))
+            .expect("heartbeat join")
+    );
+    let heartbeat_snapshot = heartbeat_session.snapshot();
+    assert_ne!(
+        heartbeat_snapshot.terminal_error.as_deref(),
+        Some("supervisor_lease_expired"),
+        "periodic heartbeat must keep the worker admitted: {heartbeat_snapshot:?}"
+    );
+    assert_eq!(heartbeat_snapshot.active_count, 0);
+    assert_eq!(heartbeat_snapshot.possibly_active_count, 0);
+
+    let mut expiry_options = test_session_options(
+        schedule,
+        1,
+        BackendConfig::Mock {
+            latency_base_us: 0,
+            latency_per_key_us: 0,
+            fault_script: FaultInjectionScript::none(),
+        },
+    );
+    expiry_options.wait.supervisor_lease_timeout_us = 50_000;
+    let expiry_session = NativeDispatchSession::new(expiry_options).expect("expiry admission");
+    expiry_session.arm(0).expect("expiry session arm");
+    assert!(
+        expiry_session
+            .join(Duration::from_secs(2))
+            .expect("expiry join")
+    );
+    let expiry_snapshot = expiry_session.snapshot();
+    assert_eq!(
+        expiry_snapshot.terminal_error.as_deref(),
+        Some("supervisor_lease_expired"),
+        "stopped heartbeat must terminate the worker: {expiry_snapshot:?}"
+    );
+    assert_eq!(expiry_snapshot.active_count, 0);
+    assert_eq!(expiry_snapshot.possibly_active_count, 0);
+    assert!(expiry_snapshot.release_outcome.is_some());
+}
+
+#[test]
 fn supervisor_lease_disabled_is_never_expired() {
     let heartbeat = AtomicU64::new(1);
     assert_eq!(

--- a/rust/crates/sky_player/src/engine/worker.rs
+++ b/rust/crates/sky_player/src/engine/worker.rs
@@ -87,6 +87,7 @@ pub(crate) use timing::{
     deadline_target_ticks, exact_sender_durations,
 };
 #[cfg(any(test, feature = "test-support"))]
+#[allow(unused_imports)]
 pub(crate) use timing::{calibrated_spin_threshold_us, derive_spin_threshold_us};
 pub(crate) use timing::{
     lease_bounded_ticks, signed_delta, signed_ticks_to_us, signed_timeline_delta_ticks,
@@ -99,7 +100,7 @@ pub(crate) use wait::{
 
 use super::shared::SessionShared;
 use super::*;
-#[cfg(feature = "test-support")]
+#[cfg(any(test, feature = "test-support"))]
 use sky_dispatch_core::coordinator::AuthoredPreparationEvidence;
 use sky_dispatch_core::model::RuntimeSchedule;
 use std::sync::Arc;
@@ -142,7 +143,7 @@ pub(crate) struct DispatchPreparationProbe {
 
 impl DispatchPreparationProbe {
     #[inline]
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) fn record_authored_preparation(&self, evidence: AuthoredPreparationEvidence) {
         self.packet_header_reads
             .fetch_add(evidence.packet_header_reads, Ordering::Relaxed);

--- a/rust/crates/sky_player/src/engine/worker/planning.rs
+++ b/rust/crates/sky_player/src/engine/worker/planning.rs
@@ -214,7 +214,7 @@ pub(crate) fn plan_next_dispatch_projected(
         preparation_probe,
     } = input;
     let authored_packet = coordinator.prepare_current_authored_packet()?;
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     if let Some(prepared) = authored_packet.as_ref() {
         preparation_probe.record_authored_preparation(prepared.preparation_evidence);
     }

--- a/rust/crates/sky_player_rs/src/python/session.rs
+++ b/rust/crates/sky_player_rs/src/python/session.rs
@@ -71,7 +71,7 @@ impl NativeDispatchSessionPy {
         let strict_timing = parsed_profile.strict_timing();
         let strict_down_completion_late_us = 2_000;
         let strict_up_completion_late_us = 2_000;
-        let supervisor_lease_timeout_us = 3_000_000;
+        let supervisor_lease_timeout_us = sky_player::engine::DEFAULT_SUPERVISOR_LEASE_TIMEOUT_US;
         if min_hold_us > 60_000_000 {
             return Err(PyValueError::new_err(
                 "min_hold_us must be at most 60000000",

--- a/scripts/build_portable_release.py
+++ b/scripts/build_portable_release.py
@@ -333,7 +333,7 @@ def _run_tauri_pair_selftest(primary_exe: Path, *, cwd: Path) -> None:
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"packaged Tauri/Core selftest failed ({result.returncode}): "
+            f"packaged Tauri/Native Desktop selftest failed ({result.returncode}): "
             f"{_decode_output(result.stderr)[-4000:]}"
         )
     print(_decode_output(result.stdout).strip())

--- a/scripts/generate_wave2_fixtures.py
+++ b/scripts/generate_wave2_fixtures.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 import tempfile
 from dataclasses import asdict
 from pathlib import Path
+
+from rapidfuzz import fuzz
 
 import sky_music.config as config_module
 from sky_music.config import AppConfig, UpdateSettings
@@ -328,6 +331,35 @@ def catalog_fixture() -> dict[str, object]:
         window_case("query_too_long_1025_unicode", "é" * 1025),
         window_case("query_multibyte_under_codepoint_limit", "é" * 600),
     ]
+    fuzzy_pairs = [
+        ("this is a test", "this is a test!"),
+        ("fuzzy was a bear", "fuzzy fuzzy was a bear"),
+        ("fuzzy was a bear but not a dog", "fuzzy was a bear but not a cat"),
+        ("abcd", "xxabceyy"),
+        ("strasse", "straße"),
+        ("sky child", "sky children of the light"),
+        ("alpha beta", "beta alpha"),
+        ("abc", "xyzabcq"),
+        ("a b c", "a a b c"),
+        ("xabcdy", "abcd"),
+        ("abc", "zab"),
+        ("abc", "qabc"),
+        ("a b", "x a b y"),
+        ("foo bar", "foo baz qux"),
+        ("testing", "test"),
+        ("aa bb aa", "bb aa"),
+        ("a", "bbbbba"),
+    ]
+    rng = random.Random(20260831)
+    alphabet = "abcde rstuv"
+    for _ in range(96):
+        left = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 48))).strip()
+        right = "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 64))).strip()
+        fuzzy_pairs.append((left or "a", right or "b"))
+    fuzzy_cases = [
+        {"query": query, "candidate": candidate, "score": fuzz.WRatio(query, candidate)}
+        for query, candidate in fuzzy_pairs
+    ]
     return {
         "schema": 1,
         "paths": [str(path) for path in paths],
@@ -346,6 +378,7 @@ def catalog_fixture() -> dict[str, object]:
             )
         },
         "window_cases": window_cases,
+        "fuzzy_cases": fuzzy_cases,
         "stale_generation_error": "catalog generation is stale",
     }
 

--- a/scripts/generate_wave3_fixtures.py
+++ b/scripts/generate_wave3_fixtures.py
@@ -256,6 +256,40 @@ def _policy_case(name: str, *, margin: int, source: str) -> dict[str, object]:
     }
 
 
+def _detail_tempo_case(tempo: float) -> dict[str, object]:
+    """Capture the Python catalog-detail projection for one persisted tempo."""
+    scheduled = _schedule_case(
+        f"detail_tempo_{tempo:.2f}",
+        VALID_CASES[3][1],
+        ".json",
+        hold=1.0,
+        tempo=tempo,
+        fps=60,
+    )
+    risk = scheduled["risk"]
+    assert isinstance(risk, dict)
+    schedule = scheduled["schedule"]
+    assert isinstance(schedule, dict)
+    return {
+        "tempo_scale": tempo,
+        "raw": scheduled["raw"],
+        "duration_us": schedule["source_duration_us"],
+        "risk_level": risk["severity"],
+        "risk_recommendations": risk["recommendations"],
+        "risk_min_any_note_gap_us": risk["min_any_note_gap_us"],
+        "risk_min_same_key_gap_us": risk["min_same_key_gap_us"],
+        "recommendation": {
+            "recommended_hold_frames": risk["suggested_hold_frames"],
+            "recommended_tempo_scale": risk["suggested_tempo_scale"],
+            "summary": (
+                risk["recommendations"][0]
+                if risk["recommendations"]
+                else "Keep the selected settings."
+            ),
+        },
+    }
+
+
 def main() -> None:
     parser_cases = []
     for name, raw, suffix in VALID_CASES + INVALID_CASES:
@@ -295,6 +329,7 @@ def main() -> None:
             source=SOURCE_INCOMPATIBLE_HOST_TRANSPORT_300,
         ),
     ]
+    detail_tempo_cases = [_detail_tempo_case(tempo) for tempo in (0.90, 0.95, 1.00, 1.05, 1.10)]
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(
         json.dumps(
@@ -303,6 +338,7 @@ def main() -> None:
                 "parser_cases": parser_cases,
                 "schedule_cases": schedule_cases,
                 "timing_policy_cases": timing_policy_cases,
+                "detail_tempo_cases": detail_tempo_cases,
             },
             ensure_ascii=False,
             indent=2,

--- a/scripts/generate_wave3_fixtures.py
+++ b/scripts/generate_wave3_fixtures.py
@@ -1,0 +1,208 @@
+"""Generate immutable Wave 3 song/planning oracle fixtures from Python.
+
+The committed output is evidence for the current Python parser, scheduler, and
+analyzer. CI consumes the JSON; it never regenerates it. Run this script only
+when intentionally refreshing the migration corpus after reviewing the Python
+behavioral change.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import asdict
+from pathlib import Path
+
+from sky_music.domain.analyzer import analyze_schedule
+from sky_music.domain.parser import parse_song_file
+from sky_music.domain.scheduler import build_key_actions
+from sky_music.domain.scheduler_types import FrameTimingPolicy
+
+ROOT = Path(__file__).resolve().parents[1]
+OUTPUT = ROOT / "tests" / "fixtures" / "wave3" / "song_planning.json"
+
+
+VALID_CASES: tuple[tuple[str, object, str], ...] = (
+    (
+        "object_basic",
+        {
+            "name": "Demo",
+            "songNotes": [
+                {"time": 20, "key": "Key1"},
+                {"time": 0, "key": "Key0"},
+            ],
+        },
+        ".json",
+    ),
+    (
+        "root_list_first_item",
+        [
+            {
+                "name": "Legacy",
+                "songNotes": [{"time": "12", "key": "Key2"}],
+            },
+            {"name": "Ignored", "songNotes": []},
+        ],
+        ".skysheet",
+    ),
+    (
+        "empty_song",
+        {"name": "Empty", "songNotes": []},
+        ".txt",
+    ),
+    (
+        "numeric_string_and_chord",
+        {
+            "name": "Unicode Élan",
+            "songNotes": [
+                {"time": "10", "key": "Key3"},
+                {"time": 10, "key": "Key4"},
+                {"time": 25, "key": "Key3"},
+            ],
+        },
+        ".json",
+    ),
+    (
+        "duplicate_notes",
+        {
+            "name": "Duplicates",
+            "songNotes": [
+                {"time": 0, "key": "Key0"},
+                {"time": 0, "key": "Key0"},
+                {"time": 0, "key": "Key1"},
+            ],
+        },
+        ".json",
+    ),
+    (
+        "dense_chord",
+        {
+            "name": "Dense",
+            "songNotes": [
+                {"time": index, "key": f"Key{index}"} for index in range(7)
+            ],
+        },
+        ".json",
+    ),
+)
+
+INVALID_CASES: tuple[tuple[str, object, str], ...] = (
+    ("malformed_json", b"{not json", ".json"),
+    ("root_list_empty", [], ".json"),
+    ("root_not_object", ["not a song"], ".json"),
+    ("missing_song_notes", {"name": "Missing"}, ".json"),
+    (
+        "missing_note_time",
+        {"songNotes": [{"key": "Key0"}]},
+        ".json",
+    ),
+    (
+        "invalid_note_key",
+        {"songNotes": [{"time": 0, "key": "NotAKey"}]},
+        ".json",
+    ),
+    (
+        "negative_time",
+        {"songNotes": [{"time": -1, "key": "Key0"}]},
+        ".json",
+    ),
+)
+
+
+def _capture_parse(raw: object, suffix: str) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="sky-wave3-fixture-") as directory:
+        path = Path(directory) / f"fixture{suffix}"
+        if isinstance(raw, bytes):
+            path.write_bytes(raw)
+        else:
+            path.write_text(json.dumps(raw), encoding="utf-8")
+        try:
+            song = parse_song_file(path)
+        except Exception as error:
+            return {"status": "error", "error_type": type(error).__name__}
+        return {
+            "status": "ok",
+            "song": {
+                "name": song.name,
+                "notes": [
+                    {
+                        "time_ms": int(note.time_ms),
+                        "key": str(note.key),
+                    }
+                    for note in song.notes
+                ],
+            },
+        }
+
+
+def _schedule_case(name: str, raw: object, suffix: str, *, hold: float, tempo: float, fps: int) -> dict[str, object]:
+    with tempfile.TemporaryDirectory(prefix="sky-wave3-schedule-") as directory:
+        path = Path(directory) / f"fixture{suffix}"
+        path.write_text(json.dumps(raw), encoding="utf-8")
+        song = parse_song_file(path)
+    policy = FrameTimingPolicy.from_hold_frames(hold, fps)
+    schedule = build_key_actions(song, policy=policy, tempo_scale=tempo)
+    risk = analyze_schedule(
+        schedule,
+        raw_notes=song.notes,
+        current_hold_frames=hold,
+        current_tempo_scale=tempo,
+    )
+    return {
+        "name": name,
+        "raw": raw,
+        "hold_frames": hold,
+        "tempo_scale": tempo,
+        "fps": fps,
+        "schedule": {
+            "actions": [
+                {
+                    "at_us": int(action.at_us),
+                    "scan_codes": [int(code) for code in action.scan_codes],
+                    "kind": str(action.kind),
+                    "reason": action.reason,
+                }
+                for action in schedule.actions
+            ],
+            "source_duration_us": int(schedule.source_duration_us),
+            "playback_duration_us": int(schedule.playback_duration_us),
+            "duration_us": int(schedule.duration_us),
+            "note_count": schedule.note_count,
+            "deduplicated_note_count": schedule.deduplicated_note_count,
+            "duplicate_note_count": schedule.duplicate_note_count,
+            "compressed_holds": schedule.compressed_holds,
+            "impossible_same_key_repeats": schedule.impossible_same_key_repeats,
+            "risky_same_key_repeats": schedule.risky_same_key_repeats,
+            "max_polyphony": schedule.max_polyphony,
+            "shortest_same_key_interval_us": schedule.shortest_same_key_interval_us,
+            "min_same_key_up_gap_us": schedule.min_same_key_up_gap_us,
+        },
+        "risk": asdict(risk),
+    }
+
+
+def main() -> None:
+    parser_cases = []
+    for name, raw, suffix in VALID_CASES + INVALID_CASES:
+        parser_cases.append({"name": name, "raw": raw.decode() if isinstance(raw, bytes) else raw, **_capture_parse(raw, suffix)})
+
+    schedule_cases = [
+        _schedule_case("basic_schedule", VALID_CASES[0][1], ".json", hold=1.0, tempo=1.0, fps=60),
+        _schedule_case("tempo_rounding", VALID_CASES[3][1], ".json", hold=1.25, tempo=0.95, fps=120),
+        _schedule_case("empty_schedule", VALID_CASES[2][1], ".txt", hold=1.0, tempo=1.0, fps=60),
+        _schedule_case("dense_risk", VALID_CASES[5][1], ".json", hold=1.0, tempo=1.0, fps=60),
+    ]
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT.write_text(
+        json.dumps(
+            {"schema": 1, "parser_cases": parser_cases, "schedule_cases": schedule_cases},
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_wave3_fixtures.py
+++ b/scripts/generate_wave3_fixtures.py
@@ -12,11 +12,23 @@ import json
 import tempfile
 from dataclasses import asdict
 from pathlib import Path
+from unittest.mock import patch
 
+from sky_music.config import AppConfig
 from sky_music.domain.analyzer import analyze_schedule
 from sky_music.domain.parser import parse_song_file
 from sky_music.domain.scheduler import build_key_actions
 from sky_music.domain.scheduler_types import FrameTimingPolicy
+from sky_music.domain.session_context import PlaybackSessionContext
+from sky_music.infrastructure.calibration_loader import (
+    SOURCE_DEFAULT_TRANSPORT_300,
+    SOURCE_DEVICE_CACHE,
+    SOURCE_INCOMPATIBLE_HOST_TRANSPORT_300,
+    SOURCE_INVALID_CACHE_TRANSPORT_300,
+    CalibrationLoadResult,
+    CalibrationStatus,
+)
+from sky_music.orchestration.calibrated_policy import resolve_calibrated_policy
 
 ROOT = Path(__file__).resolve().parents[1]
 OUTPUT = ROOT / "tests" / "fixtures" / "wave3" / "song_planning.json"
@@ -135,12 +147,54 @@ def _capture_parse(raw: object, suffix: str) -> dict[str, object]:
         }
 
 
-def _schedule_case(name: str, raw: object, suffix: str, *, hold: float, tempo: float, fps: int) -> dict[str, object]:
+def _resolved_policy(*, hold: float, fps: int, margin: int, source: str) -> FrameTimingPolicy:
+    """Resolve through the production calibration-aware entry point.
+
+    The loader result is patched only to make each committed case deterministic;
+    the resolver and domain materialization are the same production functions
+    used by the desktop player.
+    """
+    result = CalibrationLoadResult(
+        status=(
+            CalibrationStatus.VALID
+            if source == SOURCE_DEVICE_CACHE
+            else CalibrationStatus.UNCALIBRATED
+        ),
+        resolved_margin_us=margin,
+        margin_source=source,
+        summary=None,
+    )
+    with patch(
+        "sky_music.orchestration.calibrated_policy.load_calibration_resolution",
+        return_value=result,
+    ):
+        return resolve_calibrated_policy(
+            PlaybackSessionContext.default(hold_frames=hold, fps=fps),
+            AppConfig(),
+        )
+
+
+def _schedule_case(
+    name: str,
+    raw: object,
+    suffix: str,
+    *,
+    hold: float,
+    tempo: float,
+    fps: int,
+    margin: int = 300,
+    margin_source: str = SOURCE_DEFAULT_TRANSPORT_300,
+) -> dict[str, object]:
     with tempfile.TemporaryDirectory(prefix="sky-wave3-schedule-") as directory:
         path = Path(directory) / f"fixture{suffix}"
         path.write_text(json.dumps(raw), encoding="utf-8")
         song = parse_song_file(path)
-    policy = FrameTimingPolicy.from_hold_frames(hold, fps)
+    policy = _resolved_policy(
+        hold=hold,
+        fps=fps,
+        margin=margin,
+        source=margin_source,
+    )
     schedule = build_key_actions(song, policy=policy, tempo_scale=tempo)
     risk = analyze_schedule(
         schedule,
@@ -154,6 +208,8 @@ def _schedule_case(name: str, raw: object, suffix: str, *, hold: float, tempo: f
         "hold_frames": hold,
         "tempo_scale": tempo,
         "fps": fps,
+        "transport_margin_us": int(policy.transport_margin_us or 0),
+        "transport_margin_source": policy.min_hold_margin_source,
         "schedule": {
             "actions": [
                 {
@@ -176,8 +232,27 @@ def _schedule_case(name: str, raw: object, suffix: str, *, hold: float, tempo: f
             "max_polyphony": schedule.max_polyphony,
             "shortest_same_key_interval_us": schedule.shortest_same_key_interval_us,
             "min_same_key_up_gap_us": schedule.min_same_key_up_gap_us,
+            "recommended_hold_frames": schedule.recommended_hold_frames,
+            "recommended_tempo_scale": schedule.recommended_tempo_scale,
         },
         "risk": asdict(risk),
+    }
+
+
+def _policy_case(name: str, *, margin: int, source: str) -> dict[str, object]:
+    policy = _resolved_policy(hold=1.25, fps=120, margin=margin, source=source)
+    return {
+        "name": name,
+        "hold_frames": 1.25,
+        "fps": 120,
+        "transport_margin_us": int(policy.transport_margin_us or 0),
+        "transport_margin_source": policy.min_hold_margin_source,
+        "frame_us": int(policy.frame_us),
+        "frame_base_hold_us": int(policy.frame_base_hold_us or 0),
+        "down_late_grace_us": int(policy.down_late_grace_us),
+        "min_hold_us": int(policy.min_hold_us),
+        "min_release_gap_us": int(policy.min_release_gap_us or 0),
+        "focus_restore_grace_us": int(policy.focus_restore_grace_us),
     }
 
 
@@ -189,13 +264,46 @@ def main() -> None:
     schedule_cases = [
         _schedule_case("basic_schedule", VALID_CASES[0][1], ".json", hold=1.0, tempo=1.0, fps=60),
         _schedule_case("tempo_rounding", VALID_CASES[3][1], ".json", hold=1.25, tempo=0.95, fps=120),
+        _schedule_case(
+            "calibrated_margin",
+            VALID_CASES[0][1],
+            ".json",
+            hold=1.0,
+            tempo=1.0,
+            fps=60,
+            margin=777,
+            margin_source=SOURCE_DEVICE_CACHE,
+        ),
         _schedule_case("empty_schedule", VALID_CASES[2][1], ".txt", hold=1.0, tempo=1.0, fps=60),
         _schedule_case("dense_risk", VALID_CASES[5][1], ".json", hold=1.0, tempo=1.0, fps=60),
+    ]
+    timing_policy_cases = [
+        _policy_case(
+            "no_cache_fallback",
+            margin=300,
+            source=SOURCE_DEFAULT_TRANSPORT_300,
+        ),
+        _policy_case("valid_device_cache", margin=777, source=SOURCE_DEVICE_CACHE),
+        _policy_case(
+            "unhealthy_cache_fallback",
+            margin=300,
+            source=SOURCE_INVALID_CACHE_TRANSPORT_300,
+        ),
+        _policy_case(
+            "stale_cache_fallback",
+            margin=300,
+            source=SOURCE_INCOMPATIBLE_HOST_TRANSPORT_300,
+        ),
     ]
     OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(
         json.dumps(
-            {"schema": 1, "parser_cases": parser_cases, "schedule_cases": schedule_cases},
+            {
+                "schema": 1,
+                "parser_cases": parser_cases,
+                "schedule_cases": schedule_cases,
+                "timing_policy_cases": timing_policy_cases,
+            },
             ensure_ascii=False,
             indent=2,
         )

--- a/scripts/report_production_python_boundary.py
+++ b/scripts/report_production_python_boundary.py
@@ -187,12 +187,24 @@ def _python_boundary_accounting(
     return {
         "command_ownership": ownership,
         "production_python_modules_still_required": python_modules,
+        # These modules still serve the Textual/CLI surfaces or the eight
+        # remaining Python-owned desktop routes. Do not label an entire module
+        # non-authoritative until its last production consumer is gone.
         "python_modules_made_non_authoritative": [],
+        "native_command_count": ownership["after"]["native_count"],
+        "python_command_count": ownership["after"]["python_count"],
+        "python_core_process_required": True,
+        "python_runtime_shipped": True,
+        "pyinstaller_required_for_portable_desktop": True,
+        "pyo3_required_for_production_tauri_playback": False,
+        "coresupervisor_use": "yes: settings.get, settings.patch, update.check, update.preferences.get, update.preferences.patch, update.begin_handoff, calibration.start, calibration.cancel",
+        "desktop_ipc_use": "yes: the eight remaining Python-owned commands and their event stream",
         "remaining_blockers": {
-            "settings.*": "Python Core caches AppConfig; native writes stay shadow-only until live coherence is proven.",
-            "catalog.*": "Python owns RapidFuzz WRatio, rich detail, and the live generation until equivalent Rust evidence exists.",
-            "update.*": "Python update orchestration remains live; Rust policy is fixture-backed shadow logic and sky_updater remains the apply owner.",
-            "playback.*": "Realtime execution and SendInput ownership are frozen for Wave 2.",
+            "settings.*": "Python Core still owns persisted settings routes because its process-local AppConfig cache remains live; native services read the atomically persisted shadow but do not write through a second authority.",
+            "update.check": "Python still owns release metadata orchestration; preferences remain with Core until the settings/update family can move coherently through one authority.",
+            "update.preferences.*": "Python Core owns the cached update preferences; moving only these routes to Native would create stale policy reads in update.check.",
+            "update.begin_handoff": "Python still correlates the checked update to handoff; the native gateway has not yet taken over this transaction boundary.",
+            "calibration.*": "Python still owns process isolation, evidence validation, cancellation, and cache publication.",
         },
     }
 

--- a/tests/fixtures/wave2/catalog.json
+++ b/tests/fixtures/wave2/catalog.json
@@ -387,5 +387,572 @@
       }
     }
   ],
+  "fuzzy_cases": [
+    {
+      "query": "this is a test",
+      "candidate": "this is a test!",
+      "score": 96.55172413793103
+    },
+    {
+      "query": "fuzzy was a bear",
+      "candidate": "fuzzy fuzzy was a bear",
+      "score": 95.0
+    },
+    {
+      "query": "fuzzy was a bear but not a dog",
+      "candidate": "fuzzy was a bear but not a cat",
+      "score": 90.0
+    },
+    {
+      "query": "abcd",
+      "candidate": "xxabceyy",
+      "score": 67.5
+    },
+    {
+      "query": "strasse",
+      "candidate": "straße",
+      "score": 76.92307692307692
+    },
+    {
+      "query": "sky child",
+      "candidate": "sky children of the light",
+      "score": 90.0
+    },
+    {
+      "query": "alpha beta",
+      "candidate": "beta alpha",
+      "score": 95.0
+    },
+    {
+      "query": "abc",
+      "candidate": "xyzabcq",
+      "score": 90.0
+    },
+    {
+      "query": "a b c",
+      "candidate": "a a b c",
+      "score": 95.0
+    },
+    {
+      "query": "xabcdy",
+      "candidate": "abcd",
+      "score": 90.0
+    },
+    {
+      "query": "abc",
+      "candidate": "zab",
+      "score": 66.66666666666667
+    },
+    {
+      "query": "abc",
+      "candidate": "qabc",
+      "score": 85.71428571428572
+    },
+    {
+      "query": "a b",
+      "candidate": "x a b y",
+      "score": 90.0
+    },
+    {
+      "query": "foo bar",
+      "candidate": "foo baz qux",
+      "score": 85.5
+    },
+    {
+      "query": "testing",
+      "candidate": "test",
+      "score": 90.0
+    },
+    {
+      "query": "aa bb aa",
+      "candidate": "bb aa",
+      "score": 90.0
+    },
+    {
+      "query": "a",
+      "candidate": "bbbbba",
+      "score": 90.0
+    },
+    {
+      "query": "dtesvbstvurvb",
+      "candidate": "v tdrevtceuracbudaduv bsrbert stdsr  dvuusebvce",
+      "score": 48.46153846153846
+    },
+    {
+      "query": "ba rtcttbvdcstvauetrc",
+      "candidate": "ub brvutacbtvuaraabdtsrseaut ubsdbsutebuda b cbdusvturve et",
+      "score": 48.64864864864865
+    },
+    {
+      "query": "ssvrrder u cssrbaseassbuteeae",
+      "candidate": "etvabbuarcsrbucrud dus",
+      "score": 37.254901960784316
+    },
+    {
+      "query": "e scurre bvtd bdbdtsrcbtcedesvddu  cr",
+      "candidate": "b urvatvebdaaart  dvrbebbsc drecbaeavccse tdacrtr",
+      "score": 42.976190476190474
+    },
+    {
+      "query": "tvu busdbrcesv vcavartderscae",
+      "candidate": "dtdvrbcsvbuavbcuvrc rsdaacvub ade",
+      "score": 48.38709677419355
+    },
+    {
+      "query": "crbtea dtrddeudde ssauvrtcss rrsbcsvvtts  vr",
+      "candidate": "ebvsdtue  er rcbva uudac",
+      "score": 37.17391304347826
+    },
+    {
+      "query": "cvvd",
+      "candidate": "sttsradbseduebtucseda esrcvudaasutvrurbdveeescd btddsdc es",
+      "score": 45.0
+    },
+    {
+      "query": "rtvca avrdttauac d  vteb  u c bea",
+      "candidate": "stsau asdcc veer t",
+      "score": 45.0
+    },
+    {
+      "query": "bescrsrs",
+      "candidate": "deuabasdacrttes uavrrt  ddrsuvdrtsdav",
+      "score": 45.0
+    },
+    {
+      "query": "bteuaeauc",
+      "candidate": "ecusdtvtsvcsssrrcs",
+      "score": 32.727272727272734
+    },
+    {
+      "query": "acbtet re esassursbacecabdatbtd bd detavb",
+      "candidate": "euuvueeturebtavbaecdueedadauu",
+      "score": 37.142857142857146
+    },
+    {
+      "query": "rdae veta  sca du",
+      "candidate": "cvusrctcs cubvdtec rrvbuetbetubbrbdcrs srdrtvbesseuevvedcd",
+      "score": 38.0
+    },
+    {
+      "query": "dvv rdutsabteeavceeeubvrttsv vur",
+      "candidate": "sdevvdudttu vcubvcseatsbbr  ddvraddvsvee",
+      "score": 47.22222222222222
+    },
+    {
+      "query": "bdduadetrctbaeecectauab vve ea",
+      "candidate": "vta bscdde cscsu dvt",
+      "score": 41.45454545454545
+    },
+    {
+      "query": "dccuesvd",
+      "candidate": "ad svb savasvtdcudr",
+      "score": 55.38461538461539
+    },
+    {
+      "query": "ctacs acbrrrruccvtbbuc  urrvu bsseddtbc",
+      "candidate": "b",
+      "score": 60.0
+    },
+    {
+      "query": "aucbbtrratvrsv  csarrc abb seuaaa trtudtu",
+      "candidate": "tusv tavd",
+      "score": 48.857142857142854
+    },
+    {
+      "query": "v   eecsubcsseastdb",
+      "candidate": "ata",
+      "score": 60.00000000000001
+    },
+    {
+      "query": "r",
+      "candidate": "ubcee  eae bduvbtde udta",
+      "score": 0.0
+    },
+    {
+      "query": "ubasavvvvvbubetber erdbvbee dvac",
+      "candidate": "rbtaeatut ctvdeacuvdvbac bbtbsubscsbsaebecv",
+      "score": 40.0
+    },
+    {
+      "query": "eudbeua bd evuaubres escdrusbtvrvru",
+      "candidate": "buc rautedred cbrbdrstd rv eau ats",
+      "score": 46.37681159420289
+    },
+    {
+      "query": "cc tcv beavbuvv",
+      "candidate": "debesevbrdrcctrrbbssbbst vvuetbevct",
+      "score": 42.75
+    },
+    {
+      "query": "scraurbcverstdvabacre",
+      "candidate": "dabdbvas rru caevbcv  vd b  er",
+      "score": 38.77551020408163
+    },
+    {
+      "query": "bedd s ab",
+      "candidate": "daudddbutscebvetavvecbsuv  bssateu",
+      "score": 40.0
+    },
+    {
+      "query": "tbreeard adbdcbdaabasusbrcredabce bartsad vt",
+      "candidate": "usv vaarsssretcedvrcs abrusdsdrbbrevbtavc",
+      "score": 42.470588235294116
+    },
+    {
+      "query": "rrvbd",
+      "candidate": "e etdbr eduur as dacutcvadcbbacuvub vbudacdvdasburecvsdsdrves",
+      "score": 36.0
+    },
+    {
+      "query": "d   dtstr asbastt vabtssc udaed cucda v acd ttrs",
+      "candidate": "b sddetuadbdsuartcvtbcaacs aurc",
+      "score": 42.049180327868854
+    },
+    {
+      "query": "tacstcar d ueradcvartrauvcattudctvbt",
+      "candidate": "acdudcrbdrssvetdruvdad rav",
+      "score": 45.16129032258065
+    },
+    {
+      "query": "sbcsvavcr edvrv evdcdvseuu",
+      "candidate": "cc  rrecuvtt",
+      "score": 37.5
+    },
+    {
+      "query": "srvteb",
+      "candidate": "tduvcuacdtrbbcrussdcssr  bbrvscrsscbtsruscdtsaard",
+      "score": 30.0
+    },
+    {
+      "query": "ssevse sdsdsduevatdvbeevtesstrusv",
+      "candidate": "cudvaedsussacu vtvsrd tvsave euvb",
+      "score": 42.42424242424242
+    },
+    {
+      "query": "esbusctressrredssrsdcu tcd vab",
+      "candidate": "u d tvcvbussu cdatstsvesudbrdrserettbtetcbductbv",
+      "score": 39.0
+    },
+    {
+      "query": "vraaaedtc  st surcr btr",
+      "candidate": "uaes bu astc bvtbet sdurcbrv carstdvsvsde",
+      "score": 46.95652173913043
+    },
+    {
+      "query": "u avd",
+      "candidate": "d ecebbvsa acdavccaedesu",
+      "score": 54.0
+    },
+    {
+      "query": "tcvc",
+      "candidate": "dra sa rdtrudbrbeue ear bvesudvbuau",
+      "score": 19.0
+    },
+    {
+      "query": "crs",
+      "candidate": "vd aaabvddddsu rsdvvaueasctbec r",
+      "score": 40.0
+    },
+    {
+      "query": "ucu",
+      "candidate": "avt vardcus c tbausu  daabdcs etdv cdvarbbarvs",
+      "score": 40.0
+    },
+    {
+      "query": "vesred budbtvbursccsd etrueurvv ad",
+      "candidate": "ertervcbbav csbsubsdbb raaub",
+      "score": 42.903225806451616
+    },
+    {
+      "query": "baetuttedvudt",
+      "candidate": "reecu cc vdt",
+      "score": 40.0
+    },
+    {
+      "query": "dasrvecur",
+      "candidate": "vedsv ubtuestad  rcerraeuvdua cr",
+      "score": 48.0
+    },
+    {
+      "query": "cbav udd dsbsec bu",
+      "candidate": "ercddu rc",
+      "score": 45.6
+    },
+    {
+      "query": "bueutsvarctt",
+      "candidate": "tdbrab du rdectuuuu rrvbtsuetsds vtva",
+      "score": 52.5
+    },
+    {
+      "query": "cv tt stt eausbdtdut s",
+      "candidate": "ur",
+      "score": 30.0
+    },
+    {
+      "query": "acesevdvrreaatarvtsdsurbe",
+      "candidate": "s dsstdtbbrcvsvtdscbuvvsuc  rtrbsdr",
+      "score": 36.66666666666667
+    },
+    {
+      "query": "vdrbcbuecau  eucs",
+      "candidate": "ubsbbae sbud  acdasabdtuuv atbrb b tssucaree",
+      "score": 42.35294117647059
+    },
+    {
+      "query": "abscsacvdca uaebsrvredbvursssvtv",
+      "candidate": "b ctvcbuurccucsr",
+      "score": 34.61538461538461
+    },
+    {
+      "query": "cuvractbbrsr buvv be cbtcdusabdsa sestcdt",
+      "candidate": "vucaarssesseaa  tvec b  ecvcrrdc dtaerebe",
+      "score": 38.0
+    },
+    {
+      "query": "a e",
+      "candidate": "bruv  u v tvutt c",
+      "score": 36.0
+    },
+    {
+      "query": "ta rerssecauusetdrabvac tvb uacsabesceuearbb",
+      "candidate": "retdtd  btrseaddc rvarrc  tsbaareeva",
+      "score": 47.5
+    },
+    {
+      "query": "ucdccecesbsddcvabredv",
+      "candidate": "tbars dru uv basdrt vab",
+      "score": 31.818181818181824
+    },
+    {
+      "query": "a",
+      "candidate": "rbevvac s",
+      "score": 60.0
+    },
+    {
+      "query": "arsasdtdvuvcadbbdb",
+      "candidate": "uvrb sdvsbede",
+      "score": 38.70967741935484
+    },
+    {
+      "query": "bsvbvdb",
+      "candidate": "cbscucbtddeevubrartbrcsae",
+      "score": 38.57142857142858
+    },
+    {
+      "query": "turdrudde",
+      "candidate": "sv bssrt ar bubasbvesbsdsctvt c aub eradtbusscatrcbdrvut",
+      "score": 50.0
+    },
+    {
+      "query": "cur edbaets",
+      "candidate": "adrveevru rvcvdvucvssvas beur aads",
+      "score": 50.0
+    },
+    {
+      "query": "t va",
+      "candidate": "bdut vtecd  sacs ucbsstsbr",
+      "score": 67.5
+    },
+    {
+      "query": "vsauc e c ctbrdsarrauevaaudcus ba",
+      "candidate": "tb sacevsucbcbebbvv",
+      "score": 39.375
+    },
+    {
+      "query": "ravcuae cvrtecsbttrearerdcbbaeebcdadussaeered s",
+      "candidate": "srbesdruadbvrccav",
+      "score": 45.6
+    },
+    {
+      "query": "s aec u  bctcvtcdeta vbtuutdusdsavu",
+      "candidate": "btbsrus",
+      "score": 38.57142857142858
+    },
+    {
+      "query": "uc dcueb sbut",
+      "candidate": "edcdsutbcasdeveeturesavtcttv c",
+      "score": 45.0
+    },
+    {
+      "query": "rueadesv esetc tescbb c  us a",
+      "candidate": "dduurrtreavr tdsvaresaeeaurbadedbrvvssrac rseaaver",
+      "score": 40.50632911392405
+    },
+    {
+      "query": "b",
+      "candidate": "rsdcucscvdutts udsdsvvb srtbsue",
+      "score": 60.0
+    },
+    {
+      "query": "asbcdvubudb cevu avsvavteuvst",
+      "candidate": "utdcrtcdde t",
+      "score": 38.0
+    },
+    {
+      "query": "vvaa sb utbebvaea",
+      "candidate": "vcte ebeacc bcr drbebavbcbbuav",
+      "score": 42.75
+    },
+    {
+      "query": "d ctedavvttv cabvvcdvsrste e sttsacseds  uabsbs",
+      "candidate": "tuvcrdatt sudrudsaavubd eaust sauu etteausuue",
+      "score": 39.13043478260869
+    },
+    {
+      "query": "rt sddtrb sab e sauvsadt bvvdvbatctsua ctreeeb",
+      "candidate": "auadectradtvbvvtreuvttcevubsbaus",
+      "score": 38.46153846153846
+    },
+    {
+      "query": "ebrecbdv",
+      "candidate": "cs ebacercdeudaaaccddtvuvseacvdseud cttrdabrr ccdbrtstsrdcad",
+      "score": 56.25
+    },
+    {
+      "query": "r rve sdreeeturttruvbrdtdsceraervvtcsru",
+      "candidate": "av",
+      "score": 30.0
+    },
+    {
+      "query": "rdauasu uusavrrudsdua",
+      "candidate": "bcca crdsdaa cauvbeut",
+      "score": 40.714285714285715
+    },
+    {
+      "query": "bu ercvvdtustbdss brdueacascbc du bura",
+      "candidate": "rvrausebssvv bresdaa aeu rb udacusu uubccrabvt  ur v",
+      "score": 46.666666666666664
+    },
+    {
+      "query": "tvetravadevtauc aevuavucc",
+      "candidate": "b",
+      "score": 0.0
+    },
+    {
+      "query": "svrrttvvcbubs",
+      "candidate": "debvevedvev dvredabrsdebcsdcuebsda",
+      "score": 40.909090909090914
+    },
+    {
+      "query": "vcrs u aecerbtrsvtdrb",
+      "candidate": "eb",
+      "score": 40.0
+    },
+    {
+      "query": "eu csatsre e",
+      "candidate": "srrb cddcbatvtubvaeddcauaebrecdvbcdrbatcb",
+      "score": 37.5
+    },
+    {
+      "query": "ceuacaaas",
+      "candidate": "adecuteucdvdsreebcutssdubudurvuaertdc vrsedrubs crdtuvurde",
+      "score": 40.0
+    },
+    {
+      "query": "ccvscuburae",
+      "candidate": "ar sab v ttartcsa ccuduvsaacd  d duta",
+      "score": 40.909090909090914
+    },
+    {
+      "query": "a ucdur a tvascravdvdcub buectubtvbaur tuu eta",
+      "candidate": "asttbds",
+      "score": 38.57142857142858
+    },
+    {
+      "query": "ruvadu",
+      "candidate": "bt suuevsestauc",
+      "score": 40.0
+    },
+    {
+      "query": "bredevr s v",
+      "candidate": "esccebdescr ressc utscssrvdabrubvbreba vtdebvubsvu vcsuttec bsc",
+      "score": 49.090909090909086
+    },
+    {
+      "query": "sdbrcsc euvb sdcuvceddu vauuubdrvuc ddrutv",
+      "candidate": "ts",
+      "score": 40.0
+    },
+    {
+      "query": "saedsvaud bcccvd",
+      "candidate": "susucvsrvvds e bbb asabrddcedeersc d",
+      "score": 40.909090909090914
+    },
+    {
+      "query": "u",
+      "candidate": "tatssud  cdtees tevc",
+      "score": 60.0
+    },
+    {
+      "query": "vdceuecaeuv bbrevb",
+      "candidate": "tr",
+      "score": 30.0
+    },
+    {
+      "query": "tcsdvetbrbvc uaeucu raderrbas s",
+      "candidate": "rvdddbaudcbbtcrbrcv cdtuuvtc",
+      "score": 30.508474576271183
+    },
+    {
+      "query": "tvassrc",
+      "candidate": "ae edvdruts sr vb adseudccd sdavat",
+      "score": 51.42857142857142
+    },
+    {
+      "query": "dsbvctbtac drdvvcaetsavbcbdssas  e ubsaevvcc",
+      "candidate": "dubsbauttccrdc  dsc  scrdcessbccabvrb",
+      "score": 44.44444444444444
+    },
+    {
+      "query": "rst tbddbaaru e",
+      "candidate": "dtvrrvttu esctcet adt",
+      "score": 33.333333333333336
+    },
+    {
+      "query": "vtcteauvvebsbsdbsabce ecbtadr",
+      "candidate": "bvrs eevt",
+      "score": 47.5
+    },
+    {
+      "query": "tuubu caaavrus dr ur  vdrdetbudvtedu",
+      "candidate": "s tsvatedubrutdsbbsbrsb",
+      "score": 33.75
+    },
+    {
+      "query": "ut uerbduvvb",
+      "candidate": "sbuvurvbr cceevscdadsr  s cbr  tvvusa",
+      "score": 49.87499999999999
+    },
+    {
+      "query": "bdvdrttcd",
+      "candidate": "dcbu",
+      "score": 36.0
+    },
+    {
+      "query": "dcsvsrdeddbetrd  beacbtvdbtv",
+      "candidate": "ss vttdsvt  er barrcrvtbsdbdsveceudeuv",
+      "score": 41.5625
+    },
+    {
+      "query": "ecsvstrrratdeuuttcdtdd",
+      "candidate": "bubbedubruutdasussedestbcuadc",
+      "score": 31.372549019607842
+    },
+    {
+      "query": "deb rc rbdbtat a budevdacucb uuda srscdaevvdvutt",
+      "candidate": "uetubvvveduveur",
+      "score": 46.95652173913043
+    },
+    {
+      "query": "scvbdv teuvrvuervdvceerasassu",
+      "candidate": "b  evttvvdea",
+      "score": 45.0
+    },
+    {
+      "query": "crctdrubv cevsrtdt ddstut v tb",
+      "candidate": "eudebertcdct bbvtdb dbtvdabs srcuu rsbar t  bctatbu tvtvvda",
+      "score": 43.474576271186436
+    }
+  ],
   "stale_generation_error": "catalog generation is stale"
 }

--- a/tests/fixtures/wave3/song_planning.json
+++ b/tests/fixtures/wave3/song_planning.json
@@ -1,0 +1,714 @@
+{
+  "schema": 1,
+  "parser_cases": [
+    {
+      "name": "object_basic",
+      "raw": {
+        "name": "Demo",
+        "songNotes": [
+          {
+            "time": 20,
+            "key": "Key1"
+          },
+          {
+            "time": 0,
+            "key": "Key0"
+          }
+        ]
+      },
+      "status": "ok",
+      "song": {
+        "name": "Demo",
+        "notes": [
+          {
+            "time_ms": 0,
+            "key": "Key0"
+          },
+          {
+            "time_ms": 20,
+            "key": "Key1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "root_list_first_item",
+      "raw": [
+        {
+          "name": "Legacy",
+          "songNotes": [
+            {
+              "time": "12",
+              "key": "Key2"
+            }
+          ]
+        },
+        {
+          "name": "Ignored",
+          "songNotes": []
+        }
+      ],
+      "status": "ok",
+      "song": {
+        "name": "Legacy",
+        "notes": [
+          {
+            "time_ms": 12,
+            "key": "Key2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "empty_song",
+      "raw": {
+        "name": "Empty",
+        "songNotes": []
+      },
+      "status": "ok",
+      "song": {
+        "name": "Empty",
+        "notes": []
+      }
+    },
+    {
+      "name": "numeric_string_and_chord",
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "status": "ok",
+      "song": {
+        "name": "Unicode Élan",
+        "notes": [
+          {
+            "time_ms": 10,
+            "key": "Key3"
+          },
+          {
+            "time_ms": 10,
+            "key": "Key4"
+          },
+          {
+            "time_ms": 25,
+            "key": "Key3"
+          }
+        ]
+      }
+    },
+    {
+      "name": "duplicate_notes",
+      "raw": {
+        "name": "Duplicates",
+        "songNotes": [
+          {
+            "time": 0,
+            "key": "Key0"
+          },
+          {
+            "time": 0,
+            "key": "Key0"
+          },
+          {
+            "time": 0,
+            "key": "Key1"
+          }
+        ]
+      },
+      "status": "ok",
+      "song": {
+        "name": "Duplicates",
+        "notes": [
+          {
+            "time_ms": 0,
+            "key": "Key0"
+          },
+          {
+            "time_ms": 0,
+            "key": "Key0"
+          },
+          {
+            "time_ms": 0,
+            "key": "Key1"
+          }
+        ]
+      }
+    },
+    {
+      "name": "dense_chord",
+      "raw": {
+        "name": "Dense",
+        "songNotes": [
+          {
+            "time": 0,
+            "key": "Key0"
+          },
+          {
+            "time": 1,
+            "key": "Key1"
+          },
+          {
+            "time": 2,
+            "key": "Key2"
+          },
+          {
+            "time": 3,
+            "key": "Key3"
+          },
+          {
+            "time": 4,
+            "key": "Key4"
+          },
+          {
+            "time": 5,
+            "key": "Key5"
+          },
+          {
+            "time": 6,
+            "key": "Key6"
+          }
+        ]
+      },
+      "status": "ok",
+      "song": {
+        "name": "Dense",
+        "notes": [
+          {
+            "time_ms": 0,
+            "key": "Key0"
+          },
+          {
+            "time_ms": 1,
+            "key": "Key1"
+          },
+          {
+            "time_ms": 2,
+            "key": "Key2"
+          },
+          {
+            "time_ms": 3,
+            "key": "Key3"
+          },
+          {
+            "time_ms": 4,
+            "key": "Key4"
+          },
+          {
+            "time_ms": 5,
+            "key": "Key5"
+          },
+          {
+            "time_ms": 6,
+            "key": "Key6"
+          }
+        ]
+      }
+    },
+    {
+      "name": "malformed_json",
+      "raw": "{not json",
+      "status": "error",
+      "error_type": "SongParseError"
+    },
+    {
+      "name": "root_list_empty",
+      "raw": [],
+      "status": "error",
+      "error_type": "SongValidationError"
+    },
+    {
+      "name": "root_not_object",
+      "raw": [
+        "not a song"
+      ],
+      "status": "error",
+      "error_type": "SongValidationError"
+    },
+    {
+      "name": "missing_song_notes",
+      "raw": {
+        "name": "Missing"
+      },
+      "status": "error",
+      "error_type": "SongValidationError"
+    },
+    {
+      "name": "missing_note_time",
+      "raw": {
+        "songNotes": [
+          {
+            "key": "Key0"
+          }
+        ]
+      },
+      "status": "error",
+      "error_type": "SongValidationError"
+    },
+    {
+      "name": "invalid_note_key",
+      "raw": {
+        "songNotes": [
+          {
+            "time": 0,
+            "key": "NotAKey"
+          }
+        ]
+      },
+      "status": "error",
+      "error_type": "SongValidationError"
+    },
+    {
+      "name": "negative_time",
+      "raw": {
+        "songNotes": [
+          {
+            "time": -1,
+            "key": "Key0"
+          }
+        ]
+      },
+      "status": "error",
+      "error_type": "SongValidationError"
+    }
+  ],
+  "schedule_cases": [
+    {
+      "name": "basic_schedule",
+      "raw": {
+        "name": "Demo",
+        "songNotes": [
+          {
+            "time": 20,
+            "key": "Key1"
+          },
+          {
+            "time": 0,
+            "key": "Key0"
+          }
+        ]
+      },
+      "hold_frames": 1.0,
+      "tempo_scale": 1.0,
+      "fps": 60,
+      "schedule": {
+        "actions": [
+          {
+            "at_us": 0,
+            "scan_codes": [
+              21
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 17467,
+            "scan_codes": [
+              21
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 20000,
+            "scan_codes": [
+              22
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 37467,
+            "scan_codes": [
+              22
+            ],
+            "kind": "up",
+            "reason": "release"
+          }
+        ],
+        "source_duration_us": 37467,
+        "playback_duration_us": 37467,
+        "duration_us": 37467,
+        "note_count": 2,
+        "deduplicated_note_count": 2,
+        "duplicate_note_count": 0,
+        "compressed_holds": 0,
+        "impossible_same_key_repeats": 0,
+        "risky_same_key_repeats": 0,
+        "max_polyphony": 1,
+        "shortest_same_key_interval_us": null,
+        "min_same_key_up_gap_us": null
+      },
+      "risk": {
+        "severity": "low",
+        "impossible_repeats": 0,
+        "impossible_same_key_repeats": 0,
+        "compressed_holds": 0,
+        "max_polyphony": 1,
+        "min_any_note_gap_us": 20000,
+        "min_same_key_gap_us": null,
+        "dense_clusters": [],
+        "recommendations": [
+          "No timing conflicts detected. Keep the selected hold."
+        ],
+        "average_notes_per_second": 53.380308004377184,
+        "peak_notes_per_second_1s": 2.0,
+        "suggested_hold_frames": 1.0,
+        "suggested_tempo_scale": 1.0,
+        "reason": "No timing conflicts detected.",
+        "max_chord_size": 1,
+        "chords_count": 0,
+        "timing_stress_rate": 0.0
+      }
+    },
+    {
+      "name": "tempo_rounding",
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "hold_frames": 1.25,
+      "tempo_scale": 0.95,
+      "fps": 120,
+      "schedule": {
+        "actions": [
+          {
+            "at_us": 10526,
+            "scan_codes": [
+              24,
+              25
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 21744,
+            "scan_codes": [
+              24,
+              25
+            ],
+            "kind": "up",
+            "reason": "mixed"
+          },
+          {
+            "at_us": 26316,
+            "scan_codes": [
+              24
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 37534,
+            "scan_codes": [
+              24
+            ],
+            "kind": "up",
+            "reason": "release"
+          }
+        ],
+        "source_duration_us": 37534,
+        "playback_duration_us": 37534,
+        "duration_us": 37534,
+        "note_count": 3,
+        "deduplicated_note_count": 3,
+        "duplicate_note_count": 0,
+        "compressed_holds": 0,
+        "impossible_same_key_repeats": 1,
+        "risky_same_key_repeats": 0,
+        "max_polyphony": 2,
+        "shortest_same_key_interval_us": 15790,
+        "min_same_key_up_gap_us": 4572
+      },
+      "risk": {
+        "severity": "high",
+        "impossible_repeats": 1,
+        "impossible_same_key_repeats": 1,
+        "compressed_holds": 0,
+        "max_polyphony": 2,
+        "min_any_note_gap_us": 15000,
+        "min_same_key_gap_us": 15000,
+        "dense_clusters": [],
+        "recommendations": [
+          "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+          "Reduce tempo or edit the arrangement so the same key has more time between downs.",
+          "Shortest same-key repeat interval: 15.8ms.",
+          "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+        ],
+        "average_notes_per_second": 53.28502158043374,
+        "peak_notes_per_second_1s": 2.0,
+        "suggested_hold_frames": 1.0,
+        "suggested_tempo_scale": 0.92,
+        "reason": "infeasible same-key repeats detected",
+        "max_chord_size": 2,
+        "chords_count": 1,
+        "timing_stress_rate": 33.33333333333333
+      }
+    },
+    {
+      "name": "empty_schedule",
+      "raw": {
+        "name": "Empty",
+        "songNotes": []
+      },
+      "hold_frames": 1.0,
+      "tempo_scale": 1.0,
+      "fps": 60,
+      "schedule": {
+        "actions": [],
+        "source_duration_us": 17467,
+        "playback_duration_us": 0,
+        "duration_us": 0,
+        "note_count": 0,
+        "deduplicated_note_count": 0,
+        "duplicate_note_count": 0,
+        "compressed_holds": 0,
+        "impossible_same_key_repeats": 0,
+        "risky_same_key_repeats": 0,
+        "max_polyphony": 0,
+        "shortest_same_key_interval_us": null,
+        "min_same_key_up_gap_us": null
+      },
+      "risk": {
+        "severity": "low",
+        "impossible_repeats": 0,
+        "impossible_same_key_repeats": 0,
+        "compressed_holds": 0,
+        "max_polyphony": 0,
+        "min_any_note_gap_us": null,
+        "min_same_key_gap_us": null,
+        "dense_clusters": [],
+        "recommendations": [
+          "No timing conflicts detected. Keep the selected hold."
+        ],
+        "average_notes_per_second": 0.0,
+        "peak_notes_per_second_1s": 0.0,
+        "suggested_hold_frames": 1.0,
+        "suggested_tempo_scale": 1.0,
+        "reason": "No timing conflicts detected.",
+        "max_chord_size": 0,
+        "chords_count": 0,
+        "timing_stress_rate": 0.0
+      }
+    },
+    {
+      "name": "dense_risk",
+      "raw": {
+        "name": "Dense",
+        "songNotes": [
+          {
+            "time": 0,
+            "key": "Key0"
+          },
+          {
+            "time": 1,
+            "key": "Key1"
+          },
+          {
+            "time": 2,
+            "key": "Key2"
+          },
+          {
+            "time": 3,
+            "key": "Key3"
+          },
+          {
+            "time": 4,
+            "key": "Key4"
+          },
+          {
+            "time": 5,
+            "key": "Key5"
+          },
+          {
+            "time": 6,
+            "key": "Key6"
+          }
+        ]
+      },
+      "hold_frames": 1.0,
+      "tempo_scale": 1.0,
+      "fps": 60,
+      "schedule": {
+        "actions": [
+          {
+            "at_us": 0,
+            "scan_codes": [
+              21
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 1000,
+            "scan_codes": [
+              22
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 2000,
+            "scan_codes": [
+              23
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 3000,
+            "scan_codes": [
+              24
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 4000,
+            "scan_codes": [
+              25
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 5000,
+            "scan_codes": [
+              35
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 6000,
+            "scan_codes": [
+              36
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 17467,
+            "scan_codes": [
+              21
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 18467,
+            "scan_codes": [
+              22
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 19467,
+            "scan_codes": [
+              23
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 20467,
+            "scan_codes": [
+              24
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 21467,
+            "scan_codes": [
+              25
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 22467,
+            "scan_codes": [
+              35
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 23467,
+            "scan_codes": [
+              36
+            ],
+            "kind": "up",
+            "reason": "release"
+          }
+        ],
+        "source_duration_us": 23467,
+        "playback_duration_us": 23467,
+        "duration_us": 23467,
+        "note_count": 7,
+        "deduplicated_note_count": 7,
+        "duplicate_note_count": 0,
+        "compressed_holds": 0,
+        "impossible_same_key_repeats": 0,
+        "risky_same_key_repeats": 0,
+        "max_polyphony": 7,
+        "shortest_same_key_interval_us": null,
+        "min_same_key_up_gap_us": null
+      },
+      "risk": {
+        "severity": "low",
+        "impossible_repeats": 0,
+        "impossible_same_key_repeats": 0,
+        "compressed_holds": 0,
+        "max_polyphony": 7,
+        "min_any_note_gap_us": 1000,
+        "min_same_key_gap_us": null,
+        "dense_clusters": [
+          {
+            "start_us": 0,
+            "end_us": 6000,
+            "note_count": 7
+          }
+        ],
+        "recommendations": [
+          "No timing conflicts detected. Keep the selected hold."
+        ],
+        "average_notes_per_second": 298.29121745429757,
+        "peak_notes_per_second_1s": 7.0,
+        "suggested_hold_frames": 1.5,
+        "suggested_tempo_scale": 1.0,
+        "reason": "No timing conflicts detected.",
+        "max_chord_size": 1,
+        "chords_count": 0,
+        "timing_stress_rate": 0.0
+      }
+    }
+  ]
+}

--- a/tests/fixtures/wave3/song_planning.json
+++ b/tests/fixtures/wave3/song_planning.json
@@ -303,6 +303,8 @@
       "hold_frames": 1.0,
       "tempo_scale": 1.0,
       "fps": 60,
+      "transport_margin_us": 300,
+      "transport_margin_source": "default_transport_300",
       "schedule": {
         "actions": [
           {
@@ -349,7 +351,9 @@
         "risky_same_key_repeats": 0,
         "max_polyphony": 1,
         "shortest_same_key_interval_us": null,
-        "min_same_key_up_gap_us": null
+        "min_same_key_up_gap_us": null,
+        "recommended_hold_frames": null,
+        "recommended_tempo_scale": null
       },
       "risk": {
         "severity": "low",
@@ -395,6 +399,8 @@
       "hold_frames": 1.25,
       "tempo_scale": 0.95,
       "fps": 120,
+      "transport_margin_us": 300,
+      "transport_margin_source": "default_transport_300",
       "schedule": {
         "actions": [
           {
@@ -443,7 +449,9 @@
         "risky_same_key_repeats": 0,
         "max_polyphony": 2,
         "shortest_same_key_interval_us": 15790,
-        "min_same_key_up_gap_us": 4572
+        "min_same_key_up_gap_us": 4572,
+        "recommended_hold_frames": 1.0,
+        "recommended_tempo_scale": 0.74
       },
       "risk": {
         "severity": "high",
@@ -471,6 +479,98 @@
       }
     },
     {
+      "name": "calibrated_margin",
+      "raw": {
+        "name": "Demo",
+        "songNotes": [
+          {
+            "time": 20,
+            "key": "Key1"
+          },
+          {
+            "time": 0,
+            "key": "Key0"
+          }
+        ]
+      },
+      "hold_frames": 1.0,
+      "tempo_scale": 1.0,
+      "fps": 60,
+      "transport_margin_us": 777,
+      "transport_margin_source": "device_cache",
+      "schedule": {
+        "actions": [
+          {
+            "at_us": 0,
+            "scan_codes": [
+              21
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 17944,
+            "scan_codes": [
+              21
+            ],
+            "kind": "up",
+            "reason": "release"
+          },
+          {
+            "at_us": 20000,
+            "scan_codes": [
+              22
+            ],
+            "kind": "down",
+            "reason": "onset"
+          },
+          {
+            "at_us": 37944,
+            "scan_codes": [
+              22
+            ],
+            "kind": "up",
+            "reason": "release"
+          }
+        ],
+        "source_duration_us": 37944,
+        "playback_duration_us": 37944,
+        "duration_us": 37944,
+        "note_count": 2,
+        "deduplicated_note_count": 2,
+        "duplicate_note_count": 0,
+        "compressed_holds": 0,
+        "impossible_same_key_repeats": 0,
+        "risky_same_key_repeats": 0,
+        "max_polyphony": 1,
+        "shortest_same_key_interval_us": null,
+        "min_same_key_up_gap_us": null,
+        "recommended_hold_frames": null,
+        "recommended_tempo_scale": null
+      },
+      "risk": {
+        "severity": "low",
+        "impossible_repeats": 0,
+        "impossible_same_key_repeats": 0,
+        "compressed_holds": 0,
+        "max_polyphony": 1,
+        "min_any_note_gap_us": 20000,
+        "min_same_key_gap_us": null,
+        "dense_clusters": [],
+        "recommendations": [
+          "No timing conflicts detected. Keep the selected hold."
+        ],
+        "average_notes_per_second": 52.70925574530888,
+        "peak_notes_per_second_1s": 2.0,
+        "suggested_hold_frames": 1.0,
+        "suggested_tempo_scale": 1.0,
+        "reason": "No timing conflicts detected.",
+        "max_chord_size": 1,
+        "chords_count": 0,
+        "timing_stress_rate": 0.0
+      }
+    },
+    {
       "name": "empty_schedule",
       "raw": {
         "name": "Empty",
@@ -479,6 +579,8 @@
       "hold_frames": 1.0,
       "tempo_scale": 1.0,
       "fps": 60,
+      "transport_margin_us": 300,
+      "transport_margin_source": "default_transport_300",
       "schedule": {
         "actions": [],
         "source_duration_us": 17467,
@@ -492,7 +594,9 @@
         "risky_same_key_repeats": 0,
         "max_polyphony": 0,
         "shortest_same_key_interval_us": null,
-        "min_same_key_up_gap_us": null
+        "min_same_key_up_gap_us": null,
+        "recommended_hold_frames": null,
+        "recommended_tempo_scale": null
       },
       "risk": {
         "severity": "low",
@@ -554,6 +658,8 @@
       "hold_frames": 1.0,
       "tempo_scale": 1.0,
       "fps": 60,
+      "transport_margin_us": 300,
+      "transport_margin_source": "default_transport_300",
       "schedule": {
         "actions": [
           {
@@ -680,7 +786,9 @@
         "risky_same_key_repeats": 0,
         "max_polyphony": 7,
         "shortest_same_key_interval_us": null,
-        "min_same_key_up_gap_us": null
+        "min_same_key_up_gap_us": null,
+        "recommended_hold_frames": null,
+        "recommended_tempo_scale": null
       },
       "risk": {
         "severity": "low",
@@ -709,6 +817,60 @@
         "chords_count": 0,
         "timing_stress_rate": 0.0
       }
+    }
+  ],
+  "timing_policy_cases": [
+    {
+      "name": "no_cache_fallback",
+      "hold_frames": 1.25,
+      "fps": 120,
+      "transport_margin_us": 300,
+      "transport_margin_source": "default_transport_300",
+      "frame_us": 8334,
+      "frame_base_hold_us": 10418,
+      "down_late_grace_us": 500,
+      "min_hold_us": 11218,
+      "min_release_gap_us": 9134,
+      "focus_restore_grace_us": 100000
+    },
+    {
+      "name": "valid_device_cache",
+      "hold_frames": 1.25,
+      "fps": 120,
+      "transport_margin_us": 777,
+      "transport_margin_source": "device_cache",
+      "frame_us": 8334,
+      "frame_base_hold_us": 10418,
+      "down_late_grace_us": 500,
+      "min_hold_us": 11695,
+      "min_release_gap_us": 9611,
+      "focus_restore_grace_us": 100000
+    },
+    {
+      "name": "unhealthy_cache_fallback",
+      "hold_frames": 1.25,
+      "fps": 120,
+      "transport_margin_us": 300,
+      "transport_margin_source": "invalid_cache_transport_300",
+      "frame_us": 8334,
+      "frame_base_hold_us": 10418,
+      "down_late_grace_us": 500,
+      "min_hold_us": 11218,
+      "min_release_gap_us": 9134,
+      "focus_restore_grace_us": 100000
+    },
+    {
+      "name": "stale_cache_fallback",
+      "hold_frames": 1.25,
+      "fps": 120,
+      "transport_margin_us": 300,
+      "transport_margin_source": "incompatible_host_transport_300",
+      "frame_us": 8334,
+      "frame_base_hold_us": 10418,
+      "down_late_grace_us": 500,
+      "min_hold_us": 11218,
+      "min_release_gap_us": 9134,
+      "focus_restore_grace_us": 100000
     }
   ]
 }

--- a/tests/fixtures/wave3/song_planning.json
+++ b/tests/fixtures/wave3/song_planning.json
@@ -872,5 +872,182 @@
       "min_release_gap_us": 9134,
       "focus_restore_grace_us": 100000
     }
+  ],
+  "detail_tempo_cases": [
+    {
+      "tempo_scale": 0.9,
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "duration_us": 45245,
+      "risk_level": "high",
+      "risk_recommendations": [
+        "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+        "Reduce tempo or edit the arrangement so the same key has more time between downs.",
+        "Shortest same-key repeat interval: 16.7ms.",
+        "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+      ],
+      "risk_min_any_note_gap_us": 15000,
+      "risk_min_same_key_gap_us": 15000,
+      "recommendation": {
+        "recommended_hold_frames": 1.0,
+        "recommended_tempo_scale": 0.9,
+        "summary": "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation."
+      }
+    },
+    {
+      "tempo_scale": 0.95,
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "duration_us": 43783,
+      "risk_level": "high",
+      "risk_recommendations": [
+        "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+        "Reduce tempo or edit the arrangement so the same key has more time between downs.",
+        "Shortest same-key repeat interval: 15.8ms.",
+        "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+      ],
+      "risk_min_any_note_gap_us": 15000,
+      "risk_min_same_key_gap_us": 15000,
+      "recommendation": {
+        "recommended_hold_frames": 1.0,
+        "recommended_tempo_scale": 0.92,
+        "summary": "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation."
+      }
+    },
+    {
+      "tempo_scale": 1.0,
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "duration_us": 42467,
+      "risk_level": "high",
+      "risk_recommendations": [
+        "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+        "Reduce tempo or edit the arrangement so the same key has more time between downs.",
+        "Shortest same-key repeat interval: 15.0ms.",
+        "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+      ],
+      "risk_min_any_note_gap_us": 15000,
+      "risk_min_same_key_gap_us": 15000,
+      "recommendation": {
+        "recommended_hold_frames": 1.0,
+        "recommended_tempo_scale": 0.92,
+        "summary": "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation."
+      }
+    },
+    {
+      "tempo_scale": 1.05,
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "duration_us": 41277,
+      "risk_level": "high",
+      "risk_recommendations": [
+        "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+        "Reduce tempo or edit the arrangement so the same key has more time between downs.",
+        "Shortest same-key repeat interval: 14.3ms.",
+        "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+      ],
+      "risk_min_any_note_gap_us": 15000,
+      "risk_min_same_key_gap_us": 15000,
+      "recommendation": {
+        "recommended_hold_frames": 1.0,
+        "recommended_tempo_scale": 0.92,
+        "summary": "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation."
+      }
+    },
+    {
+      "tempo_scale": 1.1,
+      "raw": {
+        "name": "Unicode Élan",
+        "songNotes": [
+          {
+            "time": "10",
+            "key": "Key3"
+          },
+          {
+            "time": 10,
+            "key": "Key4"
+          },
+          {
+            "time": 25,
+            "key": "Key3"
+          }
+        ]
+      },
+      "duration_us": 40194,
+      "risk_level": "high",
+      "risk_recommendations": [
+        "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation.",
+        "Reduce tempo or edit the arrangement so the same key has more time between downs.",
+        "Shortest same-key repeat interval: 13.6ms.",
+        "Even the shortest supported hold cannot make a sub-frame repeat feasible; reduce tempo or edit the arrangement."
+      ],
+      "risk_min_any_note_gap_us": 15000,
+      "risk_min_same_key_gap_us": 15000,
+      "recommendation": {
+        "recommended_hold_frames": 1.0,
+        "recommended_tempo_scale": 0.92,
+        "summary": "1 same-key repeat(s) are infeasible under the materialized hold/release policy; sender-side policy does not prove game observation."
+      }
+    }
   ]
 }

--- a/tests/test_production_python_boundary.py
+++ b/tests/test_production_python_boundary.py
@@ -72,7 +72,12 @@ def test_payload_reports_explicit_command_ownership_and_cutover_blockers() -> No
     assert ownership["status"] == "ok"
     assert ownership["before"]["python_count"] == 21
     assert ownership["before"]["native_count"] == 0
-    assert ownership["after"]["python_count"] == 21
-    assert ownership["after"]["native_count"] == 0
-    assert "settings.*" in accounting["remaining_blockers"]
-    assert "catalog.*" in accounting["remaining_blockers"]
+    assert ownership["after"]["python_count"] == 8
+    assert ownership["after"]["native_count"] == 13
+    assert accounting["native_command_count"] == 13
+    assert accounting["python_command_count"] == 8
+    assert accounting["python_core_process_required"] is True
+    assert accounting["python_runtime_shipped"] is True
+    assert accounting["pyo3_required_for_production_tauri_playback"] is False
+    assert "update.check" in accounting["remaining_blockers"]
+    assert "calibration.*" in accounting["remaining_blockers"]

--- a/tests/test_sky_app_core_contract.py
+++ b/tests/test_sky_app_core_contract.py
@@ -34,6 +34,7 @@ def test_sky_app_core_is_pure_and_does_not_depend_on_player_or_delivery() -> Non
         "catalog.rs",
         "lib.rs",
         "settings.rs",
+        "song.rs",
         "update.rs",
     ]
 

--- a/tests/test_sky_app_core_contract.py
+++ b/tests/test_sky_app_core_contract.py
@@ -35,6 +35,7 @@ def test_sky_app_core_is_pure_and_does_not_depend_on_player_or_delivery() -> Non
         "lib.rs",
         "settings.rs",
         "song.rs",
+        "timing.rs",
         "update.rs",
     ]
 


### PR DESCRIPTION
Wave 3 native desktop ownership integration from main@0c7e9e9bbd83101f33aee9d983450e4e7c500b13.\n\nThis PR preserves the existing Tauri commands, DTOs, DesktopBridge, UiEvent wire shape, updater security boundary, and qualified realtime player hot path. It adds the explicit NativeDesktopRuntime composition root, native catalog index/detail/reload/viewport, pure-Rust song planning fixtures, direct sky_player playback control plane, diagnostics publication, install-root resolution, bounded native event delivery, and ownership enforcement.\n\nCurrent explicit ownership is 13 Native / 8 Python. Settings remain Python-owned because Core's process-local cache is live; update orchestration/handoff and calibration remain Python-owned pending their own parity/coherence gates. There is no automatic Native-to-Python fallback. The Python Core executable and _internal runtime remain in the portable package. Python source, Textual, PyO3/maturin, sky_player_rs, and tests remain as oracle/rollback material.\n\nValidation completed locally: static checks, security/architecture audits, 1096 Python tests (3 skipped, 1 xfailed), full Rust workspace clippy/tests, sky_player 236 tests, no-allocation 20 tests, updater exact suites, desktop frontend checks (22 Vitest, 10 Playwright), desktop Rust tests (111), generated bindings clean, and Tauri decoder tests (5).\n\nDo not merge until the full required CI and exact packaged qualification pass on this head and ownership/sidecar limits are reviewed.