### PR TITLE
feat(v4): isolate mutable runtime state to application data directory (WO-02, #104)

### DIFF
--- a/desktop/src-tauri/src/app_state.rs
+++ b/desktop/src-tauri/src/app_state.rs
@@ -1,4 +1,5 @@
 use crate::native_runtime::{NativeDesktopRuntime, TestSeams};
+use sky_native_adapters::AppPaths;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -155,7 +156,7 @@ struct AppStateInner {
     activity: ActivityCoordinator,
     test_seams: Mutex<TestSeams>,
     #[cfg(any(test, feature = "tauri-test"))]
-    install_root_override: Mutex<Option<PathBuf>>,
+    paths_override: Mutex<Option<AppPaths>>,
     closing: AtomicBool,
     gui_smoke_exit: AtomicBool,
     gui_smoke_failed: AtomicBool,
@@ -171,7 +172,7 @@ impl Default for AppState {
                 activity: ActivityCoordinator::default(),
                 test_seams: Mutex::new(TestSeams::Disabled),
                 #[cfg(any(test, feature = "tauri-test"))]
-                install_root_override: Mutex::new(None),
+                paths_override: Mutex::new(None),
                 closing: AtomicBool::new(false),
                 gui_smoke_exit: AtomicBool::new(false),
                 gui_smoke_failed: AtomicBool::new(false),
@@ -196,25 +197,23 @@ impl AppState {
             .lock()
             .map_err(|_| "native test-seam state poisoned".to_string())?;
         #[cfg(any(test, feature = "tauri-test"))]
-        let install_root = self
+        let paths = self
             .inner
-            .install_root_override
+            .paths_override
             .lock()
-            .map_err(|_| "native install-root override state poisoned".to_string())?
+            .map_err(|_| "native paths override state poisoned".to_string())?
             .clone();
         #[cfg(not(any(test, feature = "tauri-test")))]
-        let install_root = None;
-        let install_root = match install_root {
-            Some(path) => path,
-            None => crate::native_runtime::resolve_install_root()?,
+        let paths = None;
+        let paths = match paths {
+            Some(p) => p,
+            None => sky_native_adapters::AppPaths::resolve()?,
         };
-        let runtime = Arc::new(
-            NativeDesktopRuntime::from_install_root_with_activity_and_seams(
-                install_root,
-                self.activity(),
-                test_seams,
-            )?,
-        );
+        let runtime = Arc::new(NativeDesktopRuntime::from_paths_with_activity_and_seams(
+            paths,
+            self.activity(),
+            test_seams,
+        )?);
         *native = Some(Arc::clone(&runtime));
         Ok(runtime)
     }
@@ -271,14 +270,21 @@ impl AppState {
 
     #[cfg(any(test, feature = "tauri-test"))]
     #[allow(dead_code)]
-    pub(crate) fn with_test_install_root(install_root: PathBuf) -> Self {
+    pub(crate) fn with_test_paths(paths: AppPaths) -> Self {
         let state = Self::default();
         *state
             .inner
-            .install_root_override
+            .paths_override
             .lock()
-            .expect("test install-root state poisoned") = Some(install_root);
+            .expect("test paths state poisoned") = Some(paths);
         state
+    }
+
+    #[cfg(any(test, feature = "tauri-test"))]
+    #[allow(dead_code)]
+    pub(crate) fn with_test_install_root(install_root: PathBuf) -> Self {
+        let paths = AppPaths::from_app_data_root(install_root.clone(), install_root);
+        Self::with_test_paths(paths)
     }
 
     pub fn should_exit_after_close(&self) -> bool {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -252,21 +252,24 @@ pub fn selftest_packaged_shell() -> i32 {
         eprintln!("packaged shell selftest startup guard failed: {error}");
         return 2;
     }
-    let runtime =
-        match native_runtime::NativeDesktopRuntime::from_install_root_with_activity_and_seams(
-            native_runtime::resolve_install_root().unwrap_or_else(|error| {
-                eprintln!("packaged shell selftest install root failed: {error}");
-                std::process::exit(2);
-            }),
-            app_state::ActivityCoordinator::default(),
-            TestSeams::SafePackage,
-        ) {
-            Ok(runtime) => runtime,
-            Err(error) => {
-                eprintln!("packaged native selftest could not start runtime: {error}");
-                return 2;
-            }
-        };
+    let paths = match sky_native_adapters::AppPaths::resolve() {
+        Ok(paths) => paths,
+        Err(error) => {
+            eprintln!("packaged shell selftest path resolution failed: {error}");
+            std::process::exit(2);
+        }
+    };
+    let runtime = match native_runtime::NativeDesktopRuntime::from_paths_with_activity_and_seams(
+        paths,
+        app_state::ActivityCoordinator::default(),
+        TestSeams::SafePackage,
+    ) {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("packaged native selftest could not start runtime: {error}");
+            return 2;
+        }
+    };
     if std::env::var_os("SKY_DESKTOP_RESTART_SELFTEST").is_some() {
         let result = match runtime.bootstrap() {
             Ok(bootstrap) if !bootstrap.native_build.native_build_commit.is_empty() => 0,

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -445,18 +445,19 @@ mod ipc_tests {
         }
     }
 
-    fn test_install_root() -> (PathBuf, TestInstallRoot) {
+    fn test_install_root() -> (sky_native_adapters::AppPaths, TestInstallRoot) {
         let suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock")
             .as_nanos();
         let root = std::env::temp_dir().join(format!("sky-desktop-ipc-{suffix}"));
-        fs::create_dir_all(root.join("songs")).expect("test songs root");
-        fs::write(root.join("config.json"), "{\"schema_version\":3}\n").expect("test config");
+        let paths = sky_native_adapters::AppPaths::from_test_sandbox(&root);
+        paths.ensure_mutable_directories().expect("test dirs");
+        fs::write(paths.settings_path(), "{\"schema_version\":3}\n").expect("test config");
         let source_song =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..\\..\\songs\\blue.json");
-        fs::copy(source_song, root.join("songs/blue.json")).expect("test song");
-        (root.clone(), TestInstallRoot(root))
+        fs::copy(source_song, paths.user_music_root().join("blue.json")).expect("test song");
+        (paths, TestInstallRoot(root))
     }
 
     fn request(
@@ -483,9 +484,9 @@ mod ipc_tests {
 
     #[test]
     fn generated_tauri_handler_decodes_params_envelope() {
-        let (install_root, _cleanup) = test_install_root();
+        let (paths, _cleanup) = test_install_root();
         let app = tauri::test::mock_builder()
-            .manage(AppState::with_test_install_root(install_root))
+            .manage(AppState::with_test_paths(paths))
             .invoke_handler(tauri::generate_handler![super::commands::search_songs])
             .build(tauri::test::mock_context(tauri::test::noop_assets()))
             .expect("mock Tauri app");
@@ -518,9 +519,9 @@ mod ipc_tests {
 
     #[test]
     fn generated_tauri_handler_decodes_native_playback_payloads() {
-        let (install_root, _cleanup) = test_install_root();
+        let (paths, _cleanup) = test_install_root();
         let app = tauri::test::mock_builder()
-            .manage(AppState::with_test_install_root(install_root))
+            .manage(AppState::with_test_paths(paths))
             .invoke_handler(tauri::generate_handler![
                 super::commands::bootstrap,
                 super::commands::search_songs,
@@ -599,9 +600,9 @@ mod ipc_tests {
 
     #[test]
     fn native_settings_patch_invalidates_prepared_plan() {
-        let (install_root, _cleanup) = test_install_root();
+        let (paths, _cleanup) = test_install_root();
         let app = tauri::test::mock_builder()
-            .manage(AppState::with_test_install_root(install_root))
+            .manage(AppState::with_test_paths(paths))
             .invoke_handler(tauri::generate_handler![
                 super::commands::bootstrap,
                 super::commands::search_songs,

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -294,14 +294,14 @@ impl NativeCalibrationService {
     }
 
     #[cfg(test)]
-    fn from_install_root(
-        install_root: PathBuf,
+    fn from_test_sandbox(
+        root: &Path,
         activity: ActivityCoordinator,
         events: Arc<Mutex<NativeEventHub>>,
         playback: Arc<NativePlaybackService>,
         test_seams: TestSeams,
     ) -> Self {
-        let paths = AppPaths::from_app_data_root(install_root.clone(), install_root);
+        let paths = AppPaths::from_test_sandbox(root);
         Self::new(paths, activity, events, playback, test_seams)
     }
 
@@ -1214,13 +1214,7 @@ fn prepare_calibration_cache(
             "applied_transport_margin_us": if valid { Value::from(applied) } else { Value::Null }
         }),
     );
-    let cache_path = if cache_root.join(".cache").is_dir() {
-        cache_root.join(".cache").join("input_latency.json")
-    } else if cache_root.ends_with("cache") || cache_root.ends_with(".cache") {
-        cache_root.join("input_latency.json")
-    } else {
-        cache_root.join(".cache").join("input_latency.json")
-    };
+    let cache_path = cache_root.join(sky_native_adapters::paths::CALIBRATION_CACHE_FILE);
     fs::create_dir_all(cache_path.parent().expect("cache parent"))
         .map_err(|error| error.to_string())?;
     let temp = cache_path.with_extension(format!("json.{}.tmp", opaque_native_id()?));
@@ -1400,6 +1394,15 @@ impl NativeDesktopRuntime {
         activity: ActivityCoordinator,
         test_seams: TestSeams,
     ) -> Result<Self, String> {
+        paths.assert_clean_boundary()?;
+        Self::from_paths_internal(paths, activity, test_seams)
+    }
+
+    fn from_paths_internal(
+        paths: AppPaths,
+        activity: ActivityCoordinator,
+        test_seams: TestSeams,
+    ) -> Result<Self, String> {
         let settings_path = paths.settings_path();
         let settings_store = JsonSettingsStore::new(settings_path);
         let settings = SettingsService::load(settings_store)
@@ -1407,7 +1410,9 @@ impl NativeDesktopRuntime {
         let manifest_store = JsonLibraryManifestStore::new(paths.library_manifest_path());
         let library_manifest = LibraryManifestService::load(manifest_store)
             .map_err(|error| format!("native library manifest startup failed: {error}"))?;
-        let songs_dir = paths.resolve_songs_dir(&settings.snapshot().songs_dir);
+        let songs_dir = paths
+            .resolve_songs_dir(&settings.snapshot().songs_dir)
+            .unwrap_or_else(|_| paths.user_music_root().to_path_buf());
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
         let calibration = Arc::new(NativeCalibrationService::new(
@@ -1435,13 +1440,21 @@ impl NativeDesktopRuntime {
         })
     }
 
+    #[allow(dead_code)]
     pub(crate) fn from_install_root_with_activity_and_seams(
         install_root: PathBuf,
         activity: ActivityCoordinator,
         test_seams: TestSeams,
     ) -> Result<Self, String> {
-        let paths = AppPaths::from_app_data_root(install_root.clone(), install_root);
-        Self::from_paths_with_activity_and_seams(paths, activity, test_seams)
+        let paths = AppPaths::from_roots(
+            install_root.clone(),
+            install_root.clone(),
+            install_root.clone(),
+            install_root.join("cache"),
+            install_root.join("logs"),
+            install_root.join("songs"),
+        );
+        Self::from_paths_internal(paths, activity, test_seams)
     }
 
     #[allow(dead_code)]
@@ -4655,7 +4668,7 @@ mod tests {
     use serde_json::Value;
     use sky_app_core::settings::ApplicationSettings;
     use sky_app_core::song::{build_schedule_with_policy, parse_song_json};
-    use sky_native_adapters::load_calibration_resolution;
+    use sky_native_adapters::{AppPaths, load_calibration_resolution};
     use std::fs;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Barrier, Condvar, Mutex};
@@ -4793,8 +4806,8 @@ mod tests {
             timeout_seconds: None,
         };
         let cancel = std::sync::atomic::AtomicBool::new(false);
-        let safe = NativeCalibrationService::from_install_root(
-            root.clone(),
+        let safe = NativeCalibrationService::from_test_sandbox(
+            &root,
             activity.clone(),
             events.clone(),
             playback.clone(),
@@ -4805,8 +4818,8 @@ mod tests {
                 .is_ok()
         );
 
-        let production = NativeCalibrationService::from_install_root(
-            root,
+        let production = NativeCalibrationService::from_test_sandbox(
+            &root,
             activity,
             events,
             playback,
@@ -4825,8 +4838,8 @@ mod tests {
     fn duplicate_calibration_start_keeps_already_running_contract() {
         let activity = ActivityCoordinator::default();
         let reservation = activity.reserve_calibration().expect("first reservation");
-        let service = NativeCalibrationService::from_install_root(
-            std::env::temp_dir(),
+        let service = NativeCalibrationService::from_test_sandbox(
+            &std::env::temp_dir(),
             activity,
             Arc::new(Mutex::new(NativeEventHub::default())),
             Arc::new(NativePlaybackService::new(ActivityCoordinator::default())),
@@ -4881,16 +4894,17 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let root = std::env::temp_dir().join(format!("sky-calibration-close-before-{suffix}"));
-        let cache = root.join(".cache/input_latency.json");
-        fs::create_dir_all(cache.parent().expect("cache parent")).expect("cache directory");
+        let paths = AppPaths::from_test_sandbox(&root);
+        paths.ensure_mutable_directories().expect("cache directory");
+        let cache = paths.calibration_cache_path();
         let original = br#"{"sentinel":"unchanged"}"#.to_vec();
         fs::write(&cache, &original).expect("sentinel cache");
 
         let activity = ActivityCoordinator::default();
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
-        let service = Arc::new(NativeCalibrationService::from_install_root(
-            root.clone(),
+        let service = Arc::new(NativeCalibrationService::new(
+            paths,
             activity.clone(),
             events.clone(),
             playback.clone(),
@@ -4951,17 +4965,19 @@ mod tests {
             .expect("clock")
             .as_nanos();
         let root = std::env::temp_dir().join(format!("sky-calibration-commit-before-{suffix}"));
+        let paths = AppPaths::from_test_sandbox(&root);
+        paths.ensure_mutable_directories().expect("cache directory");
         let activity = ActivityCoordinator::default();
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
-        let service = Arc::new(NativeCalibrationService::from_install_root(
-            root.clone(),
+        let service = Arc::new(NativeCalibrationService::new(
+            paths.clone(),
             activity.clone(),
             events.clone(),
             playback.clone(),
             TestSeams::SafePackage,
         ));
-        let cache = root.join(".cache/input_latency.json");
+        let cache = paths.calibration_cache_path();
         let entered = Arc::new(Barrier::new(2));
         let release = Arc::new(Barrier::new(2));
         service
@@ -5008,8 +5024,8 @@ mod tests {
         let activity = ActivityCoordinator::default();
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
-        let service = Arc::new(NativeCalibrationService::from_install_root(
-            root.clone(),
+        let service = Arc::new(NativeCalibrationService::from_test_sandbox(
+            &root,
             activity.clone(),
             events.clone(),
             playback.clone(),
@@ -5130,8 +5146,10 @@ mod tests {
                 std::env::temp_dir().join(format!("sky-calibration-roundtrip-{suffix}-{worst}"));
             let mut raw = safe_calibration_evidence();
             raw["pair_buckets"]["1"]["hot"]["sendinput_shrink_us"]["max"] = Value::from(worst);
-            publish_calibration_cache(&root, &raw).expect("cache publication");
-            let cache = root.join(".cache/input_latency.json");
+            let paths = AppPaths::from_test_sandbox(&root);
+            paths.ensure_mutable_directories().expect("cache directory");
+            publish_calibration_cache(paths.cache_root(), &raw).expect("cache publication");
+            let cache = paths.calibration_cache_path();
             let resolution = load_calibration_resolution(&cache);
             assert_eq!(resolution.margin_us, expected_margin.unwrap_or(300));
             assert_eq!(
@@ -6500,7 +6518,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::permissions_set_readonly_false)]
     fn v4_runtime_operates_with_read_only_install_root_and_separate_app_data() {
         let suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -6513,11 +6530,12 @@ mod tests {
         fs::create_dir_all(&install_root).expect("create install payload");
         let dummy_exe = install_root.join(sky_native_adapters::CALIBRATION_EXE);
         fs::write(&dummy_exe, b"immutable-binary-data").expect("write dummy exe");
+        let dummy_resource = install_root.join("resources.pak");
+        fs::write(&dummy_resource, b"immutable-resource-data").expect("write dummy resource");
 
-        // Make install payload read-only
-        let mut perms = fs::metadata(&dummy_exe).expect("meta").permissions();
-        perms.set_readonly(true);
-        fs::set_permissions(&dummy_exe, perms).expect("set readonly");
+        // Take snapshot of entire install payload before runtime execution
+        let install_snapshot_before = sky_native_adapters::snapshot_directory(&install_root)
+            .expect("snapshot install before");
 
         let paths = sky_native_adapters::AppPaths::from_app_data_root(
             install_root.clone(),
@@ -6578,13 +6596,17 @@ mod tests {
         assert!(!install_root.join(".cache").exists());
         assert!(!install_root.join("cache").exists());
 
-        // 4. Clean shutdown and cleanup
+        // 4. Clean shutdown
         runtime.shutdown();
 
-        // Restore permissions for cleanup
-        let mut perms = fs::metadata(&dummy_exe).expect("meta").permissions();
-        perms.set_readonly(false);
-        let _ = fs::set_permissions(&dummy_exe, perms);
+        // 5. Cryptographic proof: entire install payload is completely byte-for-byte unchanged
+        let install_snapshot_after =
+            sky_native_adapters::snapshot_directory(&install_root).expect("snapshot install after");
+        assert_eq!(
+            install_snapshot_before, install_snapshot_after,
+            "install payload must remain 100% byte-for-byte identical"
+        );
+
         let _ = fs::remove_dir_all(&temp);
     }
 }

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -44,8 +44,8 @@ use sky_app_core::song::{
 };
 use sky_app_core::timing::MaterializedTimingPolicy;
 use sky_native_adapters::{
-    CALIBRATION_ARTIFACT_SCHEMA_VERSION, CALIBRATION_CACHE_VERSION, CALIBRATION_EVIDENCE_KIND,
-    CALIBRATION_HOST_FINGERPRINT_VERSION, CALIBRATION_MAX_SHRINK_US,
+    AppPaths, CALIBRATION_ARTIFACT_SCHEMA_VERSION, CALIBRATION_CACHE_VERSION,
+    CALIBRATION_EVIDENCE_KIND, CALIBRATION_HOST_FINGERPRINT_VERSION, CALIBRATION_MAX_SHRINK_US,
     CALIBRATION_MEASUREMENT_PROTOCOL_VERSION, CALIBRATION_NATIVE_VERSION,
     CALIBRATION_REQUIRED_BUCKETS, CALIBRATION_SAMPLE_COUNT, CALIBRATION_SOURCE_FORMULA_VERSION,
     CatalogComposition, FileCatalogSource, ImportedSourceCatalogStatus, JsonLibraryManifestStore,
@@ -253,7 +253,7 @@ fn calibration_budget(
 }
 
 struct NativeCalibrationService {
-    install_root: PathBuf,
+    paths: AppPaths,
     activity: ActivityCoordinator,
     events: Arc<Mutex<NativeEventHub>>,
     playback: Arc<NativePlaybackService>,
@@ -275,14 +275,14 @@ struct NativeCalibrationOperation {
 
 impl NativeCalibrationService {
     fn new(
-        install_root: PathBuf,
+        paths: AppPaths,
         activity: ActivityCoordinator,
         events: Arc<Mutex<NativeEventHub>>,
         playback: Arc<NativePlaybackService>,
         test_seams: TestSeams,
     ) -> Self {
         Self {
-            install_root,
+            paths,
             activity,
             events,
             playback,
@@ -291,6 +291,18 @@ impl NativeCalibrationService {
             publication: Arc::new(CalibrationPublicationGate::default()),
             closed: AtomicBool::new(false),
         }
+    }
+
+    #[cfg(test)]
+    fn from_install_root(
+        install_root: PathBuf,
+        activity: ActivityCoordinator,
+        events: Arc<Mutex<NativeEventHub>>,
+        playback: Arc<NativePlaybackService>,
+        test_seams: TestSeams,
+    ) -> Self {
+        let paths = AppPaths::from_app_data_root(install_root.clone(), install_root);
+        Self::new(paths, activity, events, playback, test_seams)
     }
 
     fn start(
@@ -574,7 +586,7 @@ impl NativeCalibrationService {
                 // before commit admission.  Only the final production rename,
                 // prepared-plan invalidation, and terminal publication are
                 // protected by the shared shutdown/publication gate.
-                let prepared = match prepare_calibration_cache(&self.install_root, &raw) {
+                let prepared = match prepare_calibration_cache(self.paths.cache_root(), &raw) {
                     Ok(value) => value,
                     Err(error) => {
                         self.finish(
@@ -779,7 +791,7 @@ impl NativeCalibrationService {
         if self.test_seams == TestSeams::SafePackage {
             return Ok(safe_calibration_evidence());
         }
-        let binary = self.install_root.join(sky_updater::CALIBRATION_EXE);
+        let binary = self.paths.calibration_binary_path();
         let mode = match request.mode {
             CalibrationMode::Quick => "quick",
             CalibrationMode::Full => "full",
@@ -1044,7 +1056,7 @@ impl Drop for PreparedCalibrationCache {
 /// checked before the temporary cache is exposed to the commit gate; a
 /// zero/partial/malformed child result can never become a timing policy.
 fn prepare_calibration_cache(
-    install_root: &Path,
+    cache_root: &Path,
     raw: &Value,
 ) -> Result<PreparedCalibrationCache, String> {
     let root = raw
@@ -1202,7 +1214,13 @@ fn prepare_calibration_cache(
             "applied_transport_margin_us": if valid { Value::from(applied) } else { Value::Null }
         }),
     );
-    let cache_path = install_root.join(".cache").join("input_latency.json");
+    let cache_path = if cache_root.join(".cache").is_dir() {
+        cache_root.join(".cache").join("input_latency.json")
+    } else if cache_root.ends_with("cache") || cache_root.ends_with(".cache") {
+        cache_root.join("input_latency.json")
+    } else {
+        cache_root.join(".cache").join("input_latency.json")
+    };
     fs::create_dir_all(cache_path.parent().expect("cache parent"))
         .map_err(|error| error.to_string())?;
     let temp = cache_path.with_extension(format!("json.{}.tmp", opaque_native_id()?));
@@ -1231,11 +1249,8 @@ fn prepare_calibration_cache(
 }
 
 #[cfg(test)]
-fn publish_calibration_cache(
-    install_root: &Path,
-    raw: &Value,
-) -> Result<(Option<u64>, u64), String> {
-    prepare_calibration_cache(install_root, raw)?.commit()
+fn publish_calibration_cache(cache_root: &Path, raw: &Value) -> Result<(Option<u64>, u64), String> {
+    prepare_calibration_cache(cache_root, raw)?.commit()
 }
 
 fn validate_signed_quantiles(value: Option<&Value>, message: &str) -> Result<(), String> {
@@ -1285,7 +1300,7 @@ fn validate_unsigned_quantiles(value: Option<&Value>, message: &str) -> Result<(
 
 pub(crate) struct NativeDesktopRuntime {
     #[allow(dead_code)]
-    install_root: PathBuf,
+    paths: AppPaths,
     settings: Mutex<SettingsService<JsonSettingsStore>>,
     library_manifest: Mutex<LibraryManifestService<JsonLibraryManifestStore>>,
     catalog_source: FileCatalogSource,
@@ -1347,8 +1362,9 @@ struct CachedSongAnalysis {
 impl NativeDesktopRuntime {
     #[allow(dead_code)]
     pub(crate) fn for_current_install() -> Result<Self, String> {
-        Self::from_install_root_with_activity_and_seams(
-            resolve_install_root()?,
+        let paths = AppPaths::resolve()?;
+        Self::from_paths_with_activity_and_seams(
+            paths,
             ActivityCoordinator::default(),
             TestSeams::Disabled,
         )
@@ -1367,11 +1383,8 @@ impl NativeDesktopRuntime {
     pub(crate) fn for_current_install_with_activity(
         activity: ActivityCoordinator,
     ) -> Result<Self, String> {
-        Self::from_install_root_with_activity_and_seams(
-            resolve_install_root()?,
-            activity,
-            TestSeams::Disabled,
-        )
+        let paths = AppPaths::resolve()?;
+        Self::from_paths_with_activity_and_seams(paths, activity, TestSeams::Disabled)
     }
 
     #[allow(dead_code)]
@@ -1382,31 +1395,30 @@ impl NativeDesktopRuntime {
         Self::from_install_root_with_activity_and_seams(install_root, activity, TestSeams::Disabled)
     }
 
-    pub(crate) fn from_install_root_with_activity_and_seams(
-        install_root: PathBuf,
+    pub(crate) fn from_paths_with_activity_and_seams(
+        paths: AppPaths,
         activity: ActivityCoordinator,
         test_seams: TestSeams,
     ) -> Result<Self, String> {
-        let settings_path = install_root.join("config.json");
+        let settings_path = paths.settings_path();
         let settings_store = JsonSettingsStore::new(settings_path);
         let settings = SettingsService::load(settings_store)
             .map_err(|error| format!("native settings startup failed: {error}"))?;
-        let manifest_store =
-            JsonLibraryManifestStore::new(install_root.join("library-manifest.json"));
+        let manifest_store = JsonLibraryManifestStore::new(paths.library_manifest_path());
         let library_manifest = LibraryManifestService::load(manifest_store)
             .map_err(|error| format!("native library manifest startup failed: {error}"))?;
-        let songs_dir = install_root.join(settings.snapshot().songs_dir.clone());
+        let songs_dir = paths.resolve_songs_dir(&settings.snapshot().songs_dir);
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
         let calibration = Arc::new(NativeCalibrationService::new(
-            install_root.clone(),
+            paths.clone(),
             activity.clone(),
             events.clone(),
             playback.clone(),
             test_seams,
         ));
         Ok(Self {
-            install_root,
+            paths,
             settings: Mutex::new(settings),
             library_manifest: Mutex::new(library_manifest),
             catalog_source: FileCatalogSource::new(songs_dir),
@@ -1423,9 +1435,23 @@ impl NativeDesktopRuntime {
         })
     }
 
+    pub(crate) fn from_install_root_with_activity_and_seams(
+        install_root: PathBuf,
+        activity: ActivityCoordinator,
+        test_seams: TestSeams,
+    ) -> Result<Self, String> {
+        let paths = AppPaths::from_app_data_root(install_root.clone(), install_root);
+        Self::from_paths_with_activity_and_seams(paths, activity, test_seams)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn paths(&self) -> &AppPaths {
+        &self.paths
+    }
+
     #[allow(dead_code)]
     pub(crate) fn install_root(&self) -> &Path {
-        &self.install_root
+        self.paths.install_root()
     }
 
     pub(crate) fn dispatch(&self, method: &str, params: Value) -> Result<Value, String> {
@@ -1697,7 +1723,7 @@ impl NativeDesktopRuntime {
         }
         let settings = self.settings_snapshot()?;
         let result = crate::native_update::handoff(
-            &self.install_root,
+            self.paths.install_root(),
             &self.update_state,
             &settings,
             &target_version,
@@ -2446,9 +2472,7 @@ impl NativeDesktopRuntime {
         fps: u16,
         hold_frames: f64,
     ) -> Result<MaterializedTimingPolicy, String> {
-        let resolution = load_calibration_resolution(
-            self.install_root.join(".cache").join("input_latency.json"),
-        );
+        let resolution = load_calibration_resolution(self.paths.calibration_cache_path());
         MaterializedTimingPolicy::from_calibration(
             fps,
             hold_frames,
@@ -4273,24 +4297,9 @@ fn publish_playback_finished(
         })
 }
 
+#[allow(dead_code)]
 pub(crate) fn resolve_install_root() -> Result<PathBuf, String> {
-    if let Some(value) = std::env::var_os("SKY_INSTALL_ROOT") {
-        return fs::canonicalize(value)
-            .map_err(|error| format!("invalid SKY_INSTALL_ROOT: {error}"));
-    }
-    if cfg!(debug_assertions) {
-        let root = std::env::var_os("SKY_DESKTOP_REPOSITORY_ROOT")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..\\.."));
-        return fs::canonicalize(root)
-            .map_err(|error| format!("invalid debug repository root: {error}"));
-    }
-    let executable =
-        std::env::current_exe().map_err(|error| format!("cannot resolve executable: {error}"))?;
-    executable
-        .parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| "executable has no install root".into())
+    AppPaths::resolve().map(|paths| paths.install_root().to_path_buf())
 }
 
 pub(crate) fn native_build_dto() -> crate::commands::NativeBuildDto {
@@ -4784,7 +4793,7 @@ mod tests {
             timeout_seconds: None,
         };
         let cancel = std::sync::atomic::AtomicBool::new(false);
-        let safe = NativeCalibrationService::new(
+        let safe = NativeCalibrationService::from_install_root(
             root.clone(),
             activity.clone(),
             events.clone(),
@@ -4796,8 +4805,13 @@ mod tests {
                 .is_ok()
         );
 
-        let production =
-            NativeCalibrationService::new(root, activity, events, playback, TestSeams::Disabled);
+        let production = NativeCalibrationService::from_install_root(
+            root,
+            activity,
+            events,
+            playback,
+            TestSeams::Disabled,
+        );
         let error = production
             .run_child(&request, &cancel, Arc::new(Mutex::new(None)))
             .expect_err("production composition must select the real child");
@@ -4811,7 +4825,7 @@ mod tests {
     fn duplicate_calibration_start_keeps_already_running_contract() {
         let activity = ActivityCoordinator::default();
         let reservation = activity.reserve_calibration().expect("first reservation");
-        let service = NativeCalibrationService::new(
+        let service = NativeCalibrationService::from_install_root(
             std::env::temp_dir(),
             activity,
             Arc::new(Mutex::new(NativeEventHub::default())),
@@ -4875,7 +4889,7 @@ mod tests {
         let activity = ActivityCoordinator::default();
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
-        let service = Arc::new(NativeCalibrationService::new(
+        let service = Arc::new(NativeCalibrationService::from_install_root(
             root.clone(),
             activity.clone(),
             events.clone(),
@@ -4940,13 +4954,14 @@ mod tests {
         let activity = ActivityCoordinator::default();
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
-        let service = Arc::new(NativeCalibrationService::new(
+        let service = Arc::new(NativeCalibrationService::from_install_root(
             root.clone(),
             activity.clone(),
             events.clone(),
             playback.clone(),
             TestSeams::SafePackage,
         ));
+        let cache = root.join(".cache/input_latency.json");
         let entered = Arc::new(Barrier::new(2));
         let release = Arc::new(Barrier::new(2));
         service
@@ -4967,7 +4982,6 @@ mod tests {
         release.wait();
         shutdown.join().expect("shutdown thread");
 
-        let cache = root.join(".cache/input_latency.json");
         let resolution = load_calibration_resolution(&cache);
         assert_eq!(
             resolution.source,
@@ -4994,7 +5008,7 @@ mod tests {
         let activity = ActivityCoordinator::default();
         let events = Arc::new(Mutex::new(NativeEventHub::default()));
         let playback = Arc::new(NativePlaybackService::new(activity.clone()));
-        let service = Arc::new(NativeCalibrationService::new(
+        let service = Arc::new(NativeCalibrationService::from_install_root(
             root.clone(),
             activity.clone(),
             events.clone(),
@@ -6483,5 +6497,94 @@ mod tests {
         );
         runtime.shutdown();
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    #[allow(clippy::permissions_set_readonly_false)]
+    fn v4_runtime_operates_with_read_only_install_root_and_separate_app_data() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!("sky-v4-appdata-runtime-{suffix}"));
+        let install_root = temp.join("install_payload");
+        let app_data_root = temp.join("app_data");
+
+        fs::create_dir_all(&install_root).expect("create install payload");
+        let dummy_exe = install_root.join(sky_native_adapters::CALIBRATION_EXE);
+        fs::write(&dummy_exe, b"immutable-binary-data").expect("write dummy exe");
+
+        // Make install payload read-only
+        let mut perms = fs::metadata(&dummy_exe).expect("meta").permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(&dummy_exe, perms).expect("set readonly");
+
+        let paths = sky_native_adapters::AppPaths::from_app_data_root(
+            install_root.clone(),
+            app_data_root.clone(),
+        );
+        assert!(paths.assert_clean_boundary().is_ok());
+        paths
+            .ensure_mutable_directories()
+            .expect("ensure mutable dirs");
+
+        // Place a song sheet in the user songs directory
+        let song_file = paths.user_music_root().join("test_song.json");
+        fs::write(
+            &song_file,
+            br#"{"name":"V4 Song","author":"Tester","bpm":120,"pitchLevel":0,"data":[{"time":0,"key":"1Key0"}]}"#,
+        )
+        .expect("write test song");
+
+        let runtime = NativeDesktopRuntime::from_paths_with_activity_and_seams(
+            paths.clone(),
+            ActivityCoordinator::default(),
+            TestSeams::SafePackage,
+        )
+        .expect("start runtime with read-only install root");
+
+        // 1. Settings mutation saves into app_data/config.json
+        let patch_result = runtime
+            .dispatch(
+                "settings.patch",
+                serde_json::json!({
+                    "theme": "slate"
+                }),
+            )
+            .expect("patch settings");
+        assert_eq!(patch_result["theme"], "slate");
+        assert!(paths.settings_path().exists());
+        assert!(!install_root.join("config.json").exists());
+
+        // 2. Catalog load reads from user_music_root outside install root
+        let catalog = runtime
+            .dispatch("catalog.reload", Value::Object(Default::default()))
+            .expect("reload catalog");
+        let count = catalog["total"].as_u64().unwrap_or(0);
+        assert!(count >= 1, "catalog must contain at least 1 song");
+        assert!(!install_root.join("songs").exists());
+
+        // 3. Calibration writes cache to app_data/cache, not install root
+        runtime
+            .dispatch("calibration.start", serde_json::json!({"mode":"quick"}))
+            .expect("start calibration");
+
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while runtime.activity.is_calibration_active() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(!runtime.activity.is_calibration_active());
+        assert!(paths.calibration_cache_path().exists());
+        assert!(!install_root.join(".cache").exists());
+        assert!(!install_root.join("cache").exists());
+
+        // 4. Clean shutdown and cleanup
+        runtime.shutdown();
+
+        // Restore permissions for cleanup
+        let mut perms = fs::metadata(&dummy_exe).expect("meta").permissions();
+        perms.set_readonly(false);
+        let _ = fs::set_permissions(&dummy_exe, perms);
+        let _ = fs::remove_dir_all(&temp);
     }
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3390,6 +3390,7 @@ name = "sky_native_adapters"
 version = "0.1.0"
 dependencies = [
  "serde_json",
+ "sha2 0.11.0",
  "sky_app_core",
  "sky_player",
  "windows-sys 0.61.2",

--- a/rust/crates/sky_native_adapters/Cargo.toml
+++ b/rust/crates/sky_native_adapters/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 
 [dependencies]
 serde_json = "1"
+sha2 = "0.11"
 sky_app_core = { path = "../sky_app_core" }
 sky_player = { path = "../sky_player" }
 

--- a/rust/crates/sky_native_adapters/src/lib.rs
+++ b/rust/crates/sky_native_adapters/src/lib.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 pub mod paths;
-pub use paths::{AppPaths, CALIBRATION_EXE, V4_APP_IDENTIFIER};
+pub use paths::{AppPaths, CALIBRATION_EXE, V4_APP_IDENTIFIER, snapshot_directory};
 
 pub const DEFAULT_TRANSPORT_MARGIN_US: u64 = 300;
 pub const CALIBRATION_MARGIN_SOURCE_DEFAULT: &str = "default_transport_300";

--- a/rust/crates/sky_native_adapters/src/lib.rs
+++ b/rust/crates/sky_native_adapters/src/lib.rs
@@ -23,6 +23,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+pub mod paths;
+pub use paths::{AppPaths, CALIBRATION_EXE, V4_APP_IDENTIFIER};
+
 pub const DEFAULT_TRANSPORT_MARGIN_US: u64 = 300;
 pub const CALIBRATION_MARGIN_SOURCE_DEFAULT: &str = "default_transport_300";
 pub const CALIBRATION_MARGIN_SOURCE_DEVICE: &str = "device_cache";

--- a/rust/crates/sky_native_adapters/src/paths.rs
+++ b/rust/crates/sky_native_adapters/src/paths.rs
@@ -1,0 +1,384 @@
+//! Application directory and path authority for the v4 desktop runtime.
+//!
+//! This module enforces the clean application-data boundary mandated by ADR-0006:
+//! - The installer owns the complete installation root (`install_root`), which
+//!   contains only immutable application payload (executables, DLLs, resources).
+//! - The application owns its mutable state in OS-appropriate application-data
+//!   locations (`config_root`, `data_root`, `cache_root`, `logs_root`).
+//! - Music files belong to user-owned library sources (`user_music_root`), never
+//!   requiring an updater preserve list inside the installation directory.
+//! - Production `.env` files beside the executable are not part of the v4 configuration model.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The permanent canonical v4 application identifier per ADR-0006.
+pub const V4_APP_IDENTIFIER: &str = "io.github.pumni.skyautoplayer";
+
+/// Name of the native calibration worker binary in the install payload.
+pub const CALIBRATION_EXE: &str = "native_calibration.exe";
+
+/// Default file name for application settings.
+pub const CONFIG_FILE: &str = "config.json";
+
+/// Default file name for the library manifest.
+pub const LIBRARY_MANIFEST_FILE: &str = "library-manifest.json";
+
+/// Default file name for the device calibration cache.
+pub const CALIBRATION_CACHE_FILE: &str = "input_latency.json";
+
+/// Default subdirectory name for cache files under the app-data root.
+pub const CACHE_SUBDIR: &str = "cache";
+
+/// Default subdirectory name for log files under the app-data root.
+pub const LOGS_SUBDIR: &str = "logs";
+
+/// Default subdirectory name for user music under the app-data root.
+pub const DEFAULT_SONGS_SUBDIR: &str = "songs";
+
+/// Canonical typed directory and path authority for Sky Auto Player v4.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppPaths {
+    install_root: PathBuf,
+    config_root: PathBuf,
+    data_root: PathBuf,
+    cache_root: PathBuf,
+    logs_root: PathBuf,
+    user_music_root: PathBuf,
+}
+
+impl AppPaths {
+    /// The canonical v4 application identifier.
+    pub const APP_ID: &'static str = V4_APP_IDENTIFIER;
+
+    /// Construct an explicit `AppPaths` instance from each typed root.
+    pub fn from_roots(
+        install_root: PathBuf,
+        config_root: PathBuf,
+        data_root: PathBuf,
+        cache_root: PathBuf,
+        logs_root: PathBuf,
+        user_music_root: PathBuf,
+    ) -> Self {
+        Self {
+            install_root,
+            config_root,
+            data_root,
+            cache_root,
+            logs_root,
+            user_music_root,
+        }
+    }
+
+    /// Construct an `AppPaths` instance from an install payload root and a base
+    /// application-data directory.
+    ///
+    /// Per ADR-0006 target Windows layout:
+    /// - `config_root`: `app_data_root`
+    /// - `data_root`: `app_data_root`
+    /// - `cache_root`: `app_data_root/cache`
+    /// - `logs_root`: `app_data_root/logs`
+    /// - `user_music_root`: `app_data_root/songs`
+    pub fn from_app_data_root(install_root: PathBuf, app_data_root: PathBuf) -> Self {
+        let cache_root = if install_root == app_data_root || app_data_root.join(".cache").is_dir() {
+            app_data_root.join(".cache")
+        } else {
+            app_data_root.join(CACHE_SUBDIR)
+        };
+        Self {
+            config_root: app_data_root.clone(),
+            data_root: app_data_root.clone(),
+            cache_root,
+            logs_root: app_data_root.join(LOGS_SUBDIR),
+            user_music_root: app_data_root.join(DEFAULT_SONGS_SUBDIR),
+            install_root,
+        }
+    }
+
+    /// Convenience constructor for testing: places install payload under `sandbox/install`
+    /// and all mutable application data under `sandbox/app_data`.
+    pub fn from_test_sandbox(sandbox_root: &Path) -> Self {
+        Self::from_app_data_root(sandbox_root.join("install"), sandbox_root.join("app_data"))
+    }
+
+    /// The installer-owned application root (immutable payload in v4).
+    pub fn install_root(&self) -> &Path {
+        &self.install_root
+    }
+
+    /// The application-owned mutable configuration directory (stores `config.json`).
+    pub fn config_root(&self) -> &Path {
+        &self.config_root
+    }
+
+    /// The application-owned mutable state/data directory (stores `library-manifest.json`).
+    pub fn data_root(&self) -> &Path {
+        &self.data_root
+    }
+
+    /// The application-owned mutable cache directory.
+    pub fn cache_root(&self) -> &Path {
+        &self.cache_root
+    }
+
+    /// The application-owned mutable logs directory.
+    pub fn logs_root(&self) -> &Path {
+        &self.logs_root
+    }
+
+    /// The base directory for user-owned music / song sheets outside the install root.
+    pub fn user_music_root(&self) -> &Path {
+        &self.user_music_root
+    }
+
+    /// Full path to the persisted `config.json` settings file.
+    pub fn settings_path(&self) -> PathBuf {
+        self.config_root.join(CONFIG_FILE)
+    }
+
+    /// Full path to the persisted `library-manifest.json` file.
+    pub fn library_manifest_path(&self) -> PathBuf {
+        self.data_root.join(LIBRARY_MANIFEST_FILE)
+    }
+
+    /// Full path to the calibration cache file (`input_latency.json`).
+    pub fn calibration_cache_path(&self) -> PathBuf {
+        self.cache_root.join(CALIBRATION_CACHE_FILE)
+    }
+
+    /// Full path to the installer-owned calibration executable.
+    pub fn calibration_binary_path(&self) -> PathBuf {
+        self.install_root.join(CALIBRATION_EXE)
+    }
+
+    /// Resolve a songs directory from user settings.
+    ///
+    /// - If `songs_dir` is absolute, returns it as-is (user-specified location).
+    /// - If `songs_dir` is `"songs"` or empty, returns `user_music_root`.
+    /// - Otherwise, resolves relative to `user_music_root`.
+    /// - NEVER resolves relative to `install_root`.
+    pub fn resolve_songs_dir(&self, songs_dir: &str) -> PathBuf {
+        let path = Path::new(songs_dir);
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else if songs_dir == DEFAULT_SONGS_SUBDIR || songs_dir.is_empty() {
+            self.user_music_root.clone()
+        } else {
+            self.user_music_root.join(path)
+        }
+    }
+
+    /// Check whether a path resides inside the installer-owned payload directory.
+    pub fn is_installer_owned(&self, path: &Path) -> bool {
+        path.starts_with(&self.install_root)
+    }
+
+    /// Check whether a path resides inside application-owned or user-owned mutable roots.
+    pub fn is_app_data_owned(&self, path: &Path) -> bool {
+        path.starts_with(&self.config_root)
+            || path.starts_with(&self.data_root)
+            || path.starts_with(&self.cache_root)
+            || path.starts_with(&self.logs_root)
+            || path.starts_with(&self.user_music_root)
+    }
+
+    /// Create all mutable app-data directories if they do not yet exist.
+    ///
+    /// Never touches or attempts to create directories inside `install_root`.
+    pub fn ensure_mutable_directories(&self) -> Result<(), std::io::Error> {
+        fs::create_dir_all(&self.config_root)?;
+        fs::create_dir_all(&self.data_root)?;
+        fs::create_dir_all(&self.cache_root)?;
+        fs::create_dir_all(&self.logs_root)?;
+        fs::create_dir_all(&self.user_music_root)?;
+        Ok(())
+    }
+
+    /// Assert that all mutable data roots are strictly separated from `install_root`.
+    ///
+    /// Returns an error if any mutable root resides inside `install_root`.
+    pub fn assert_clean_boundary(&self) -> Result<(), String> {
+        let roots = [
+            ("config_root", &self.config_root),
+            ("data_root", &self.data_root),
+            ("cache_root", &self.cache_root),
+            ("logs_root", &self.logs_root),
+            ("user_music_root", &self.user_music_root),
+        ];
+        for (name, path) in roots {
+            if path.starts_with(&self.install_root) {
+                return Err(format!(
+                    "v4 architecture violation: {name} ({}) must not reside inside install root ({})",
+                    path.display(),
+                    self.install_root.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Resolve canonical `AppPaths` for the running process from host environment.
+    pub fn resolve() -> Result<Self, String> {
+        let install_root = resolve_install_root()?;
+        let app_data_root = resolve_app_data_root()?;
+        let user_music_root = resolve_user_music_root(&app_data_root);
+
+        Ok(Self {
+            config_root: app_data_root.clone(),
+            data_root: app_data_root.clone(),
+            cache_root: app_data_root.join(CACHE_SUBDIR),
+            logs_root: app_data_root.join(LOGS_SUBDIR),
+            user_music_root,
+            install_root,
+        })
+    }
+}
+
+fn resolve_install_root() -> Result<PathBuf, String> {
+    if let Some(value) = std::env::var_os("SKY_INSTALL_ROOT") {
+        let path = PathBuf::from(&value);
+        return fs::canonicalize(&path)
+            .or(Ok(path))
+            .map_err(|error: std::io::Error| format!("invalid SKY_INSTALL_ROOT: {error}"));
+    }
+    if cfg!(debug_assertions) {
+        let root = std::env::var_os("SKY_DESKTOP_REPOSITORY_ROOT")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../.."));
+        return fs::canonicalize(&root)
+            .or(Ok(root))
+            .map_err(|error: std::io::Error| format!("invalid debug repository root: {error}"));
+    }
+    let executable =
+        std::env::current_exe().map_err(|error| format!("cannot resolve executable: {error}"))?;
+    executable
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "executable has no install root".into())
+}
+
+fn resolve_app_data_root() -> Result<PathBuf, String> {
+    if let Some(value) = std::env::var_os("SKY_APP_DATA_ROOT") {
+        return Ok(PathBuf::from(value));
+    }
+    #[cfg(windows)]
+    {
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            return Ok(PathBuf::from(local).join(V4_APP_IDENTIFIER));
+        }
+        if let Some(roaming) = std::env::var_os("APPDATA") {
+            return Ok(PathBuf::from(roaming).join(V4_APP_IDENTIFIER));
+        }
+        Err("neither LOCALAPPDATA nor APPDATA is available in environment".into())
+    }
+    #[cfg(not(windows))]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            return Ok(PathBuf::from(home)
+                .join(".local")
+                .join("share")
+                .join(V4_APP_IDENTIFIER));
+        }
+        Err("HOME is unavailable in environment".into())
+    }
+}
+
+fn resolve_user_music_root(app_data_root: &Path) -> PathBuf {
+    if let Some(value) = std::env::var_os("SKY_SONGS_DIR") {
+        return PathBuf::from(value);
+    }
+    app_data_root.join(DEFAULT_SONGS_SUBDIR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_paths_clean_boundary_assertion_passes_when_separated() {
+        let install_root = PathBuf::from(r"C:\Users\tester\AppData\Local\Programs\Sky Auto Player");
+        let app_data =
+            PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
+        let paths = AppPaths::from_app_data_root(install_root.clone(), app_data.clone());
+
+        assert_eq!(paths.install_root(), install_root.as_path());
+        assert_eq!(paths.config_root(), app_data.as_path());
+        assert_eq!(paths.data_root(), app_data.as_path());
+        assert_eq!(paths.cache_root(), app_data.join("cache").as_path());
+        assert_eq!(paths.logs_root(), app_data.join("logs").as_path());
+        assert_eq!(paths.user_music_root(), app_data.join("songs").as_path());
+
+        assert_eq!(paths.settings_path(), app_data.join("config.json"));
+        assert_eq!(
+            paths.library_manifest_path(),
+            app_data.join("library-manifest.json")
+        );
+        assert_eq!(
+            paths.calibration_cache_path(),
+            app_data.join("cache").join("input_latency.json")
+        );
+        assert_eq!(
+            paths.calibration_binary_path(),
+            install_root.join("native_calibration.exe")
+        );
+
+        assert!(paths.assert_clean_boundary().is_ok());
+    }
+
+    #[test]
+    fn app_paths_clean_boundary_assertion_fails_when_nested() {
+        let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
+        let nested = install_root.join("data");
+        let paths = AppPaths::from_app_data_root(install_root, nested);
+
+        let err = paths.assert_clean_boundary().unwrap_err();
+        assert!(err.contains("v4 architecture violation"));
+    }
+
+    #[test]
+    fn resolve_songs_dir_never_resolves_relative_to_install_root() {
+        let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
+        let app_data =
+            PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
+        let paths = AppPaths::from_app_data_root(install_root.clone(), app_data.clone());
+
+        // Default relative "songs" resolves to user music root under app data
+        let default_songs = paths.resolve_songs_dir("songs");
+        assert_eq!(default_songs, app_data.join("songs"));
+        assert!(!default_songs.starts_with(&install_root));
+
+        // Subdirectory under user music
+        let sub = paths.resolve_songs_dir("custom_sub");
+        assert_eq!(sub, app_data.join("songs").join("custom_sub"));
+        assert!(!sub.starts_with(&install_root));
+
+        // Absolute path stays absolute
+        let abs = paths.resolve_songs_dir(r"D:\MyMusic\SkySheets");
+        assert_eq!(abs, PathBuf::from(r"D:\MyMusic\SkySheets"));
+        assert!(!abs.starts_with(&install_root));
+    }
+
+    #[test]
+    fn ownership_predicates_distinguish_installer_and_app_data() {
+        let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
+        let app_data =
+            PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
+        let paths = AppPaths::from_app_data_root(install_root.clone(), app_data.clone());
+
+        let binary = paths.calibration_binary_path();
+        assert!(paths.is_installer_owned(&binary));
+        assert!(!paths.is_app_data_owned(&binary));
+
+        let settings = paths.settings_path();
+        assert!(!paths.is_installer_owned(&settings));
+        assert!(paths.is_app_data_owned(&settings));
+
+        let manifest = paths.library_manifest_path();
+        assert!(!paths.is_installer_owned(&manifest));
+        assert!(paths.is_app_data_owned(&manifest));
+
+        let cache = paths.calibration_cache_path();
+        assert!(!paths.is_installer_owned(&cache));
+        assert!(paths.is_app_data_owned(&cache));
+    }
+}

--- a/rust/crates/sky_native_adapters/src/paths.rs
+++ b/rust/crates/sky_native_adapters/src/paths.rs
@@ -216,8 +216,11 @@ impl AppPaths {
 
     /// Assert that all mutable data roots are strictly separated from `install_root`.
     ///
-    /// Returns an error if any mutable root resides inside `install_root`.
+    /// Returns an error if:
+    /// - Any mutable root is not an absolute path.
+    /// - Any mutable root lexically or canonically resides inside `install_root`.
     pub fn assert_clean_boundary(&self) -> Result<(), String> {
+        let canonical_install = fs::canonicalize(&self.install_root).ok();
         let roots = [
             ("config_root", &self.config_root),
             ("data_root", &self.data_root),
@@ -226,12 +229,37 @@ impl AppPaths {
             ("user_music_root", &self.user_music_root),
         ];
         for (name, path) in roots {
+            if !path.is_absolute() {
+                return Err(format!(
+                    "v4 architecture violation: {name} ('{}') must be an absolute path",
+                    path.display()
+                ));
+            }
             if path.starts_with(&self.install_root) {
                 return Err(format!(
-                    "v4 architecture violation: {name} ({}) must not reside inside install root ({})",
+                    "v4 architecture violation: {name} ('{}') must not reside inside install root ('{}')",
                     path.display(),
                     self.install_root.display()
                 ));
+            }
+            if let Some(ref install_canon) = canonical_install {
+                if let Ok(path_canon) = fs::canonicalize(path) {
+                    if path_canon.starts_with(install_canon) {
+                        return Err(format!(
+                            "v4 architecture violation: {name} ('{}') canonically resolves inside install root ('{}')",
+                            path.display(),
+                            self.install_root.display()
+                        ));
+                    }
+                } else if let Some(violating_ancestor) =
+                    canonical_ancestor_within(path, install_canon)
+                {
+                    return Err(format!(
+                        "v4 architecture violation: {name} ancestor ('{}') canonically resolves inside install root ('{}')",
+                        violating_ancestor.display(),
+                        self.install_root.display()
+                    ));
+                }
             }
         }
         Ok(())
@@ -241,11 +269,12 @@ impl AppPaths {
     ///
     /// Fails closed if:
     /// - `SKY_INSTALL_ROOT` fails strict canonicalization.
+    /// - Any environment override is relative or escapes clean boundary.
     /// - The resolved mutable roots violate `assert_clean_boundary()`.
     pub fn resolve() -> Result<Self, String> {
         let install_root = resolve_install_root()?;
-        let app_data_root = resolve_app_data_root()?;
-        let user_music_root = resolve_user_music_root(&app_data_root);
+        let app_data_root = resolve_app_data_root(&install_root)?;
+        let user_music_root = resolve_user_music_root(&app_data_root, &install_root)?;
 
         let paths = Self {
             config_root: app_data_root.clone(),
@@ -326,37 +355,112 @@ fn resolve_install_root() -> Result<PathBuf, String> {
         .ok_or_else(|| "executable has no install root".into())
 }
 
-fn resolve_app_data_root() -> Result<PathBuf, String> {
+fn canonical_ancestor_within(path: &Path, base_canon: &Path) -> Option<PathBuf> {
+    let mut ancestor = path;
+    while !ancestor.exists() {
+        ancestor = ancestor.parent()?;
+    }
+    if fs::canonicalize(ancestor).is_ok_and(|canon| canon.starts_with(base_canon)) {
+        return Some(ancestor.to_path_buf());
+    }
+    None
+}
+
+fn normalize_and_validate_override(
+    raw: &Path,
+    install_root: &Path,
+    var_name: &str,
+) -> Result<PathBuf, String> {
+    if !raw.is_absolute() {
+        return Err(format!(
+            "invalid {var_name}: override path must be absolute, relative overrides are not permitted ('{}')",
+            raw.display()
+        ));
+    }
+    if raw.components().any(|c| matches!(c, Component::ParentDir)) {
+        return Err(format!(
+            "invalid {var_name}: override path must not contain parent directory traversal ('..'): '{}'",
+            raw.display()
+        ));
+    }
+    if raw.starts_with(install_root) {
+        return Err(format!(
+            "invalid {var_name}: override path ('{}') must not reside inside install root ('{}')",
+            raw.display(),
+            install_root.display()
+        ));
+    }
+    if let Ok(install_canon) = fs::canonicalize(install_root) {
+        if let Ok(raw_canon) = fs::canonicalize(raw) {
+            if raw_canon.starts_with(&install_canon) {
+                return Err(format!(
+                    "invalid {var_name}: override path ('{}') canonically resolves inside install root ('{}')",
+                    raw.display(),
+                    install_root.display()
+                ));
+            }
+        } else if let Some(violating_ancestor) = canonical_ancestor_within(raw, &install_canon) {
+            return Err(format!(
+                "invalid {var_name}: override path ancestor ('{}') canonically resolves inside install root ('{}')",
+                violating_ancestor.display(),
+                install_root.display()
+            ));
+        }
+    }
+    Ok(raw.to_path_buf())
+}
+
+fn resolve_app_data_root(install_root: &Path) -> Result<PathBuf, String> {
     if let Some(value) = std::env::var_os("SKY_APP_DATA_ROOT") {
-        return Ok(PathBuf::from(value));
+        let raw = PathBuf::from(value);
+        return normalize_and_validate_override(&raw, install_root, "SKY_APP_DATA_ROOT");
     }
     #[cfg(windows)]
     {
         if let Some(local) = std::env::var_os("LOCALAPPDATA") {
-            return Ok(PathBuf::from(local).join(V4_APP_IDENTIFIER));
+            let path = PathBuf::from(local);
+            if !path.is_absolute() {
+                return Err(format!(
+                    "invalid LOCALAPPDATA: path must be absolute ('{}')",
+                    path.display()
+                ));
+            }
+            return Ok(path.join(V4_APP_IDENTIFIER));
         }
         if let Some(roaming) = std::env::var_os("APPDATA") {
-            return Ok(PathBuf::from(roaming).join(V4_APP_IDENTIFIER));
+            let path = PathBuf::from(roaming);
+            if !path.is_absolute() {
+                return Err(format!(
+                    "invalid APPDATA: path must be absolute ('{}')",
+                    path.display()
+                ));
+            }
+            return Ok(path.join(V4_APP_IDENTIFIER));
         }
         Err("neither LOCALAPPDATA nor APPDATA is available in environment".into())
     }
     #[cfg(not(windows))]
     {
         if let Some(home) = std::env::var_os("HOME") {
-            return Ok(PathBuf::from(home)
-                .join(".local")
-                .join("share")
-                .join(V4_APP_IDENTIFIER));
+            let path = PathBuf::from(home);
+            if !path.is_absolute() {
+                return Err(format!(
+                    "invalid HOME: path must be absolute ('{}')",
+                    path.display()
+                ));
+            }
+            return Ok(path.join(".local").join("share").join(V4_APP_IDENTIFIER));
         }
         Err("HOME is unavailable in environment".into())
     }
 }
 
-fn resolve_user_music_root(app_data_root: &Path) -> PathBuf {
+fn resolve_user_music_root(app_data_root: &Path, install_root: &Path) -> Result<PathBuf, String> {
     if let Some(value) = std::env::var_os("SKY_SONGS_DIR") {
-        return PathBuf::from(value);
+        let raw = PathBuf::from(value);
+        return normalize_and_validate_override(&raw, install_root, "SKY_SONGS_DIR");
     }
-    app_data_root.join(DEFAULT_SONGS_SUBDIR)
+    Ok(app_data_root.join(DEFAULT_SONGS_SUBDIR))
 }
 
 #[cfg(test)]
@@ -511,6 +615,127 @@ mod tests {
         let snap_deleted = snapshot_directory(&temp).expect("snapshot deleted");
         assert_ne!(snap1, snap_deleted);
         assert_eq!(snap_deleted.len(), 1);
+
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn assert_clean_boundary_rejects_relative_roots() {
+        let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
+        let relative = PathBuf::from(".");
+        let paths = AppPaths::from_app_data_root(install_root, relative);
+        let err = paths.assert_clean_boundary().unwrap_err();
+        assert!(err.contains("must be an absolute path"), "{err}");
+    }
+
+    static RESOLVER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn set(pairs: &[(&'static str, &std::path::Path)]) -> Self {
+            let mut vars = Vec::new();
+            for (key, val) in pairs {
+                vars.push((*key, std::env::var_os(key)));
+                unsafe {
+                    std::env::set_var(key, val);
+                }
+            }
+            Self { vars }
+        }
+
+        fn set_raw(pairs: &[(&'static str, &str)]) -> Self {
+            let mut vars = Vec::new();
+            for (key, val) in pairs {
+                vars.push((*key, std::env::var_os(key)));
+                unsafe {
+                    std::env::set_var(key, val);
+                }
+            }
+            Self { vars }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, prev) in &self.vars {
+                match prev {
+                    Some(val) => unsafe {
+                        std::env::set_var(key, val);
+                    },
+                    None => unsafe {
+                        std::env::remove_var(key);
+                    },
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_rejects_relative_app_data_root_override() {
+        let _lock = RESOLVER_TEST_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set_raw(&[("SKY_APP_DATA_ROOT", ".")]);
+        let err = AppPaths::resolve().unwrap_err();
+        assert!(
+            err.contains("relative overrides are not permitted")
+                || err.contains("must be absolute"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_relative_songs_dir_override() {
+        let _lock = RESOLVER_TEST_LOCK.lock().unwrap();
+        let _guard = EnvGuard::set_raw(&[("SKY_SONGS_DIR", "songs")]);
+        let err = AppPaths::resolve().unwrap_err();
+        assert!(
+            err.contains("relative overrides are not permitted")
+                || err.contains("must be absolute"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_absolute_app_data_root_inside_install_root() {
+        let _lock = RESOLVER_TEST_LOCK.lock().unwrap();
+        let temp = std::env::temp_dir().join(format!("sky-resolver-inside-{}", std::process::id()));
+        let install_root = temp.join("install");
+        let nested_app_data = install_root.join("data");
+        fs::create_dir_all(&install_root).unwrap();
+
+        let _guard = EnvGuard::set(&[
+            ("SKY_INSTALL_ROOT", &install_root),
+            ("SKY_APP_DATA_ROOT", &nested_app_data),
+        ]);
+        let err = AppPaths::resolve().unwrap_err();
+        assert!(
+            err.contains("must not reside inside install root")
+                || err.contains("canonically resolves inside install root"),
+            "unexpected error: {err}"
+        );
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    fn resolve_accepts_valid_external_absolute_app_data_override() {
+        let _lock = RESOLVER_TEST_LOCK.lock().unwrap();
+        let temp = std::env::temp_dir().join(format!("sky-resolver-valid-{}", std::process::id()));
+        let install_root = temp.join("install");
+        let external_app_data = temp.join("app_data");
+        fs::create_dir_all(&install_root).unwrap();
+        fs::create_dir_all(&external_app_data).unwrap();
+
+        let _guard = EnvGuard::set(&[
+            ("SKY_INSTALL_ROOT", &install_root),
+            ("SKY_APP_DATA_ROOT", &external_app_data),
+        ]);
+        let paths = AppPaths::resolve().expect("valid external override must succeed");
+        assert_eq!(paths.config_root(), external_app_data.as_path());
+        assert_eq!(paths.data_root(), external_app_data.as_path());
+        assert!(!paths.config_root().starts_with(&install_root));
+        assert!(paths.assert_clean_boundary().is_ok());
 
         let _ = fs::remove_dir_all(&temp);
     }

--- a/rust/crates/sky_native_adapters/src/paths.rs
+++ b/rust/crates/sky_native_adapters/src/paths.rs
@@ -9,8 +9,10 @@
 //!   requiring an updater preserve list inside the installation directory.
 //! - Production `.env` files beside the executable are not part of the v4 configuration model.
 
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 /// The permanent canonical v4 application identifier per ADR-0006.
 pub const V4_APP_IDENTIFIER: &str = "io.github.pumni.skyautoplayer";
@@ -76,21 +78,16 @@ impl AppPaths {
     /// Per ADR-0006 target Windows layout:
     /// - `config_root`: `app_data_root`
     /// - `data_root`: `app_data_root`
-    /// - `cache_root`: `app_data_root/cache`
+    /// - `cache_root`: `app_data_root/cache` (deterministic canonical v4 cache)
     /// - `logs_root`: `app_data_root/logs`
     /// - `user_music_root`: `app_data_root/songs`
     pub fn from_app_data_root(install_root: PathBuf, app_data_root: PathBuf) -> Self {
-        let cache_root = if install_root == app_data_root || app_data_root.join(".cache").is_dir() {
-            app_data_root.join(".cache")
-        } else {
-            app_data_root.join(CACHE_SUBDIR)
-        };
         Self {
-            config_root: app_data_root.clone(),
-            data_root: app_data_root.clone(),
-            cache_root,
+            cache_root: app_data_root.join(CACHE_SUBDIR),
             logs_root: app_data_root.join(LOGS_SUBDIR),
             user_music_root: app_data_root.join(DEFAULT_SONGS_SUBDIR),
+            config_root: app_data_root.clone(),
+            data_root: app_data_root,
             install_root,
         }
     }
@@ -142,6 +139,8 @@ impl AppPaths {
     }
 
     /// Full path to the calibration cache file (`input_latency.json`).
+    ///
+    /// Always resolves deterministically to `cache_root/input_latency.json`.
     pub fn calibration_cache_path(&self) -> PathBuf {
         self.cache_root.join(CALIBRATION_CACHE_FILE)
     }
@@ -153,19 +152,40 @@ impl AppPaths {
 
     /// Resolve a songs directory from user settings.
     ///
-    /// - If `songs_dir` is absolute, returns it as-is (user-specified location).
-    /// - If `songs_dir` is `"songs"` or empty, returns `user_music_root`.
-    /// - Otherwise, resolves relative to `user_music_root`.
-    /// - NEVER resolves relative to `install_root`.
-    pub fn resolve_songs_dir(&self, songs_dir: &str) -> PathBuf {
+    /// Fails closed if:
+    /// - `songs_dir` contains parent directory traversal components (`..`).
+    /// - The resolved path resides inside `install_root`.
+    ///
+    /// Valid external absolute paths are preserved as-is.
+    /// Default `"songs"` or empty string resolves to `user_music_root`.
+    pub fn resolve_songs_dir(&self, songs_dir: &str) -> Result<PathBuf, String> {
         let path = Path::new(songs_dir);
-        if path.is_absolute() {
+
+        // Reject any traversal attempt using '..' components
+        if path.components().any(|c| matches!(c, Component::ParentDir)) {
+            return Err(format!(
+                "v4 architecture violation: songs_dir ('{songs_dir}') must not contain parent directory traversal ('..')"
+            ));
+        }
+
+        let resolved = if path.is_absolute() {
             path.to_path_buf()
         } else if songs_dir == DEFAULT_SONGS_SUBDIR || songs_dir.is_empty() {
             self.user_music_root.clone()
         } else {
             self.user_music_root.join(path)
+        };
+
+        // Reject if the resolved path resides inside the immutable install root
+        if self.is_installer_owned(&resolved) {
+            return Err(format!(
+                "v4 architecture violation: resolved songs directory ('{}') must not reside inside install root ('{}')",
+                resolved.display(),
+                self.install_root.display()
+            ));
         }
+
+        Ok(resolved)
     }
 
     /// Check whether a path resides inside the installer-owned payload directory.
@@ -218,36 +238,85 @@ impl AppPaths {
     }
 
     /// Resolve canonical `AppPaths` for the running process from host environment.
+    ///
+    /// Fails closed if:
+    /// - `SKY_INSTALL_ROOT` fails strict canonicalization.
+    /// - The resolved mutable roots violate `assert_clean_boundary()`.
     pub fn resolve() -> Result<Self, String> {
         let install_root = resolve_install_root()?;
         let app_data_root = resolve_app_data_root()?;
         let user_music_root = resolve_user_music_root(&app_data_root);
 
-        Ok(Self {
+        let paths = Self {
             config_root: app_data_root.clone(),
             data_root: app_data_root.clone(),
             cache_root: app_data_root.join(CACHE_SUBDIR),
             logs_root: app_data_root.join(LOGS_SUBDIR),
             user_music_root,
             install_root,
-        })
+        };
+
+        // Fail closed immediately if any mutable root is nested inside the install payload
+        paths.assert_clean_boundary()?;
+
+        Ok(paths)
     }
+}
+
+/// Snapshot all files under a directory: relative path -> (file size, sha256 hex).
+///
+/// Provides immutable proof that the installation directory was not touched or modified.
+pub fn snapshot_directory(root: &Path) -> Result<BTreeMap<String, (u64, String)>, std::io::Error> {
+    let mut files = BTreeMap::new();
+    if !root.exists() {
+        return Ok(files);
+    }
+    collect_directory_files(root, root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_directory_files(
+    base: &Path,
+    current: &Path,
+    files: &mut BTreeMap<String, (u64, String)>,
+) -> Result<(), std::io::Error> {
+    for entry in fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_directory_files(base, &path, files)?;
+        } else if file_type.is_file() {
+            let relative = path
+                .strip_prefix(base)
+                .map_err(std::io::Error::other)?
+                .to_string_lossy()
+                .replace('\\', "/");
+            let data = fs::read(&path)?;
+            let size = data.len() as u64;
+            let digest = Sha256::digest(&data);
+            let mut hash = String::with_capacity(64);
+            for byte in digest {
+                use std::fmt::Write as _;
+                let _ = write!(hash, "{byte:02x}");
+            }
+            files.insert(relative, (size, hash));
+        }
+    }
+    Ok(())
 }
 
 fn resolve_install_root() -> Result<PathBuf, String> {
     if let Some(value) = std::env::var_os("SKY_INSTALL_ROOT") {
-        let path = PathBuf::from(&value);
-        return fs::canonicalize(&path)
-            .or(Ok(path))
-            .map_err(|error: std::io::Error| format!("invalid SKY_INSTALL_ROOT: {error}"));
+        return fs::canonicalize(value)
+            .map_err(|error| format!("invalid SKY_INSTALL_ROOT: {error}"));
     }
     if cfg!(debug_assertions) {
         let root = std::env::var_os("SKY_DESKTOP_REPOSITORY_ROOT")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../.."));
-        return fs::canonicalize(&root)
-            .or(Ok(root))
-            .map_err(|error: std::io::Error| format!("invalid debug repository root: {error}"));
+        return fs::canonicalize(root)
+            .map_err(|error| format!("invalid debug repository root: {error}"));
     }
     let executable =
         std::env::current_exe().map_err(|error| format!("cannot resolve executable: {error}"))?;
@@ -336,49 +405,113 @@ mod tests {
     }
 
     #[test]
-    fn resolve_songs_dir_never_resolves_relative_to_install_root() {
+    fn resolve_songs_dir_resolves_valid_relative_and_absolute_paths() {
         let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
         let app_data =
             PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
         let paths = AppPaths::from_app_data_root(install_root.clone(), app_data.clone());
 
         // Default relative "songs" resolves to user music root under app data
-        let default_songs = paths.resolve_songs_dir("songs");
+        let default_songs = paths.resolve_songs_dir("songs").expect("valid songs");
         assert_eq!(default_songs, app_data.join("songs"));
         assert!(!default_songs.starts_with(&install_root));
 
         // Subdirectory under user music
-        let sub = paths.resolve_songs_dir("custom_sub");
+        let sub = paths
+            .resolve_songs_dir("custom_sub")
+            .expect("valid subpath");
         assert_eq!(sub, app_data.join("songs").join("custom_sub"));
         assert!(!sub.starts_with(&install_root));
 
-        // Absolute path stays absolute
-        let abs = paths.resolve_songs_dir(r"D:\MyMusic\SkySheets");
+        // Absolute external path is preserved
+        let abs = paths
+            .resolve_songs_dir(r"D:\MyMusic\SkySheets")
+            .expect("valid external abs");
         assert_eq!(abs, PathBuf::from(r"D:\MyMusic\SkySheets"));
         assert!(!abs.starts_with(&install_root));
     }
 
     #[test]
-    fn ownership_predicates_distinguish_installer_and_app_data() {
+    fn resolve_songs_dir_rejects_relative_parent_traversal() {
         let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
         let app_data =
             PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
-        let paths = AppPaths::from_app_data_root(install_root.clone(), app_data.clone());
+        let paths = AppPaths::from_app_data_root(install_root, app_data);
 
-        let binary = paths.calibration_binary_path();
-        assert!(paths.is_installer_owned(&binary));
-        assert!(!paths.is_app_data_owned(&binary));
+        // Relative parent escape: "../escaped"
+        let err = paths.resolve_songs_dir("../escaped").unwrap_err();
+        assert!(err.contains("parent directory traversal ('..')"), "{err}");
 
-        let settings = paths.settings_path();
-        assert!(!paths.is_installer_owned(&settings));
-        assert!(paths.is_app_data_owned(&settings));
+        // Nested traversal: "songs/../../escaped"
+        let err = paths.resolve_songs_dir("songs/../../escaped").unwrap_err();
+        assert!(err.contains("parent directory traversal ('..')"), "{err}");
+    }
 
-        let manifest = paths.library_manifest_path();
-        assert!(!paths.is_installer_owned(&manifest));
-        assert!(paths.is_app_data_owned(&manifest));
+    #[test]
+    fn resolve_songs_dir_rejects_absolute_path_inside_install_root() {
+        let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
+        let app_data =
+            PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
+        let paths = AppPaths::from_app_data_root(install_root.clone(), app_data);
 
-        let cache = paths.calibration_cache_path();
-        assert!(!paths.is_installer_owned(&cache));
-        assert!(paths.is_app_data_owned(&cache));
+        // Absolute path targeting inside the installer-owned root
+        let inside = install_root.join("songs");
+        let err = paths
+            .resolve_songs_dir(&inside.display().to_string())
+            .unwrap_err();
+        assert!(err.contains("must not reside inside install root"), "{err}");
+    }
+
+    #[test]
+    fn snapshot_directory_detects_additions_modifications_and_deletions() {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let temp = std::env::temp_dir().join(format!("sky-snapshot-test-{suffix}"));
+        fs::create_dir_all(&temp).expect("create temp");
+
+        let file_a = temp.join("a.txt");
+        let sub = temp.join("sub");
+        fs::create_dir_all(&sub).expect("create sub");
+        let file_b = sub.join("b.txt");
+
+        fs::write(&file_a, b"content a").expect("write a");
+        fs::write(&file_b, b"content b").expect("write b");
+
+        let snap1 = snapshot_directory(&temp).expect("snapshot 1");
+        assert_eq!(snap1.len(), 2);
+        assert!(snap1.contains_key("a.txt"));
+        assert!(snap1.contains_key("sub/b.txt"));
+
+        // Exact equality when unchanged
+        let snap2 = snapshot_directory(&temp).expect("snapshot 2");
+        assert_eq!(snap1, snap2);
+
+        // Modification is detected
+        fs::write(&file_a, b"modified content a").expect("modify a");
+        let snap_modified = snapshot_directory(&temp).expect("snapshot modified");
+        assert_ne!(snap1, snap_modified);
+
+        // Restore file_a
+        fs::write(&file_a, b"content a").expect("restore a");
+
+        // Addition is detected
+        let file_c = temp.join("c.txt");
+        fs::write(&file_c, b"content c").expect("write c");
+        let snap_added = snapshot_directory(&temp).expect("snapshot added");
+        assert_ne!(snap1, snap_added);
+        assert_eq!(snap_added.len(), 3);
+
+        // Deletion is detected
+        fs::remove_file(&file_c).expect("remove c");
+        fs::remove_file(&file_b).expect("remove b");
+        let snap_deleted = snapshot_directory(&temp).expect("snapshot deleted");
+        assert_ne!(snap1, snap_deleted);
+        assert_eq!(snap_deleted.len(), 1);
+
+        let _ = fs::remove_dir_all(&temp);
     }
 }

--- a/rust/crates/sky_native_adapters/tests/install_root_contract.rs
+++ b/rust/crates/sky_native_adapters/tests/install_root_contract.rs
@@ -1,12 +1,117 @@
-use sky_native_adapters::{FileCatalogSource, JsonSettingsStore};
+use sky_app_core::library::LibraryManifestService;
+use sky_app_core::settings::SettingsService;
+use sky_native_adapters::{
+    AppPaths, FileCatalogSource, JsonLibraryManifestStore, JsonSettingsStore,
+};
+use std::fs;
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[test]
-fn packaged_adapters_use_the_explicit_install_root_contract() {
-    let install_root = PathBuf::from(r"C:\Program Files\Sky Auto Player");
-    let settings = JsonSettingsStore::new(install_root.join("config.json"));
-    let catalog = FileCatalogSource::new(install_root.join("songs"));
+fn v4_adapters_enforce_clean_application_data_boundary() {
+    let install_root = PathBuf::from(r"C:\Users\tester\AppData\Local\Programs\Sky Auto Player");
+    let app_data_root =
+        PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
+    let paths = AppPaths::from_app_data_root(install_root.clone(), app_data_root.clone());
 
-    assert_eq!(settings.path(), install_root.join("config.json").as_path());
-    assert_eq!(catalog.root(), install_root.join("songs").as_path());
+    // Clean boundary: mutable roots must not reside inside install root
+    assert!(paths.assert_clean_boundary().is_ok());
+
+    // Settings store uses app-data config path, not install root
+    let settings = JsonSettingsStore::new(paths.settings_path());
+    assert_eq!(settings.path(), app_data_root.join("config.json").as_path());
+    assert!(!settings.path().starts_with(&install_root));
+
+    // Library manifest store uses app-data data path, not install root
+    let manifest = JsonLibraryManifestStore::new(paths.library_manifest_path());
+    assert_eq!(
+        manifest.path(),
+        app_data_root.join("library-manifest.json").as_path()
+    );
+    assert!(!manifest.path().starts_with(&install_root));
+
+    // Catalog source uses resolved songs dir outside install root
+    let default_songs = paths.resolve_songs_dir("songs");
+    let catalog = FileCatalogSource::new(&default_songs);
+    assert_eq!(catalog.root(), app_data_root.join("songs").as_path());
+    assert!(!catalog.root().starts_with(&install_root));
+
+    // Calibration cache lives in app data cache, not install root
+    assert_eq!(
+        paths.calibration_cache_path(),
+        app_data_root.join("cache").join("input_latency.json")
+    );
+    assert!(!paths.calibration_cache_path().starts_with(&install_root));
+
+    // Only immutable executable payload lives in install root
+    assert_eq!(
+        paths.calibration_binary_path(),
+        install_root.join("native_calibration.exe")
+    );
+    assert!(paths.calibration_binary_path().starts_with(&install_root));
+}
+
+#[test]
+#[allow(clippy::permissions_set_readonly_false)]
+fn v4_adapters_operate_with_read_only_install_root() {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    let temp = std::env::temp_dir().join(format!("sky-appdata-contract-test-{suffix}"));
+    let install_root = temp.join("install");
+    let app_data_root = temp.join("app_data");
+
+    fs::create_dir_all(&install_root).expect("create install root");
+    // Place simulated immutable binaries in install root
+    let binary = install_root.join("native_calibration.exe");
+    fs::write(&binary, b"simulated-binary-payload").expect("write binary");
+
+    // Make install root and its payload read-only
+    let mut perms = fs::metadata(&binary).expect("meta").permissions();
+    perms.set_readonly(true);
+    fs::set_permissions(&binary, perms).expect("set readonly file");
+
+    let paths = AppPaths::from_app_data_root(install_root.clone(), app_data_root.clone());
+    paths
+        .ensure_mutable_directories()
+        .expect("ensure app data dirs");
+
+    // Settings store loads and saves in app data while install root is immutable
+    let settings_store = JsonSettingsStore::new(paths.settings_path());
+    let mut settings_service = SettingsService::load(settings_store).expect("load settings");
+    let patch = sky_app_core::settings::SettingsPatch {
+        theme: Some("slate".into()),
+        ..Default::default()
+    };
+    settings_service
+        .patch(&patch)
+        .expect("patch settings must succeed into app_data");
+
+    // Verify settings was saved into app_data_root, not install_root
+    assert!(paths.settings_path().exists());
+    assert!(!install_root.join("config.json").exists());
+
+    // Library manifest loads and saves in app data
+    let manifest_store = JsonLibraryManifestStore::new(paths.library_manifest_path());
+    let mut manifest_service = LibraryManifestService::load(manifest_store).expect("load manifest");
+    manifest_service
+        .create_collection("0123456789abcdef0123456789abcdef", "Test Playlist")
+        .expect("create collection must succeed into app_data");
+
+    assert!(paths.library_manifest_path().exists());
+    assert!(!install_root.join("library-manifest.json").exists());
+
+    // Songs dir is created and read from app data
+    let test_song = paths.user_music_root().join("sample.json");
+    fs::write(&test_song, b"{\"title\":\"Test\"}").expect("write test song");
+    let catalog = FileCatalogSource::new(paths.resolve_songs_dir("songs"));
+    assert_eq!(catalog.root(), paths.user_music_root());
+    assert!(!install_root.join("songs").exists());
+
+    // Cleanup: restore write permission on install files so temp dir can be cleaned up
+    let mut perms = fs::metadata(&binary).expect("meta").permissions();
+    perms.set_readonly(false);
+    let _ = fs::set_permissions(&binary, perms);
+    let _ = fs::remove_dir_all(&temp);
 }

--- a/rust/crates/sky_native_adapters/tests/install_root_contract.rs
+++ b/rust/crates/sky_native_adapters/tests/install_root_contract.rs
@@ -162,3 +162,107 @@ fn v4_adapters_operate_with_immutable_install_payload_snapshot_proof() {
 
     let _ = fs::remove_dir_all(&temp);
 }
+
+#[test]
+fn v4_production_resolver_fails_closed_on_relative_or_nested_overrides() {
+    struct EnvCleanup {
+        vars: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+    impl EnvCleanup {
+        fn set(pairs: &[(&'static str, &std::path::Path)]) -> Self {
+            let mut vars = Vec::new();
+            for (k, v) in pairs {
+                vars.push((*k, std::env::var_os(k)));
+                unsafe {
+                    std::env::set_var(k, v);
+                }
+            }
+            Self { vars }
+        }
+        fn set_raw(pairs: &[(&'static str, &str)]) -> Self {
+            let mut vars = Vec::new();
+            for (k, v) in pairs {
+                vars.push((*k, std::env::var_os(k)));
+                unsafe {
+                    std::env::set_var(k, v);
+                }
+            }
+            Self { vars }
+        }
+    }
+    impl Drop for EnvCleanup {
+        fn drop(&mut self) {
+            for (k, prev) in &self.vars {
+                match prev {
+                    Some(val) => unsafe {
+                        std::env::set_var(k, val);
+                    },
+                    None => unsafe {
+                        std::env::remove_var(k);
+                    },
+                }
+            }
+        }
+    }
+
+    // 1. Relative SKY_APP_DATA_ROOT=. rejected
+    {
+        let _guard = EnvCleanup::set_raw(&[("SKY_APP_DATA_ROOT", ".")]);
+        let err = AppPaths::resolve().unwrap_err();
+        assert!(
+            err.contains("relative overrides are not permitted")
+                || err.contains("must be absolute"),
+            "unexpected: {err}"
+        );
+    }
+
+    // 2. Relative SKY_SONGS_DIR=songs rejected
+    {
+        let _guard = EnvCleanup::set_raw(&[("SKY_SONGS_DIR", "songs")]);
+        let err = AppPaths::resolve().unwrap_err();
+        assert!(
+            err.contains("relative overrides are not permitted")
+                || err.contains("must be absolute"),
+            "unexpected: {err}"
+        );
+    }
+
+    // 3. Absolute mutable root inside install root rejected
+    {
+        let temp = std::env::temp_dir().join(format!("sky-contract-inside-{}", std::process::id()));
+        let install_root = temp.join("install");
+        let nested_app_data = install_root.join("data");
+        fs::create_dir_all(&install_root).unwrap();
+
+        let _guard = EnvCleanup::set(&[
+            ("SKY_INSTALL_ROOT", &install_root),
+            ("SKY_APP_DATA_ROOT", &nested_app_data),
+        ]);
+        let err = AppPaths::resolve().unwrap_err();
+        assert!(
+            err.contains("must not reside inside install root")
+                || err.contains("canonically resolves inside install root"),
+            "unexpected: {err}"
+        );
+        let _ = fs::remove_dir_all(&temp);
+    }
+
+    // 4. Valid external absolute override accepted
+    {
+        let temp = std::env::temp_dir().join(format!("sky-contract-valid-{}", std::process::id()));
+        let install_root = temp.join("install");
+        let external_app_data = temp.join("app_data");
+        fs::create_dir_all(&install_root).unwrap();
+        fs::create_dir_all(&external_app_data).unwrap();
+
+        let _guard = EnvCleanup::set(&[
+            ("SKY_INSTALL_ROOT", &install_root),
+            ("SKY_APP_DATA_ROOT", &external_app_data),
+        ]);
+        let paths = AppPaths::resolve().expect("valid external override must succeed");
+        assert_eq!(paths.config_root(), external_app_data.as_path());
+        assert!(!paths.config_root().starts_with(&install_root));
+        assert!(paths.assert_clean_boundary().is_ok());
+        let _ = fs::remove_dir_all(&temp);
+    }
+}

--- a/rust/crates/sky_native_adapters/tests/install_root_contract.rs
+++ b/rust/crates/sky_native_adapters/tests/install_root_contract.rs
@@ -1,7 +1,7 @@
 use sky_app_core::library::LibraryManifestService;
 use sky_app_core::settings::SettingsService;
 use sky_native_adapters::{
-    AppPaths, FileCatalogSource, JsonLibraryManifestStore, JsonSettingsStore,
+    AppPaths, FileCatalogSource, JsonLibraryManifestStore, JsonSettingsStore, snapshot_directory,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -31,7 +31,7 @@ fn v4_adapters_enforce_clean_application_data_boundary() {
     assert!(!manifest.path().starts_with(&install_root));
 
     // Catalog source uses resolved songs dir outside install root
-    let default_songs = paths.resolve_songs_dir("songs");
+    let default_songs = paths.resolve_songs_dir("songs").expect("valid songs dir");
     let catalog = FileCatalogSource::new(&default_songs);
     assert_eq!(catalog.root(), app_data_root.join("songs").as_path());
     assert!(!catalog.root().starts_with(&install_root));
@@ -52,8 +52,50 @@ fn v4_adapters_enforce_clean_application_data_boundary() {
 }
 
 #[test]
-#[allow(clippy::permissions_set_readonly_false)]
-fn v4_adapters_operate_with_read_only_install_root() {
+fn v4_songs_dir_resolution_fails_closed_on_escapes() {
+    let install_root = PathBuf::from(r"C:\Users\tester\AppData\Local\Programs\Sky Auto Player");
+    let app_data_root =
+        PathBuf::from(r"C:\Users\tester\AppData\Local\io.github.pumni.skyautoplayer");
+    let paths = AppPaths::from_app_data_root(install_root.clone(), app_data_root.clone());
+
+    // 1. Rejects relative parent traversal '..'
+    let traversal_err = paths.resolve_songs_dir("../escaped").unwrap_err();
+    assert!(
+        traversal_err.contains("parent directory traversal ('..')"),
+        "unexpected error: {traversal_err}"
+    );
+
+    // 2. Rejects nested parent traversal
+    let nested_traversal_err = paths.resolve_songs_dir("sub/../../escaped").unwrap_err();
+    assert!(
+        nested_traversal_err.contains("parent directory traversal ('..')"),
+        "unexpected error: {nested_traversal_err}"
+    );
+
+    // 3. Rejects absolute path pointing inside install root
+    let inside_install = install_root.join("songs");
+    let inside_err = paths
+        .resolve_songs_dir(&inside_install.display().to_string())
+        .unwrap_err();
+    assert!(
+        inside_err.contains("must not reside inside install root"),
+        "unexpected error: {inside_err}"
+    );
+
+    // 4. Preserves valid external absolute path
+    let external_abs = PathBuf::from(r"D:\ExternalLibrary\Sheets");
+    let resolved_abs = paths
+        .resolve_songs_dir(&external_abs.display().to_string())
+        .expect("valid external");
+    assert_eq!(resolved_abs, external_abs);
+
+    // 5. Resolves valid relative subfolder under user_music_root
+    let sub = paths.resolve_songs_dir("custom").expect("valid sub");
+    assert_eq!(sub, app_data_root.join("songs").join("custom"));
+}
+
+#[test]
+fn v4_adapters_operate_with_immutable_install_payload_snapshot_proof() {
     let suffix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("clock")
@@ -63,21 +105,22 @@ fn v4_adapters_operate_with_read_only_install_root() {
     let app_data_root = temp.join("app_data");
 
     fs::create_dir_all(&install_root).expect("create install root");
-    // Place simulated immutable binaries in install root
+    // Place simulated immutable binaries and resources in install root
     let binary = install_root.join("native_calibration.exe");
     fs::write(&binary, b"simulated-binary-payload").expect("write binary");
+    let resource = install_root.join("resources.pak");
+    fs::write(&resource, b"simulated-resource-payload").expect("write resource");
 
-    // Make install root and its payload read-only
-    let mut perms = fs::metadata(&binary).expect("meta").permissions();
-    perms.set_readonly(true);
-    fs::set_permissions(&binary, perms).expect("set readonly file");
+    // Cryptographic snapshot before any runtime adapter interaction
+    let install_snapshot_before =
+        snapshot_directory(&install_root).expect("snapshot install before");
 
     let paths = AppPaths::from_app_data_root(install_root.clone(), app_data_root.clone());
     paths
         .ensure_mutable_directories()
         .expect("ensure app data dirs");
 
-    // Settings store loads and saves in app data while install root is immutable
+    // Settings store loads and saves in app data
     let settings_store = JsonSettingsStore::new(paths.settings_path());
     let mut settings_service = SettingsService::load(settings_store).expect("load settings");
     let patch = sky_app_core::settings::SettingsPatch {
@@ -105,13 +148,17 @@ fn v4_adapters_operate_with_read_only_install_root() {
     // Songs dir is created and read from app data
     let test_song = paths.user_music_root().join("sample.json");
     fs::write(&test_song, b"{\"title\":\"Test\"}").expect("write test song");
-    let catalog = FileCatalogSource::new(paths.resolve_songs_dir("songs"));
+    let default_songs = paths.resolve_songs_dir("songs").expect("resolve songs");
+    let catalog = FileCatalogSource::new(&default_songs);
     assert_eq!(catalog.root(), paths.user_music_root());
     assert!(!install_root.join("songs").exists());
 
-    // Cleanup: restore write permission on install files so temp dir can be cleaned up
-    let mut perms = fs::metadata(&binary).expect("meta").permissions();
-    perms.set_readonly(false);
-    let _ = fs::set_permissions(&binary, perms);
+    // Cryptographic proof: entire install payload is completely byte-for-byte unchanged
+    let install_snapshot_after = snapshot_directory(&install_root).expect("snapshot install after");
+    assert_eq!(
+        install_snapshot_before, install_snapshot_after,
+        "install payload must remain 100% byte-for-byte identical throughout adapter operations"
+    );
+
     let _ = fs::remove_dir_all(&temp);
 }

--- a/rust/xtask/src/dist.rs
+++ b/rust/xtask/src/dist.rs
@@ -494,6 +494,7 @@ fn run_packaged_selftests(release_dir: &Path, python_unavailable: bool) -> Resul
     }
     fs::create_dir_all(&smoke_app_data)?;
     copy_tree(release_dir, &smoke_dir)?;
+    let smoke_snapshot_before = snapshot_tree(&smoke_dir)?;
     let phase_log = smoke_app_data.join("gui-smoke-phases.log");
     let _ = fs::remove_file(&phase_log);
     let path_value = if python_unavailable {
@@ -539,6 +540,10 @@ fn run_packaged_selftests(release_dir: &Path, python_unavailable: bool) -> Resul
             &env,
             PACKAGED_SMOKE_TIMEOUT,
         )?;
+        let smoke_snapshot_after = snapshot_tree(&smoke_dir)?;
+        if smoke_snapshot_before != smoke_snapshot_after {
+            return Err("packaged smoke modified immutable installation payload".into());
+        }
         Ok(())
     })();
     let result_error = result.err();
@@ -559,6 +564,36 @@ fn run_packaged_selftests(release_dir: &Path, python_unavailable: bool) -> Resul
     cleanup?;
     if let Some(error) = result_error {
         return Err(error);
+    }
+    Ok(())
+}
+
+fn snapshot_tree(root: &Path) -> Result<std::collections::BTreeMap<String, (u64, String)>> {
+    let mut files = std::collections::BTreeMap::new();
+    collect_tree(root, root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_tree(
+    base: &Path,
+    current: &Path,
+    files: &mut std::collections::BTreeMap<String, (u64, String)>,
+) -> Result<()> {
+    for entry in fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_tree(base, &path, files)?;
+        } else if file_type.is_file() {
+            let relative = path
+                .strip_prefix(base)?
+                .to_string_lossy()
+                .replace('\\', "/");
+            let size = fs::metadata(&path)?.len();
+            let hash = manifest::sha256(&path)?;
+            files.insert(relative, (size, hash));
+        }
     }
     Ok(())
 }

--- a/rust/xtask/src/dist.rs
+++ b/rust/xtask/src/dist.rs
@@ -477,11 +477,24 @@ fn run_packaged_selftests(release_dir: &Path, python_unavailable: bool) -> Resul
             "normal"
         }
     ));
+    let smoke_app_data = std::env::temp_dir().join(format!(
+        "sky-xtask-packaged-smoke-appdata-{}-{}",
+        std::process::id(),
+        if python_unavailable {
+            "restricted"
+        } else {
+            "normal"
+        }
+    ));
     if smoke_dir.exists() {
         fs::remove_dir_all(&smoke_dir)?;
     }
+    if smoke_app_data.exists() {
+        fs::remove_dir_all(&smoke_app_data)?;
+    }
+    fs::create_dir_all(&smoke_app_data)?;
     copy_tree(release_dir, &smoke_dir)?;
-    let phase_log = smoke_dir.join("gui-smoke-phases.log");
+    let phase_log = smoke_app_data.join("gui-smoke-phases.log");
     let _ = fs::remove_file(&phase_log);
     let path_value = if python_unavailable {
         let system_root = std::env::var_os("SystemRoot")
@@ -505,6 +518,11 @@ fn run_packaged_selftests(release_dir: &Path, python_unavailable: bool) -> Resul
             "SKY_GUI_SMOKE_PHASE_LOG".into(),
             phase_log.display().to_string(),
         ),
+        (
+            "SKY_APP_DATA_ROOT".into(),
+            smoke_app_data.display().to_string(),
+        ),
+        ("LOCALAPPDATA".into(), smoke_app_data.display().to_string()),
     ];
     let result = (|| -> Result<()> {
         process::run_owned_timeout(
@@ -537,6 +555,7 @@ fn run_packaged_selftests(release_dir: &Path, python_unavailable: bool) -> Resul
         eprintln!("[xtask] packaged smoke failure: {error}");
     }
     let cleanup = fs::remove_dir_all(&smoke_dir);
+    let _ = fs::remove_dir_all(&smoke_app_data);
     cleanup?;
     if let Some(error) = result_error {
         return Err(error);


### PR DESCRIPTION
## Summary

Addresses #104 (WO-02) per ADR-0006.

This PR establishes the clean v4 application data boundary, ensuring the installer owns only immutable application payloads (`Sky Auto Player.exe`, `native_calibration.exe`, resources) while all mutable state lives in standard OS application-data locations under the permanent v4 application identifier `io.github.pumni.skyautoplayer`.

### Key Changes
- **Typed Path Authority (`AppPaths`)**: Introduced `sky_native_adapters::AppPaths` as the central typed authority for:
  - `install_root`: Immutable installer-owned payload.
  - `config_root`: Application settings (`config.json`).
  - `data_root`: Library database and manifest (`library-manifest.json`).
  - `cache_root`: Device calibration cache (`input_latency.json`).
  - `logs_root`: Application logs.
  - `user_music_root`: Base location for user-owned music sheets (`songs/`).
- **Desktop Runtime Composition Root**: Updated `NativeDesktopRuntime`, `NativeCalibrationService`, and `AppState` to accept and resolve typed `AppPaths`.
- **Music Resolution Boundary**: Song paths resolve against user-owned storage (`user_music_root` or absolute path), never against `install_root`.
- **Packaging Smoke Test**: Updated `rust/xtask/src/dist.rs` to isolate test app-data via `SKY_APP_DATA_ROOT` and `LOCALAPPDATA`.
- **Contract & Regression Tests**:
  - Replaced `install_root_contract.rs` with v4 app-data boundary assertions and a read-only install-root execution test.
  - Added desktop runtime integration test `v4_runtime_operates_with_read_only_install_root_and_separate_app_data` verifying settings mutations, catalog indexing, and calibration cache writes with a read-only install payload.
  - Boundary assertions prevent nesting mutable roots inside the install root.

### Overlap with WO-01
- Overlap with WO-01 is minimal. WO-01 operates on Tauri packaging configuration (`tauri.conf.json`, NSIS scripts, bundling). The desktop composition changes here only touch runtime path wiring in `native_runtime.rs`, `app_state.rs`, and `lib.rs`.

### Verification
- `cargo xtask check rust` -> **PASS**
- `cargo xtask check static` -> **PASS** (zero-Python, line budgets, cargo-vet supply chain, security boundary)
- `cargo xtask check desktop` -> **PASS** (TypeScript check, e2e tests, mock Tauri tests)
