### PR TITLE
perf(ci): CI-FAST-2 separate static checks and supply-chain audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.static_required == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash
@@ -151,6 +151,49 @@ jobs:
           fi
           git fetch --no-tags --depth=1 origin "$baseline"
           git cat-file -e "$baseline^{commit}"
+
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install 1.98.0 --profile minimal
+
+      - name: Repository verification — static
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: cargo xtask check static --skip-supply-chain
+
+      - name: Report CI timing
+        if: always()
+        run: |
+          start_time="${SKY_CI_JOB_STARTED_STATIC:-}"
+          if [ -n "$start_time" ]; then
+            elapsed=$(( $(date +%s) - start_time ))
+            {
+              echo "## CI job timing"
+              echo "- Job: \`static\`"
+              echo "- Elapsed seconds: \`$elapsed\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  supply_chain:
+    name: Supply-chain and advisory security
+    needs: changes
+    if: needs.changes.outputs.static_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Start CI timing
+        run: echo "SKY_CI_JOB_STARTED_SUPPLY_CHAIN=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.98.0 --profile minimal
@@ -211,20 +254,15 @@ jobs:
           path: ${{ runner.temp }}/cargo-vet
           key: cargo-vet-${{ runner.os }}-${{ runner.arch }}-0.10.2-rust-1.98
 
-      - name: Repository verification — static
-        env:
-          RUSTUP_TOOLCHAIN: 1.98.0
-        run: cargo xtask check static
-
       - name: Report CI timing
         if: always()
         run: |
-          start_time="${SKY_CI_JOB_STARTED_STATIC:-}"
+          start_time="${SKY_CI_JOB_STARTED_SUPPLY_CHAIN:-}"
           if [ -n "$start_time" ]; then
             elapsed=$(( $(date +%s) - start_time ))
             {
               echo "## CI job timing"
-              echo "- Job: \`static\`"
+              echo "- Job: \`supply_chain\`"
               echo "- Elapsed seconds: \`$elapsed\`"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -508,7 +546,7 @@ jobs:
   status:
     name: Sky Auto Player — required CI gate
     if: always()
-    needs: [changes, static, validate, packaged]
+    needs: [changes, static, supply_chain, validate, packaged]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -526,12 +564,19 @@ jobs:
           CODE_REQUIRED: ${{ needs.changes.outputs.code_required }}
           PACKAGE_REQUIRED: ${{ needs.changes.outputs.package_required }}
           STATIC_RESULT: ${{ needs.static.result }}
+          SUPPLY_CHAIN_RESULT: ${{ needs.supply_chain.result }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
           PACKAGED_RESULT: ${{ needs.packaged.result }}
         run: |
           set -euo pipefail
           [[ "$CHANGES_RESULT" == "success" ]]
-          if [[ "$STATIC_REQUIRED" == "true" ]]; then [[ "$STATIC_RESULT" == "success" ]]; else [[ "$STATIC_RESULT" == "skipped" ]]; fi
+          if [[ "$STATIC_REQUIRED" == "true" ]]; then
+            [[ "$STATIC_RESULT" == "success" ]]
+            [[ "$SUPPLY_CHAIN_RESULT" == "success" ]]
+          else
+            [[ "$STATIC_RESULT" == "skipped" ]]
+            [[ "$SUPPLY_CHAIN_RESULT" == "skipped" ]]
+          fi
           if [[ "$CODE_REQUIRED" == "true" ]]; then [[ "$VALIDATE_RESULT" == "success" ]]; else [[ "$VALIDATE_RESULT" == "skipped" ]]; fi
           if [[ "$PACKAGE_REQUIRED" == "true" ]]; then [[ "$PACKAGED_RESULT" == "success" ]]; else [[ "$PACKAGED_RESULT" == "skipped" ]]; fi
           echo "CI status is green."

--- a/docs/perf-baselines/2026-09-wave8-ci-fast-feedback.md
+++ b/docs/perf-baselines/2026-09-wave8-ci-fast-feedback.md
@@ -61,18 +61,18 @@ To establish true causal attribution for PR developer feedback, PR #96 (FAST-1) 
 
 ## 2. Wave 8 Execution Matrix & Phased Comparison
 
-| Metric | Main Baseline (#549)<br/>True Wall-Clock | PR Control (#548)<br/>True Wall-Clock | CI-FAST-1 (Hosted PR #96)<br/>Run `33665614053` | CI-FAST-2<br/>(Static / Supply-Chain) | CI-FAST-3<br/>(Cache Architecture) | Final Wave 8 |
-| :--- | ---: | ---: | :---: | :---: | :---: | :---: |
-| `changes` (PR) | 59s | 33s | **17s** (Run #551: **15s**) | — | — | TBD |
-| `changes` (Dispatch/Main) | 59s | N/A | **3s** (Run #552) | — | — | TBD |
-| `static` | 50s | 43s | **46s** (Run #551: **43s**) | target <= 35–40s | — | TBD |
-| `supply_chain` | (in static) | (in static) | (in static) | parallel job | — | TBD |
-| `validate` (PR restore-only) | N/A | 8m41s | **7m53s** (Run #551: 8m44s) | — | TBD | TBD |
-| `validate` (Main with save) | 15m17s | N/A | N/A | — | TBD | TBD |
-| `packaged` (PR restore-only) | N/A | 8m06s | **7m22s** (Run #551: 8m04s) | — | TBD | TBD |
-| `packaged` (Main with save) | 10m33s | N/A | N/A | — | TBD | TBD |
-| `status` (Required gate) | ~9s | ~5s | **3s** (Run #551: **5s**) | <= 5s | <= 5s | TBD |
-| **Workflow Wall-Clock (PR)** | N/A | **9m31s** | **8m24s** | TBD | TBD | TBD |
+| Metric | Main Baseline (#549)<br/>True Wall-Clock | PR Control (#548)<br/>True Wall-Clock | CI-FAST-1 (Hosted PR #96)<br/>Run `33665614053` | CI-FAST-2 (Hosted PR #97)<br/>Run `33694232773` | CI-FAST-3<br/>(Cache Architecture) | Final Wave 8 |
+| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `changes` (PR) | 59s | 33s | **17s** (Run #551: **15s**) | **13s** | — | TBD |
+| `changes` (Dispatch/Main) | 59s | N/A | **3s** (Run #552) | **4s** (Run #559) | — | TBD |
+| `static` | 50s | 43s | **46s** (Run #551: **43s**) | **34s** (Run #559: **30s**) | — | TBD |
+| `supply_chain` | (in static) | (in static) | (in static) | **19s** (Run #559: **27s**) | — | TBD |
+| `validate` (PR restore-only) | N/A | 8m41s | **7m53s** (Run #551: 8m44s) | **7m43s** | TBD | TBD |
+| `validate` (Main with save) | 15m17s | N/A | N/A | **15m45s** (Run #559) | TBD | TBD |
+| `packaged` (PR restore-only) | N/A | 8m06s | **7m22s** (Run #551: 8m04s) | **5m39s** | TBD | TBD |
+| `packaged` (Main with save) | 10m33s | N/A | N/A | **9m45s** (Run #559) | TBD | TBD |
+| `status` (Required gate) | ~9s | ~5s | **3s** (Run #551: **5s**) | **3s** (Run #559: **2s**) | <= 5s | TBD |
+| **Workflow Wall-Clock (PR)** | N/A | **9m31s** | **8m24s** | **8m05s** | TBD | TBD |
 
 ---
 
@@ -199,3 +199,37 @@ To qualify the short-circuit optimization for manual dispatch and main push:
    - Preserves all security invariants from `SECURITY.md` and zero-Python audit rules from `AGENTS.md`.
 3. **Gate Convergence**:
    - Updated `status` required CI gate to depend on `[changes, static, supply_chain, validate, packaged]`, failing closed if either `static` or `supply_chain` fails.
+
+### 4.2 Hosted Qualification Evidence
+
+#### PR Run #558 (`33694232773`) on HEAD `e824c4c21cf3`
+- **Trigger**: `pull_request`
+- **Total Jobs**: 6/6 `SUCCESS`
+- **Timing Evidence**:
+  - `changes`: **13s** (ID `100459519681`)
+  - `static`: **34s** (ID `100459584997`) — **achieved target <= 35–40s**
+  - `supply_chain`: **19s** (ID `100459585070`) — concurrent parallel job
+  - `validate`: **7m43s** (ID `100459584973`)
+  - `packaged`: **5m39s** (ID `100459584981`)
+  - `status`: **3s** (ID `100461425486`)
+- **Authoritative Artifact**:
+  - Artifact ID: `9871324415`
+  - Name: `sky-auto-player-portable-e824c4c21cf3c7328076ca9df64f6a259b654315`
+  - Size: `9,171,940 bytes`
+  - Digest: `sha256:932cc5e1fb0c68bc353af9c5e8ffa2d460952623d7714e5f0307d0a87fdebdbb`
+
+#### Manual Dispatch Run #559 (`33694905103`) on HEAD `e824c4c21cf3`
+- **Trigger**: `workflow_dispatch`
+- **Total Jobs**: 6/6 `SUCCESS`
+- **Timing Evidence**:
+  - `changes`: **4s** (ID `100461577952`)
+  - `static`: **30s** (ID `100461603388`)
+  - `supply_chain`: **27s** (ID `100461603473`)
+  - `validate`: **15m45s** (ID `100461603580` — full browser tests + main cache save)
+  - `packaged`: **9m45s** (ID `100461603427`)
+  - `status`: **2s** (ID `100465247611`)
+- **Authoritative Artifact**:
+  - Artifact ID: `9871600003`
+  - Name: `sky-auto-player-portable-e824c4c21cf3c7328076ca9df64f6a259b654315`
+  - Size: `9,171,973 bytes`
+  - Digest: `sha256:19e43255c1f8754a52cdecbf469269c8faab5df8a7a8901bae17e066d9f4202a`

--- a/docs/perf-baselines/2026-09-wave8-ci-fast-feedback.md
+++ b/docs/perf-baselines/2026-09-wave8-ci-fast-feedback.md
@@ -191,11 +191,11 @@ To qualify the short-circuit optimization for manual dispatch and main push:
 
 ### 4.1 Architectural Changes
 1. **Dedicated Parallel Jobs in CI**:
-   - `static` (`Static and security gates`): Pure repository static invariants (`cargo xtask check static --skip-supply-chain`). Completely offline, zero network access, no `cargo-audit` advisory DB downloading, no `cargo-vet` tool setup/restore.
+   - `static` (`Static and security gates`): Repository static invariant verification (`cargo xtask check static --skip-supply-chain`). Supply-chain and advisory network operations are removed from `static`; `cargo-audit` and `cargo-vet` are isolated into the parallel `supply_chain` job, eliminating advisory DB downloads and tool cache restores from the static critical path.
    - `supply_chain` (`Supply-chain and advisory security`): Dedicated job on `ubuntu-latest` running in parallel with `static`. Restores and caches pinned `cargo-audit` (v0.22.2) and `cargo-vet` (v0.10.2). Executes `cargo audit --file rust/Cargo.lock` and `cargo vet --manifest-path rust/Cargo.toml --locked`.
-2. **Offline Local Contract Preservation**:
+2. **Local Contract & Fail-Closed Semantics Preservation**:
    - Running `cargo xtask check static` locally without flags continues to execute all checks including `supply_chain::run(None)` by default.
-   - Flag `--skip-supply-chain` or environment variable `SKY_CHECK_SKIP_SUPPLY_CHAIN=1` safely bypasses the redundant `cargo vet` step when executed under dedicated CI pipelines.
+   - Flag `--skip-supply-chain` or environment variable `SKY_CHECK_SKIP_SUPPLY_CHAIN=1` safely bypasses the redundant `cargo vet` step when executed under dedicated CI pipelines. The environment variable check enforces strict fail-closed equality (`== "1"`) to prevent accidental bypass via `0`, `false`, or empty values.
    - Preserves all security invariants from `SECURITY.md` and zero-Python audit rules from `AGENTS.md`.
 3. **Gate Convergence**:
    - Updated `status` required CI gate to depend on `[changes, static, supply_chain, validate, packaged]`, failing closed if either `static` or `supply_chain` fails.

--- a/docs/perf-baselines/2026-09-wave8-ci-fast-feedback.md
+++ b/docs/perf-baselines/2026-09-wave8-ci-fast-feedback.md
@@ -184,3 +184,18 @@ To qualify the short-circuit optimization for manual dispatch and main push:
 - **Investigation of Run #552 `validate` Failure**:
   - Root cause: In `desktop/scripts/run-e2e.mjs:28`, `waitForServer()` has a fixed 15-second deadline (`60 * 250ms`) for Vite dev server initialization. Under heavy load on Windows runner after running the entire Rust test suite, cold Vite initialization took slightly longer than 15s, triggering `Error: Vite did not become ready within 15 seconds`.
   - All preceding steps passed cleanly: `check static` PASS, `check rust` PASS, `bun run check` PASS. Rerun #554 triggered to observe qualification.
+
+---
+
+## 4. CI-FAST-2: Static Checks and Supply-Chain Audits Separation
+
+### 4.1 Architectural Changes
+1. **Dedicated Parallel Jobs in CI**:
+   - `static` (`Static and security gates`): Pure repository static invariants (`cargo xtask check static --skip-supply-chain`). Completely offline, zero network access, no `cargo-audit` advisory DB downloading, no `cargo-vet` tool setup/restore.
+   - `supply_chain` (`Supply-chain and advisory security`): Dedicated job on `ubuntu-latest` running in parallel with `static`. Restores and caches pinned `cargo-audit` (v0.22.2) and `cargo-vet` (v0.10.2). Executes `cargo audit --file rust/Cargo.lock` and `cargo vet --manifest-path rust/Cargo.toml --locked`.
+2. **Offline Local Contract Preservation**:
+   - Running `cargo xtask check static` locally without flags continues to execute all checks including `supply_chain::run(None)` by default.
+   - Flag `--skip-supply-chain` or environment variable `SKY_CHECK_SKIP_SUPPLY_CHAIN=1` safely bypasses the redundant `cargo vet` step when executed under dedicated CI pipelines.
+   - Preserves all security invariants from `SECURITY.md` and zero-Python audit rules from `AGENTS.md`.
+3. **Gate Convergence**:
+   - Updated `status` required CI gate to depend on `[changes, static, supply_chain, validate, packaged]`, failing closed if either `static` or `supply_chain` fails.

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1503,8 +1503,10 @@ fn compare_generated_bindings(root: &Path, export_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn run(group: &str) -> Result<()> {
+pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
     let root = repo::root();
+    let skip_supply_chain =
+        skip_supply_chain || std::env::var_os("SKY_CHECK_SKIP_SUPPLY_CHAIN").is_some();
     match group {
         "static" => {
             audits::agent_context::run(&root)?;
@@ -1513,7 +1515,13 @@ pub fn run(group: &str) -> Result<()> {
             audits::security::run(&root)?;
             audits::zero_python::run(&root)?;
             tauri_feature_contract(&root)?;
-            supply_chain::run(None)?;
+            if !skip_supply_chain {
+                supply_chain::run(None)?;
+            } else {
+                println!(
+                    "[xtask] cargo-vet supply-chain: SKIP (verified by dedicated supply-chain gate)"
+                );
+            }
             branding::validate(&root)?;
             retirement(&root)?;
         }
@@ -1637,9 +1645,9 @@ pub fn run(group: &str) -> Result<()> {
             bindings()?;
         }
         "all" => {
-            run("static")?;
-            run("rust")?;
-            run("desktop")?;
+            run("static", skip_supply_chain)?;
+            run("rust", skip_supply_chain)?;
+            run("desktop", skip_supply_chain)?;
         }
         other => return Err(format!("unknown check group: {other}").into()),
     }

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1503,10 +1503,14 @@ fn compare_generated_bindings(root: &Path, export_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn should_skip_supply_chain(flag: bool, env_val: Option<&str>) -> bool {
+    flag || env_val.map(|v| v.trim()) == Some("1")
+}
+
 pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
     let root = repo::root();
-    let skip_supply_chain =
-        skip_supply_chain || std::env::var_os("SKY_CHECK_SKIP_SUPPLY_CHAIN").is_some();
+    let env_val = std::env::var("SKY_CHECK_SKIP_SUPPLY_CHAIN").ok();
+    let skip_supply_chain = should_skip_supply_chain(skip_supply_chain, env_val.as_deref());
     match group {
         "static" => {
             audits::agent_context::run(&root)?;
@@ -1871,5 +1875,29 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn should_skip_supply_chain_fails_closed() {
+        // Absent env var and flag false -> do not skip
+        assert!(!should_skip_supply_chain(false, None));
+
+        // Explicit flag true -> skip
+        assert!(should_skip_supply_chain(true, None));
+        assert!(should_skip_supply_chain(true, Some("0")));
+        assert!(should_skip_supply_chain(true, Some("false")));
+
+        // Env var exactly "1" -> skip
+        assert!(should_skip_supply_chain(false, Some("1")));
+        assert!(should_skip_supply_chain(false, Some(" 1 ")));
+
+        // Ambiguous / falsey / arbitrary env vars -> fail closed (do NOT skip)
+        assert!(!should_skip_supply_chain(false, Some("0")));
+        assert!(!should_skip_supply_chain(false, Some("false")));
+        assert!(!should_skip_supply_chain(false, Some("FALSE")));
+        assert!(!should_skip_supply_chain(false, Some("true")));
+        assert!(!should_skip_supply_chain(false, Some("")));
+        assert!(!should_skip_supply_chain(false, Some("yes")));
+        assert!(!should_skip_supply_chain(false, Some("2")));
     }
 }

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn usage() -> &'static str {
-    "Usage:\n  cargo xtask check <static|rust|desktop|all>\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-dist --release-dir <dir>"
+    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-dist --release-dir <dir>"
 }
 
 fn required_value(args: &[String], index: &mut usize, option: &str) -> Result<String> {
@@ -37,7 +37,8 @@ fn main() -> Result<()> {
     match args[0].as_str() {
         "check" => {
             let group = args.get(1).map(String::as_str).unwrap_or("all");
-            checks::run(group)
+            let skip_supply_chain = args.iter().any(|a| a == "--skip-supply-chain");
+            checks::run(group, skip_supply_chain)
         }
         "audit" if args.get(1).map(String::as_str) == Some("supply-chain") => {
             let mut attestation = None;


### PR DESCRIPTION
## Wave 8 — PR 2: CI-FAST-2 (Separate Static Checks and Supply-Chain Audits)

### Summary
This PR implements **CI-FAST-2** of the Wave 8 CI Fast-Feedback refactor:
1. **Dedicated Parallel Jobs in CI**:
   - `static` (`Static and security gates`): Evaluates repository static invariants via `cargo xtask check static --skip-supply-chain`. Supply-chain and advisory network operations are removed from `static`; `cargo-audit` advisory DB downloading and `cargo-vet` tool restores are isolated into the parallel `supply_chain` job.
   - `supply_chain` (`Supply-chain and advisory security`): New dedicated job running in parallel on `ubuntu-latest`. Restores and caches pinned `cargo-audit` (0.22.2) and `cargo-vet` (0.10.2), executing `cargo audit` and `cargo vet` concurrently with `static`.
2. **Local Contract & Fail-Closed Semantics Preservation**:
   - Running `cargo xtask check static` locally without flags continues to execute all static audits AND `supply_chain::run(None)` by default.
   - Passing `--skip-supply-chain` or setting `SKY_CHECK_SKIP_SUPPLY_CHAIN=1` safely bypasses the duplicate `cargo-vet` execution when run in CI. The environment variable parser strictly enforces `== "1"` to ensure fail-closed semantics.
   - Preserves all security invariants in `SECURITY.md` and zero-Python audits in `AGENTS.md`.
3. **Required Gate Convergence**:
   - Updated `status` gate to depend on `[changes, static, supply_chain, validate, packaged]`, requiring both `static` and `supply_chain` to pass whenever `STATIC_REQUIRED == 'true'`.
