### PR TITLE
feat(v4): establish Tauri NSIS packaging foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,10 @@ jobs:
         working-directory: desktop
         run: bun install --frozen-lockfile
 
+      - name: Build pinned desktop frontend
+        working-directory: desktop
+        run: bun run build
+
       - name: Construct Python-unavailable canonical environment
         run: |
           $required = @("cargo", "rustc", "rustup", "git", "bun", "bunx", "link", "rc", "sccache")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
         run: pwsh scripts/ci_job_timing.ps1 -Mode finish -Job validate -CacheHit "${{ steps.rust-cache.outputs.cache-hit }}"
 
   packaged:
-    name: Packaged frozen unsigned app smoke
+    name: Packaged v4 Tauri NSIS qualification
     needs: changes
     if: needs.changes.outputs.package_required == 'true'
     runs-on: windows-latest
@@ -500,6 +500,10 @@ jobs:
         with:
           bun-version: 1.4.0
 
+      - name: Install pinned desktop dependencies
+        working-directory: desktop
+        run: bun install --frozen-lockfile
+
       - name: Construct Python-unavailable canonical environment
         run: |
           $required = @("cargo", "rustc", "rustup", "git", "bun", "bunx", "link", "rc", "sccache")
@@ -528,39 +532,93 @@ jobs:
             "$name=" | Add-Content $env:GITHUB_ENV -Encoding UTF8
           }
 
-      - name: Build and qualify exact portable artifact
+      - name: Build and sign Tauri NSIS test artifact
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
         run: |
-          $output = Join-Path $env:RUNNER_TEMP "Sky Auto Player portable"
-          cargo xtask dist --profile dist --output $output
-          "SKY_PORTABLE_OUTPUT=$output" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          $keyPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-test.key"
+          $configPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-test-updater.json"
+          try {
+            Push-Location desktop
+            try {
+              bun run tauri signer generate --ci --password "" --force -w $keyPath
+              $privateKey = (Get-Content -LiteralPath $keyPath -Raw).Trim()
+              $testPublicKey = (Get-Content -LiteralPath "$keyPath.pub" -Raw).Trim()
+              [ordered]@{
+                plugins = [ordered]@{
+                  updater = [ordered]@{
+                    pubkey = $testPublicKey
+                    endpoints = @("https://example.invalid/sky-auto-player/{{target}}/{{arch}}/{{current_version}}")
+                  }
+                }
+              } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $configPath -Encoding utf8
+              $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
+              $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
+              bun run tauri build --ci --config $configPath -- --profile dist
+            } finally {
+              Pop-Location
+            }
+            "SKY_TAURI_BUNDLE=$(Join-Path $env:GITHUB_WORKSPACE 'rust/target/dist/bundle/nsis')" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          } finally {
+            Remove-Item -LiteralPath $keyPath, "$keyPath.pub", $configPath -Force -ErrorAction SilentlyContinue
+            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
+            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+          }
 
-      - name: Verify packaged release tree
+      - name: Verify exact Tauri NSIS bundle
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
         run: |
-          $version = (cargo xtask version check | Select-String '^version=').ToString().Substring(8)
-          cargo xtask verify-dist --release-dir (Join-Path $env:SKY_PORTABLE_OUTPUT "Sky-Auto-Player-v$version")
+          cargo xtask verify-tauri-bundle `
+            --bundle-dir $env:SKY_TAURI_BUNDLE `
+            --summary rust/target/dist/TAURI_ARTIFACT_SUMMARY.json
 
-      - name: Report exact portable artifact identity
-        shell: pwsh
+      - name: Report exact Tauri NSIS artifact identity
         run: |
-          $summary = Get-Content (Join-Path $env:SKY_PORTABLE_OUTPUT "PORTABLE_ARTIFACT_SUMMARY.json") -Raw | ConvertFrom-Json
+          $summary = Get-Content rust/target/dist/TAURI_ARTIFACT_SUMMARY.json -Raw | ConvertFrom-Json
           @"
-          ## Exact portable artifact
-          - repo head: ``$($summary.repo_head)``
-          - ZIP: ``$($summary.artifact_name)`` ($($summary.artifact_size) bytes)
-          - ZIP SHA-256: ``$($summary.artifact_sha256)``
-          - MANIFEST SHA-256: ``$($summary.manifest_sha256)``
-          - portable files: $($summary.portable_file_count)
-          - managed entries: $($summary.managed_entry_count)
+          ## Tauri NSIS artifact
+          - identifier: ``$($summary.identifier)``
+          - version: ``$($summary.version)``
+          - installer: ``$($summary.installer)`` ($($summary.installer_size) bytes)
+          - updater signature: ``$($summary.updater_signature)`` ($($summary.signature_size) bytes)
+          - target: ``$($summary.target)``
+          - install mode: ``$($summary.install_mode)``
           "@ | Add-Content $env:GITHUB_STEP_SUMMARY -Encoding UTF8
-          Get-Content (Join-Path $env:SKY_PORTABLE_OUTPUT "PROVENANCE.json")
 
-      - name: Upload exact portable release candidate
+      - name: Qualify current-user install, launch, and uninstall
+        run: |
+          $summary = Get-Content rust/target/dist/TAURI_ARTIFACT_SUMMARY.json -Raw | ConvertFrom-Json
+          $installer = Join-Path $env:SKY_TAURI_BUNDLE $summary.installer
+          $installRoot = Join-Path $env:RUNNER_TEMP ("sky-auto-player-v4-smoke-" + [guid]::NewGuid().ToString("N"))
+          $appPath = Join-Path $installRoot "sky_desktop_shell.exe"
+          $uninstaller = Join-Path $installRoot "uninstall.exe"
+          $appProcess = $null
+          $installerRun = Start-Process -FilePath $installer -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
+          if ($installerRun.ExitCode -ne 0) { throw "Tauri NSIS installer exited with $($installerRun.ExitCode)" }
+          try {
+            if (-not (Test-Path -LiteralPath $appPath)) { throw "Installed Tauri executable is missing: $appPath" }
+            if (-not (Test-Path -LiteralPath $uninstaller)) { throw "Tauri uninstaller is missing: $uninstaller" }
+            $appProcess = Start-Process -FilePath $appPath -WindowStyle Hidden -PassThru
+            Start-Sleep -Seconds 5
+            if ($appProcess.HasExited) { throw "Packaged Tauri application exited during launch smoke (exit $($appProcess.ExitCode))" }
+            Stop-Process -Id $appProcess.Id -Force
+            $appProcess = $null
+            $uninstallerRun = Start-Process -FilePath $uninstaller -ArgumentList @("/S") -WindowStyle Hidden -Wait -PassThru
+            if ($uninstallerRun.ExitCode -ne 0) { throw "Tauri uninstaller exited with $($uninstallerRun.ExitCode)" }
+            "Tauri NSIS install/launch/uninstall: PASS (installer=$($installerRun.ExitCode), uninstaller=$($uninstallerRun.ExitCode))" | Add-Content $env:GITHUB_STEP_SUMMARY -Encoding UTF8
+          } finally {
+            if ($null -ne $appProcess -and -not $appProcess.HasExited) { Stop-Process -Id $appProcess.Id -Force -ErrorAction SilentlyContinue }
+            if (Test-Path -LiteralPath $installRoot) { Remove-Item -LiteralPath $installRoot -Recurse -Force }
+          }
+
+      - name: Upload exact Tauri NSIS release candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sky-auto-player-portable-${{ github.event.pull_request.head.sha || github.sha }}
-          path: ${{ runner.temp }}/Sky Auto Player portable
+          name: sky-auto-player-tauri-nsis-${{ github.event.pull_request.head.sha || github.sha }}
+          path: |
+            rust/target/dist/bundle/nsis
+            rust/target/dist/TAURI_ARTIFACT_SUMMARY.json
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,18 @@ jobs:
           fetch-tags: false
           persist-credentials: false
 
+      # Temporary WO-01 isolation guard. Replace this with the dedicated v4
+      # release authority delivered by WO-04/WO-07.
+      - name: Block v4+ tags from legacy v3 release workflow
+        run: |
+          $tag = $env:GITHUB_REF_NAME
+          if ($tag -match '^v(?<major>\d+)\.') {
+            $major = [int64]$Matches.major
+            if ($major -ge 4) {
+              throw "v4 publication is disabled in the legacy v3 release workflow until the dedicated release authority work order is complete: $tag"
+            }
+          }
+
       - name: Fetch Wave-6 retirement baseline commit for static checks
         run: |
           $ledger = Get-Content "docs/migration/wave6-tooling-retirement-ledger.json" -Raw | ConvertFrom-Json

--- a/desktop/bun.lock
+++ b/desktop/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "@tanstack/react-virtual": "3.14.10",
         "@tauri-apps/api": "2.11.1",
+        "@tauri-apps/plugin-process": "2.3.1",
+        "@tauri-apps/plugin-updater": "2.11.0",
         "lucide-react": "1.34.0",
         "react": "19.2.8",
         "react-aria-components": "1.20.0",
@@ -251,6 +253,10 @@
     "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.11.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA=="],
 
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.11.0", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-AE36XkOoSna24G40jZMY15nzAnkXEPL/73tGoseGrtGOHuI/cZwWzHpZFLjKXDPgzYZ435z1gHu28LgrsBwIxQ=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,11 +15,13 @@
     "test:e2e": "node scripts/run-e2e.mjs",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build --profile dist",
+    "tauri:build": "tauri build --ci -- --profile dist",
     "check": "bun run typecheck && bun run lint && bun run format:check && bun run test && bun run build:web"
   },
   "dependencies": {
     "@tauri-apps/api": "2.11.1",
+    "@tauri-apps/plugin-process": "2.3.1",
+    "@tauri-apps/plugin-updater": "2.11.0",
     "@tanstack/react-virtual": "3.14.10",
     "lucide-react": "1.34.0",
     "react": "19.2.8",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "3.5.0"
+version = "4.0.0-alpha.1"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true
@@ -35,6 +35,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "=2.11.5", default-features = false, features = [] }
 tauri-plugin-dialog = "=2.7.3"
+tauri-plugin-process = "=2.3.1"
 sky_dispatch_win32 = { path = "../../rust/crates/sky_dispatch_win32" }
 sky_player = { path = "../../rust/crates/sky_player" }
 sha2 = "0.11"
@@ -45,6 +46,9 @@ sky_updater = { path = "../../rust/crates/sky_updater" }
 ts-rs = { version = "=12.0.1", features = ["serde-json-impl"] }
 thiserror = "2"
 getrandom = "0.3"
+
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-updater = "=2.11.0"
 
 [target.'cfg(windows)'.dependencies]
 raw-window-handle = "0.6"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Sky Auto Player",
-  "version": "3.5.0",
-  "identifier": "com.skyautoplayer.desktop",
+  "identifier": "io.github.pumni.skyautoplayer",
   "build": {
     "beforeDevCommand": "bun run dev -- --host 127.0.0.1",
     "devUrl": "http://127.0.0.1:1420",
@@ -30,8 +29,14 @@
     }
   },
   "bundle": {
-    "active": false,
+    "active": true,
     "icon": ["icons/icon.ico"],
-    "targets": "all"
+    "targets": ["nsis"],
+    "createUpdaterArtifacts": true,
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser"
+      }
+    }
   }
 }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,6 +42,8 @@ not open every architecture page by default.
 - [../SECURITY.md](../SECURITY.md) — canonical security policy and disclosure process.
 - [distribution-and-update.md](distribution-and-update.md) — public package, native updater,
   integrity/provenance, rollback, and release contract.
+- [v4-tauri-packaging.md](v4-tauri-packaging.md) — v4 local Tauri NSIS/updater artifact qualification
+  and current-user packaging contract.
 - [rust-toolchain-policy.md](rust-toolchain-policy.md) — Rust compiler/toolchain policy.
 - [wave5-legacy-python-retirement.md](wave5-legacy-python-retirement.md) — historical evidence for
   the completed product/runtime Python retirement; not a tooling instruction.

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -15,6 +15,10 @@ production updater key, or switching the runtime update path.
 - Updater output: the NSIS setup executable and its `.exe.sig` sidecar
 - Legacy `sky_updater`: retained and buildable until the later retirement work order
 
+The legacy `cargo xtask dist` portable assembler remains available for the
+v3-maintenance line but fails closed when run against the canonical v4 source.
+It is not a v4 packaging entry point.
+
 The Tauri config intentionally omits its optional `version` field so Cargo
 remains the single v4 version source. `cargo xtask check static` rejects
 version/config drift and any updater endpoint or trust key added during this

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -27,7 +27,10 @@ non-production local fixture and must remain outside the repository:
 
 ```powershell
 $keyPath = Join-Path $env:TEMP "sky-auto-player-v4-test.key"
-bunx tauri signer generate --ci --password "" --force -w $keyPath
+Push-Location desktop
+bun install --frozen-lockfile
+bun run tauri signer generate --ci --password "" --force -w $keyPath
+Pop-Location
 $env:TAURI_SIGNING_PRIVATE_KEY = (Get-Content $keyPath -Raw).Trim()
 $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
 $testConfigPath = Join-Path $env:TEMP "sky-auto-player-v4-test-updater.json"

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -1,0 +1,76 @@
+# V4 Tauri Packaging Foundation
+
+V4 uses the Tauri Windows bundler as its canonical package producer. The
+current foundation is intentionally local-only: it enables the NSIS package
+and updater artifact generation without publishing an endpoint, embedding a
+production updater key, or switching the runtime update path.
+
+## Canonical package contract
+
+- Application identifier: `io.github.pumni.skyautoplayer`
+- Version source: `desktop/src-tauri/Cargo.toml`
+- Current foundation version: `4.0.0-alpha.1`
+- Windows target: NSIS only
+- Installer scope: `currentUser` under `%LOCALAPPDATA%`
+- Updater output: the NSIS setup executable and its `.exe.sig` sidecar
+- Legacy `sky_updater`: retained and buildable until the later retirement work order
+
+The Tauri config intentionally omits its optional `version` field so Cargo
+remains the single v4 version source. `cargo xtask check static` rejects
+version/config drift and any updater endpoint or trust key added during this
+foundation phase.
+
+## Local Windows package qualification
+
+Run these commands from PowerShell on Windows. The signing key is a
+non-production local fixture and must remain outside the repository:
+
+```powershell
+$keyPath = Join-Path $env:TEMP "sky-auto-player-v4-test.key"
+bunx tauri signer generate --ci --password "" --force -w $keyPath
+$env:TAURI_SIGNING_PRIVATE_KEY = (Get-Content $keyPath -Raw).Trim()
+$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
+$testConfigPath = Join-Path $env:TEMP "sky-auto-player-v4-test-updater.json"
+$testPublicKey = (Get-Content "$keyPath.pub" -Raw).Trim()
+@{
+  plugins = @{
+    updater = @{
+      pubkey = $testPublicKey
+      endpoints = @("https://example.invalid/sky-auto-player/{{target}}/{{arch}}/{{current_version}}")
+    }
+  }
+} | ConvertTo-Json -Depth 5 | Set-Content -Encoding utf8 $testConfigPath
+
+Push-Location desktop
+bun run tauri build --ci --config $testConfigPath -- --profile dist
+Pop-Location
+
+cargo xtask verify-tauri-bundle `
+  --bundle-dir rust/target/dist/bundle/nsis `
+  --summary rust/target/dist/TAURI_ARTIFACT_SUMMARY.json
+```
+
+The expected bundle directory contains exactly:
+
+```
+rust/target/dist/bundle/nsis/
+  Sky Auto Player_<version>_<arch>-setup.exe
+  Sky Auto Player_<version>_<arch>-setup.exe.sig
+```
+
+The verifier records the exact installer and signature filenames, version,
+identifier, target, install mode, and byte sizes in
+`TAURI_ARTIFACT_SUMMARY.json`. It rejects MSI, portable/updater ZIP, missing
+signatures, empty signatures, unexpected files, and version-naming drift.
+
+Tauri’s updater signer reads the private key from environment variables; a
+`.env` file is not used for this operation. Do not commit the generated key,
+public key, updater metadata, installer, signature, or summary.
+
+## Acceptance boundary
+
+The local NSIS installer and updater signature require Windows packaging tools
+and a test signing key. Fresh current-user install, launch, GUI smoke, and
+uninstall remain Windows-manual acceptance evidence for this work order. The
+production v4 updater service and release-authority endpoint are intentionally
+deferred to later work orders.

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -33,6 +33,7 @@ non-production local fixture and must remain outside the repository:
 $keyPath = Join-Path $env:TEMP "sky-auto-player-v4-test.key"
 Push-Location desktop
 bun install --frozen-lockfile
+bun run build
 bun run tauri signer generate --ci --password "" --force -w $keyPath
 Pop-Location
 $env:TAURI_SIGNING_PRIVATE_KEY = (Get-Content $keyPath -Raw).Trim()

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +379,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -391,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -404,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -626,6 +645,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -903,6 +933,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1414,6 +1454,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,9 +1486,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1717,6 +1774,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1861,6 +1948,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2111,6 +2204,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2174,10 +2279,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "pango"
@@ -2657,15 +2782,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2699,6 +2829,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2736,6 +2880,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,6 +2977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2818,6 +3044,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3051,6 +3300,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,7 +3339,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "3.5.0"
+version = "4.0.0-alpha.1"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",
@@ -3090,6 +3355,8 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
  "thiserror 2.0.20",
  "ts-rs",
  "windows-sys 0.61.2",
@@ -3154,7 +3421,7 @@ dependencies = [
  "thiserror 2.0.20",
  "toml 0.9.12+spec-1.1.0",
  "windows-sys 0.61.2",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3163,15 +3430,15 @@ version = "0.1.0"
 dependencies = [
  "ed25519-dalek",
  "ico",
- "pep440_rs",
  "roxmltree",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "sky_ci_classifier",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -3363,6 +3630,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,7 +3671,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -3391,7 +3679,7 @@ dependencies = [
  "dpi",
  "gdkwayland-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3424,6 +3712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,7 +3745,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3600,6 +3899,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.20",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3609,7 +3951,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -3632,7 +3974,7 @@ checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -3837,6 +4179,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4170,6 +4522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4422,6 +4780,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4607,6 +4974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,6 +5027,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4945,7 +5332,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -4968,6 +5355,16 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
  "windows-version",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -5071,6 +5468,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/rust/supply-chain/config.toml
+++ b/rust/supply-chain/config.toml
@@ -28,6 +28,10 @@ criteria = "safe-to-deploy"
 version = "1.0.104"
 criteria = "safe-to-deploy"
 
+[[exemptions.arbitrary]]
+version = "1.4.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.atk]]
 version = "0.18.2"
 criteria = "safe-to-deploy"
@@ -177,6 +181,10 @@ version = "0.18.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.core-foundation]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-foundation]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
 
@@ -280,6 +288,10 @@ criteria = "safe-to-deploy"
 version = "0.5.8"
 criteria = "safe-to-deploy"
 
+[[exemptions.derive_arbitrary]]
+version = "1.4.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.derive_more]]
 version = "2.1.1"
 criteria = "safe-to-deploy"
@@ -378,7 +390,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.errno]]
 version = "0.3.14"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
 version = "2.5.0"
@@ -394,6 +406,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.field-offset]]
 version = "0.3.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.filetime]]
+version = "0.2.29"
 criteria = "safe-to-deploy"
 
 [[exemptions.find-msvc-tools]]
@@ -584,6 +600,10 @@ criteria = "safe-to-deploy"
 version = "1.11.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.hyper-rustls]]
+version = "0.27.9"
+criteria = "safe-to-deploy"
+
 [[exemptions.hyper-util]]
 version = "0.1.20"
 criteria = "safe-to-deploy"
@@ -692,6 +712,14 @@ criteria = "safe-to-deploy"
 version = "0.21.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.jni]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-macros]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.jni-sys]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
@@ -730,7 +758,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.linux-raw-sys]]
 version = "0.12.1"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.litemap]]
 version = "0.8.3"
@@ -758,6 +786,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.mime]]
 version = "0.3.17"
+criteria = "safe-to-deploy"
+
+[[exemptions.minisign-verify]]
+version = "0.2.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.miniz_oxide]]
@@ -852,6 +884,10 @@ criteria = "safe-to-deploy"
 version = "0.3.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.objc2-osa-kit]]
+version = "0.3.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.objc2-quartz-core]]
 version = "0.3.2"
 criteria = "safe-to-deploy"
@@ -872,8 +908,16 @@ criteria = "safe-to-deploy"
 version = "1.21.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.openssl-probe]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.option-ext]]
 version = "0.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.osakit]]
+version = "0.3.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.pango]]
@@ -1076,6 +1120,10 @@ criteria = "safe-to-deploy"
 version = "0.16.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.ring]]
+version = "0.17.14"
+criteria = "safe-to-deploy"
+
 [[exemptions.roxmltree]]
 version = "0.20.0"
 criteria = "safe-to-deploy"
@@ -1090,7 +1138,31 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rustix]]
 version = "1.1.4"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls]]
+version = "0.23.43"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-native-certs]]
+version = "0.8.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-pki-types]]
+version = "1.15.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-platform-verifier]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-platform-verifier-android]]
+version = "0.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.rustls-webpki]]
+version = "0.103.15"
+criteria = "safe-to-deploy"
 
 [[exemptions.rustversion]]
 version = "1.0.23"
@@ -1102,6 +1174,10 @@ criteria = "safe-to-run"
 
 [[exemptions.same-file]]
 version = "1.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.schannel]]
+version = "0.1.29"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars]]
@@ -1122,6 +1198,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.scopeguard]]
 version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework]]
+version = "3.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.security-framework-sys]]
+version = "2.17.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.selectors]]
@@ -1208,6 +1292,14 @@ criteria = "safe-to-deploy"
 version = "0.3.10"
 criteria = "safe-to-deploy"
 
+[[exemptions.simd_cesu8]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.simdutf8]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.siphasher]]
 version = "1.0.3"
 criteria = "safe-to-deploy"
@@ -1284,6 +1376,14 @@ criteria = "safe-to-deploy"
 version = "0.13.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.system-configuration]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.system-configuration-sys]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.system-deps]]
 version = "6.2.2"
 criteria = "safe-to-deploy"
@@ -1294,6 +1394,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tao-macros]]
 version = "0.1.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.tar]]
+version = "0.4.46"
 criteria = "safe-to-deploy"
 
 [[exemptions.target-lexicon]]
@@ -1328,6 +1432,14 @@ criteria = "safe-to-deploy"
 version = "2.5.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.tauri-plugin-process]]
+version = "2.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tauri-plugin-updater]]
+version = "2.11.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.tauri-runtime]]
 version = "2.11.3"
 criteria = "safe-to-deploy"
@@ -1346,7 +1458,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
 version = "3.27.0"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
 
 [[exemptions.tendril]]
 version = "0.5.1"
@@ -1398,6 +1510,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio]]
 version = "1.53.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.tokio-rustls]]
+version = "0.26.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-util]]
@@ -1544,6 +1660,10 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.untrusted]]
+version = "0.9.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.url]]
 version = "2.5.8"
 criteria = "safe-to-deploy"
@@ -1636,6 +1756,10 @@ criteria = "safe-to-deploy"
 version = "2.0.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.webpki-root-certs]]
+version = "1.0.9"
+criteria = "safe-to-deploy"
+
 [[exemptions.webview2-com]]
 version = "0.38.2"
 criteria = "safe-to-deploy"
@@ -1708,6 +1832,10 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.windows-registry]]
+version = "0.6.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.windows-result]]
 version = "0.3.4"
 criteria = "safe-to-deploy"
@@ -1726,6 +1854,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
 version = "0.45.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-sys]]
+version = "0.52.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-sys]]
@@ -1880,6 +2012,10 @@ criteria = "safe-to-deploy"
 version = "0.55.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.xattr]]
+version = "1.6.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.yoke]]
 version = "0.8.3"
 criteria = "safe-to-deploy"
@@ -1918,6 +2054,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zerovec-derive]]
 version = "0.11.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.zip]]
+version = "4.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zip]]

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -12,8 +12,8 @@ path = "src/main.rs"
 [dependencies]
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["std"] }
 ico = "0.5"
-pep440_rs = "0.7.3"
 roxmltree = "0.20.0"
+semver = "=1.0.28"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -226,6 +226,33 @@ fn tauri_feature_contract(root: &Path) -> Result<()> {
     Ok(())
 }
 
+fn legacy_release_guard_source(source: &str) -> Result<()> {
+    for marker in [
+        "name: Block v4+ tags from legacy v3 release workflow",
+        "$tag = $env:GITHUB_REF_NAME",
+        r#"$tag -match '^v(?<major>\d+)\.'"#,
+        "$major -ge 4",
+        "v4 publication is disabled in the legacy v3 release workflow until the dedicated release authority work order is complete",
+        "WO-04/WO-07",
+    ] {
+        if !source.contains(marker) {
+            return Err(format!(
+                "legacy release workflow is missing the v4 isolation guard marker: {marker}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn legacy_release_guard(root: &Path) -> Result<()> {
+    let path = root.join(".github/workflows/release.yml");
+    legacy_release_guard_source(&fs::read_to_string(&path)?)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    println!("[xtask] legacy v3 release workflow v4 guard: PASS");
+    Ok(())
+}
+
 fn active_files(root: &Path) -> impl Iterator<Item = std::path::PathBuf> {
     [
         root.join("rust/Cargo.toml"),
@@ -1529,6 +1556,7 @@ pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
             }
             branding::validate(&root)?;
             tauri_bundle::validate_config(&root)?;
+            legacy_release_guard(&root)?;
             retirement(&root)?;
         }
         "rust" => {
@@ -1754,6 +1782,26 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
         );
         let error = tauri_feature_contract_manifest(&source).unwrap_err();
         assert!(error.contains("desktop-runtime must not contain `tauri/custom-protocol`"));
+    }
+
+    #[test]
+    fn legacy_release_guard_requires_the_v4_fail_closed_contract() {
+        let source = r#"
+      - name: Block v4+ tags from legacy v3 release workflow
+        run: |
+          $tag = $env:GITHUB_REF_NAME
+          if ($tag -match '^v(?<major>\d+)\.') {
+            $major = [int64]$Matches.major
+            if ($major -ge 4) {
+              throw "v4 publication is disabled in the legacy v3 release workflow until the dedicated release authority work order is complete: $tag"
+            }
+          }
+      # WO-04/WO-07
+"#;
+        assert!(legacy_release_guard_source(source).is_ok());
+        assert!(
+            legacy_release_guard_source(&source.replace("$major -ge 4", "$major -gt 4")).is_err()
+        );
     }
 
     #[test]

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -254,14 +254,15 @@ fn legacy_release_guard(root: &Path) -> Result<()> {
 }
 
 fn packaged_ci_contract_source(source: &str) -> Result<()> {
-    let start = source
+    let normalized = source.replace("\r\n", "\n");
+    let start = normalized
         .find("  packaged:\n")
         .ok_or("CI workflow is missing the packaged job")?;
-    let end = source[start..]
+    let end = normalized[start..]
         .find("\n  status:\n")
         .map(|offset| start + offset)
         .ok_or("CI workflow packaged job is missing the status boundary")?;
-    let packaged = &source[start..end];
+    let packaged = &normalized[start..end];
 
     for marker in [
         "name: Packaged v4 Tauri NSIS qualification",
@@ -1879,8 +1880,10 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
         run: check sky_desktop_shell.exe uninstall.exe
       - uses: actions/upload-artifact@v7
   status:
-"#;
+        "#;
         assert!(packaged_ci_contract_source(source).is_ok());
+        let crlf_source = source.replace('\n', "\r\n");
+        assert!(packaged_ci_contract_source(&crlf_source).is_ok());
         for forbidden in [
             "cargo xtask dist",
             "verify-dist",

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -253,6 +253,63 @@ fn legacy_release_guard(root: &Path) -> Result<()> {
     Ok(())
 }
 
+fn packaged_ci_contract_source(source: &str) -> Result<()> {
+    let start = source
+        .find("  packaged:\n")
+        .ok_or("CI workflow is missing the packaged job")?;
+    let end = source[start..]
+        .find("\n  status:\n")
+        .map(|offset| start + offset)
+        .ok_or("CI workflow packaged job is missing the status boundary")?;
+    let packaged = &source[start..end];
+
+    for marker in [
+        "name: Packaged v4 Tauri NSIS qualification",
+        "bun install --frozen-lockfile",
+        "bun run tauri signer generate",
+        "TAURI_SIGNING_PRIVATE_KEY",
+        "bun run tauri build --ci --config",
+        "cargo xtask verify-tauri-bundle",
+        "current-user install, launch, and uninstall",
+        "sky_desktop_shell.exe",
+        "uninstall.exe",
+        "actions/upload-artifact@",
+    ] {
+        if !packaged.contains(marker) {
+            return Err(format!(
+                "canonical v4 packaged CI is missing the Tauri qualification marker: {marker}"
+            )
+            .into());
+        }
+    }
+
+    for forbidden in [
+        "cargo xtask dist",
+        "verify-dist",
+        "Sky-Auto-Player-v",
+        "Sky-Auto-Player-Updater.exe",
+        "MANIFEST.json",
+        "PORTABLE_ARTIFACT",
+        "portable",
+    ] {
+        if packaged.contains(forbidden) {
+            return Err(format!(
+                "canonical v4 packaged CI must not contain the legacy v3 artifact marker: {forbidden}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn packaged_ci_contract(root: &Path) -> Result<()> {
+    let path = root.join(".github/workflows/ci.yml");
+    packaged_ci_contract_source(&fs::read_to_string(&path)?)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    println!("[xtask] canonical v4 packaged CI Tauri contract: PASS");
+    Ok(())
+}
+
 fn active_files(root: &Path) -> impl Iterator<Item = std::path::PathBuf> {
     [
         root.join("rust/Cargo.toml"),
@@ -1557,6 +1614,7 @@ pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
             branding::validate(&root)?;
             tauri_bundle::validate_config(&root)?;
             legacy_release_guard(&root)?;
+            packaged_ci_contract(&root)?;
             retirement(&root)?;
         }
         "rust" => {
@@ -1802,6 +1860,41 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
         assert!(
             legacy_release_guard_source(&source.replace("$major -ge 4", "$major -gt 4")).is_err()
         );
+    }
+
+    #[test]
+    fn packaged_ci_contract_requires_tauri_and_rejects_v3_artifacts() {
+        let source = r#"
+  packaged:
+    name: Packaged v4 Tauri NSIS qualification
+    steps:
+      - run: bun install --frozen-lockfile
+      - run: bun run tauri signer generate
+        env: { TAURI_SIGNING_PRIVATE_KEY: test }
+      - run: bun run tauri build --ci --config test.json
+      - run: cargo xtask verify-tauri-bundle
+      - name: Qualify current-user install, launch, and uninstall
+        run: check sky_desktop_shell.exe uninstall.exe
+      - uses: actions/upload-artifact@v7
+  status:
+"#;
+        assert!(packaged_ci_contract_source(source).is_ok());
+        for forbidden in [
+            "cargo xtask dist",
+            "verify-dist",
+            "Sky-Auto-Player-v",
+            "Sky-Auto-Player-Updater.exe",
+            "MANIFEST.json",
+            "PORTABLE_ARTIFACT",
+            "portable",
+        ] {
+            let source_with_legacy_marker =
+                source.replace("  status:", &format!("  # {forbidden}\n  status:"));
+            assert!(
+                packaged_ci_contract_source(&source_with_legacy_marker).is_err(),
+                "{forbidden}"
+            );
+        }
     }
 
     #[test]

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1,4 +1,4 @@
-use crate::{Result, audits, branding, process, repo, supply_chain};
+use crate::{Result, audits, branding, process, repo, supply_chain, tauri_bundle};
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
@@ -1528,6 +1528,7 @@ pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
                 );
             }
             branding::validate(&root)?;
+            tauri_bundle::validate_config(&root)?;
             retirement(&root)?;
         }
         "rust" => {

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -266,6 +266,7 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
     for marker in [
         "name: Packaged v4 Tauri NSIS qualification",
         "bun install --frozen-lockfile",
+        "bun run build",
         "bun run tauri signer generate",
         "TAURI_SIGNING_PRIVATE_KEY",
         "bun run tauri build --ci --config",
@@ -1869,6 +1870,7 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
     name: Packaged v4 Tauri NSIS qualification
     steps:
       - run: bun install --frozen-lockfile
+      - run: bun run build
       - run: bun run tauri signer generate
         env: { TAURI_SIGNING_PRIVATE_KEY: test }
       - run: bun run tauri build --ci --config test.json

--- a/rust/xtask/src/dist.rs
+++ b/rust/xtask/src/dist.rs
@@ -252,6 +252,17 @@ fn default_config() -> Value {
     })
 }
 
+fn ensure_v3_portable_distribution(version_value: &str) -> Result<()> {
+    let parsed = version::parse(version_value)?;
+    if parsed.major >= 4 {
+        return Err(format!(
+            "cargo xtask dist is v3-only: the legacy portable distribution contract is retired from canonical v4 packaging (version {version_value}); use Tauri NSIS qualification"
+        )
+        .into());
+    }
+    Ok(())
+}
+
 fn zip_tree(release_dir: &Path, destination: &Path) -> Result<String> {
     let file = fs::File::create(destination)?;
     let mut zip = ZipWriter::new(file);
@@ -308,6 +319,8 @@ pub fn build(output: &Path) -> Result<()> {
         return Err("cargo xtask dist requires Windows".into());
     }
     let root = repo::root();
+    let version_value = repo::project_version(&root)?;
+    ensure_v3_portable_distribution(&version_value)?;
     let output = safe_output(&root, output)?;
     if output.exists() {
         if has_reparse_component(&output)? {
@@ -317,8 +330,6 @@ pub fn build(output: &Path) -> Result<()> {
     }
     fs::create_dir_all(&output)?;
     let head = repo::git_head(&root, true)?;
-    let version_value = repo::project_version(&root)?;
-    version::parse(&version_value)?;
     let fingerprint = repo::source_fingerprint(&root)?;
     let env = env_overrides(&head, &fingerprint, &root)?;
     process::run(
@@ -634,6 +645,17 @@ mod tests {
         assert!(safe_output(&root, &root).is_err());
         assert!(safe_output(&root, &root.join(".")).is_err());
         assert!(safe_output(&root, Path::new("")).is_err());
+    }
+
+    #[test]
+    fn portable_distribution_is_v3_only() {
+        assert!(ensure_v3_portable_distribution("3.5.0").is_ok());
+        for version in ["4.0.0-alpha.1", "4.0.0", "5.0.0"] {
+            let error = ensure_v3_portable_distribution(version).unwrap_err();
+            let error = error.to_string();
+            assert!(error.contains("legacy portable distribution contract"));
+            assert!(error.contains("Tauri NSIS qualification"));
+        }
     }
 
     #[test]

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -9,6 +9,7 @@ mod manifest;
 mod process;
 mod repo;
 mod supply_chain;
+mod tauri_bundle;
 mod update_trust;
 mod version;
 
@@ -18,7 +19,7 @@ use std::path::Path;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn usage() -> &'static str {
-    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-dist --release-dir <dir>"
+    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> [--summary <path>]\n  cargo xtask verify-dist --release-dir <dir>"
 }
 
 fn required_value(args: &[String], index: &mut usize, option: &str) -> Result<String> {
@@ -192,6 +193,32 @@ fn main() -> Result<()> {
                 release_dir
                     .ok_or("verify-dist requires --release-dir <dir>")?
                     .as_ref(),
+            )
+        }
+        "verify-tauri-bundle" => {
+            let mut bundle_dir = None;
+            let mut summary = None;
+            let mut i = 1;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--bundle-dir" => {
+                        bundle_dir = Some(required_value(&args, &mut i, "--bundle-dir")?)
+                    }
+                    "--summary" => summary = Some(required_value(&args, &mut i, "--summary")?),
+                    option => {
+                        return Err(format!("unknown verify-tauri-bundle option: {option}").into());
+                    }
+                }
+                i += 1;
+            }
+            tauri_bundle::verify(
+                &repo::root(),
+                Path::new(
+                    bundle_dir
+                        .ok_or("verify-tauri-bundle requires --bundle-dir <dir>")?
+                        .as_str(),
+                ),
+                summary.as_deref().map(Path::new),
             )
         }
         _ => {

--- a/rust/xtask/src/manifest.rs
+++ b/rust/xtask/src/manifest.rs
@@ -382,6 +382,10 @@ mod tests {
         tempfile_like::TempDir::new()
     }
 
+    fn project_version() -> String {
+        repo::project_version(&repo::root()).expect("project version")
+    }
+
     mod tempfile_like {
         use std::path::{Path, PathBuf};
         pub struct TempDir(PathBuf);
@@ -436,7 +440,13 @@ mod tests {
         ] {
             fs::write(temp.path().join(name), name.as_bytes()).unwrap();
         }
-        write(temp.path(), "3.5.0", &"a".repeat(40), &"a".repeat(40)).unwrap();
+        write(
+            temp.path(),
+            &project_version(),
+            &"a".repeat(40),
+            &"a".repeat(40),
+        )
+        .unwrap();
         let written: Value =
             serde_json::from_slice(&fs::read(temp.path().join("MANIFEST.json")).unwrap()).unwrap();
         assert_ne!(
@@ -468,7 +478,13 @@ mod tests {
             ] {
                 fs::write(temp.path().join(name), name.as_bytes()).unwrap();
             }
-            write(temp.path(), "3.5.0", &"a".repeat(40), &"a".repeat(40)).unwrap();
+            write(
+                temp.path(),
+                &project_version(),
+                &"a".repeat(40),
+                &"a".repeat(40),
+            )
+            .unwrap();
             let path = temp.path().join(relative);
             if let Some(parent) = path.parent() {
                 fs::create_dir_all(parent).unwrap();
@@ -488,7 +504,13 @@ mod tests {
         ] {
             fs::write(temp.path().join(name), name.as_bytes()).unwrap();
         }
-        write(temp.path(), "3.5.0", &"a".repeat(40), &"a".repeat(40)).unwrap();
+        write(
+            temp.path(),
+            &project_version(),
+            &"a".repeat(40),
+            &"a".repeat(40),
+        )
+        .unwrap();
         let mut manifest: Value =
             serde_json::from_slice(&fs::read(temp.path().join("MANIFEST.json")).unwrap()).unwrap();
         manifest["native_build_commit"] = json!("b".repeat(40));
@@ -511,7 +533,7 @@ mod tests {
             fs::write(temp.path().join(name), name.as_bytes()).unwrap();
         }
         let payload = json!({
-            "schema_version": 2, "app": APP_NAME, "version": "3.5.0", "executable": PRIMARY_EXE,
+            "schema_version": 2, "app": APP_NAME, "version": project_version(), "executable": PRIMARY_EXE,
             "dirty_worktree": false, "files": [{"path":"../escape", "size":0, "sha256":"0".repeat(64)}]
         });
         fs::write(

--- a/rust/xtask/src/tauri_bundle.rs
+++ b/rust/xtask/src/tauri_bundle.rs
@@ -1,0 +1,331 @@
+use crate::{Result, repo, version};
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const CONFIG_PATH: &str = "desktop/src-tauri/tauri.conf.json";
+const V4_IDENTIFIER: &str = "io.github.pumni.skyautoplayer";
+const PRODUCT_NAME: &str = "Sky Auto Player";
+const NSIS_TARGET: &str = "nsis";
+const CURRENT_USER_INSTALL_MODE: &str = "currentUser";
+
+#[derive(Debug, Serialize)]
+struct ArtifactSummary {
+    schema_version: u32,
+    product_name: &'static str,
+    identifier: &'static str,
+    version: String,
+    target: &'static str,
+    install_mode: &'static str,
+    installer: String,
+    updater_signature: String,
+    installer_size: u64,
+    signature_size: u64,
+}
+
+fn object<'a>(value: &'a Value, key: &str) -> Result<&'a serde_json::Map<String, Value>> {
+    value
+        .get(key)
+        .and_then(Value::as_object)
+        .ok_or_else(|| format!("Tauri config field {key} must be an object").into())
+}
+
+fn bool_field(value: &serde_json::Map<String, Value>, key: &str) -> Result<bool> {
+    value
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| format!("Tauri config field {key} must be a boolean").into())
+}
+
+fn string_field<'a>(value: &'a Value, key: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("Tauri config field {key} must be a string").into())
+}
+
+fn validate_config_value(config: &Value, project_version: &str) -> Result<()> {
+    let parsed_version = version::parse(project_version)?;
+    if parsed_version.to_string() != project_version {
+        return Err(
+            format!("Cargo project version is not canonical SemVer: {project_version:?}").into(),
+        );
+    }
+    if config.get("version").is_some() {
+        return Err(
+            "Tauri config must omit version; desktop/src-tauri/Cargo.toml is the canonical v4 version source".into(),
+        );
+    }
+    if string_field(config, "productName")? != PRODUCT_NAME {
+        return Err("Tauri productName does not match the v4 package contract".into());
+    }
+    if string_field(config, "identifier")? != V4_IDENTIFIER {
+        return Err("Tauri identifier does not match ADR-0006".into());
+    }
+
+    let bundle = object(config, "bundle")?;
+    if !bool_field(bundle, "active")? {
+        return Err("Tauri bundling must be enabled for the v4 package".into());
+    }
+    if !bool_field(bundle, "createUpdaterArtifacts")? {
+        return Err("Tauri updater artifacts must be enabled for the v4 package".into());
+    }
+    let targets = bundle
+        .get("targets")
+        .and_then(Value::as_array)
+        .ok_or("Tauri bundle.targets must be an array containing only nsis")?;
+    if targets.len() != 1 || targets[0].as_str() != Some(NSIS_TARGET) {
+        return Err("Tauri bundle.targets must contain only nsis for v4.0".into());
+    }
+    let windows = bundle
+        .get("windows")
+        .and_then(Value::as_object)
+        .ok_or("Tauri bundle.windows must be configured")?;
+    let nsis = windows
+        .get("nsis")
+        .and_then(Value::as_object)
+        .ok_or("Tauri bundle.windows.nsis must be configured")?;
+    if nsis.get("installMode").and_then(Value::as_str) != Some(CURRENT_USER_INSTALL_MODE) {
+        return Err("Tauri NSIS installMode must be currentUser".into());
+    }
+
+    if let Some(updater) = config
+        .get("plugins")
+        .and_then(Value::as_object)
+        .and_then(|plugins| plugins.get("updater"))
+        && updater.as_object().is_some_and(|updater| {
+            updater.contains_key("endpoints") || updater.contains_key("pubkey")
+        })
+    {
+        return Err(
+            "WO-01 must not commit v4 updater endpoints or trust keys before the release authority exists".into(),
+        );
+    }
+    Ok(())
+}
+
+pub fn validate_config(root: &Path) -> Result<()> {
+    let config_path = root.join(CONFIG_PATH);
+    let config: Value = serde_json::from_slice(&fs::read(&config_path)?)?;
+    let project_version = repo::project_version(root)?;
+    validate_config_value(&config, &project_version)
+        .map_err(|error| format!("{}: {error}", config_path.display()).into())
+}
+
+fn is_installer(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_ascii_lowercase().ends_with("-setup.exe"))
+        .unwrap_or(false)
+}
+
+fn signature_path(installer: &Path) -> PathBuf {
+    let name = installer
+        .file_name()
+        .expect("installer path must have a filename")
+        .to_string_lossy();
+    installer.with_file_name(format!("{name}.sig"))
+}
+
+fn artifact_summary(bundle_dir: &Path, project_version: &str) -> Result<ArtifactSummary> {
+    let bundle_dir = bundle_dir.canonicalize()?;
+    if !bundle_dir.is_dir() {
+        return Err(format!(
+            "Tauri bundle directory is missing: {}",
+            bundle_dir.display()
+        )
+        .into());
+    }
+
+    let mut files = Vec::new();
+    for entry in fs::read_dir(&bundle_dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            return Err(format!(
+                "Tauri bundle directory contains a symlink: {}",
+                entry.path().display()
+            )
+            .into());
+        }
+        if !file_type.is_file() {
+            return Err(format!(
+                "Tauri bundle directory contains an unexpected non-file: {}",
+                entry.path().display()
+            )
+            .into());
+        }
+        files.push(entry.path());
+    }
+    files.sort();
+
+    let installers = files
+        .iter()
+        .filter(|path| is_installer(path))
+        .collect::<Vec<_>>();
+    if installers.len() != 1 {
+        return Err(format!(
+            "expected exactly one Tauri NSIS setup executable, found {}",
+            installers.len()
+        )
+        .into());
+    }
+    let installer = installers[0];
+    let signature = signature_path(installer);
+    if !files.iter().any(|path| path == &signature) {
+        return Err(format!(
+            "Tauri updater signature is missing: {}",
+            signature.display()
+        )
+        .into());
+    }
+    if files.len() != 2 {
+        let names = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        return Err(format!(
+            "Tauri NSIS bundle must contain only the setup executable and its .sig: {names:?}"
+        )
+        .into());
+    }
+    if installer.metadata()?.len() == 0 {
+        return Err("Tauri NSIS installer is empty".into());
+    }
+    let signature_text = String::from_utf8(fs::read(&signature)?)?;
+    if signature_text.trim().is_empty() {
+        return Err("Tauri updater signature is empty".into());
+    }
+    let installer_name = installer.file_name().unwrap().to_string_lossy();
+    let expected_prefix = format!("{PRODUCT_NAME}_{project_version}_");
+    if !installer_name.starts_with(&expected_prefix) {
+        return Err(format!(
+            "Tauri installer name does not match canonical product/version {expected_prefix}: {installer_name}"
+        )
+        .into());
+    }
+
+    Ok(ArtifactSummary {
+        schema_version: 1,
+        product_name: PRODUCT_NAME,
+        identifier: V4_IDENTIFIER,
+        version: project_version.to_owned(),
+        target: NSIS_TARGET,
+        install_mode: CURRENT_USER_INSTALL_MODE,
+        installer: installer_name.into_owned(),
+        updater_signature: signature
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned(),
+        installer_size: installer.metadata()?.len(),
+        signature_size: signature.metadata()?.len(),
+    })
+}
+
+pub fn verify(root: &Path, bundle_dir: &Path, summary_path: Option<&Path>) -> Result<()> {
+    validate_config(root)?;
+    let project_version = repo::project_version(root)?;
+    let summary = artifact_summary(bundle_dir, &project_version)?;
+    let payload = serde_json::to_vec_pretty(&json!(summary))?;
+    if let Some(path) = summary_path {
+        fs::write(path, &payload)?;
+        println!("[xtask] Tauri artifact summary: {}", path.display());
+    }
+    println!("{}", String::from_utf8(payload)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_config() -> Value {
+        json!({
+            "productName": PRODUCT_NAME,
+            "identifier": V4_IDENTIFIER,
+            "build": {},
+            "bundle": {
+                "active": true,
+                "targets": [NSIS_TARGET],
+                "createUpdaterArtifacts": true,
+                "windows": {"nsis": {"installMode": CURRENT_USER_INSTALL_MODE}}
+            }
+        })
+    }
+
+    #[test]
+    fn config_contract_requires_the_canonical_v4_shape() {
+        assert!(validate_config_value(&valid_config(), "4.0.0-alpha.1").is_ok());
+
+        for (field, replacement) in [
+            ("identifier", json!("com.skyautoplayer.desktop")),
+            ("productName", json!("Other App")),
+        ] {
+            let mut config = valid_config();
+            config[field] = replacement;
+            assert!(
+                validate_config_value(&config, "4.0.0-alpha.1").is_err(),
+                "{field}"
+            );
+        }
+
+        let mut config = valid_config();
+        config["version"] = json!("4.0.0-alpha.1");
+        assert!(validate_config_value(&config, "4.0.0-alpha.1").is_err());
+    }
+
+    #[test]
+    fn config_contract_rejects_non_nsis_or_elevated_installers() {
+        let mut config = valid_config();
+        config["bundle"]["targets"] = json!(["nsis", "msi"]);
+        assert!(validate_config_value(&config, "4.0.0-alpha.1").is_err());
+
+        let mut config = valid_config();
+        config["bundle"]["windows"]["nsis"]["installMode"] = json!("both");
+        assert!(validate_config_value(&config, "4.0.0-alpha.1").is_err());
+    }
+
+    #[test]
+    fn config_contract_rejects_v4_updater_authority_before_wo03() {
+        let mut config = valid_config();
+        config["plugins"] = json!({"updater": {"endpoints": ["https://example.invalid"]}});
+        assert!(validate_config_value(&config, "4.0.0-alpha.1").is_err());
+    }
+
+    #[test]
+    fn artifact_verifier_requires_setup_executable_and_signature_pair() {
+        let root =
+            std::env::temp_dir().join(format!("sky-xtask-tauri-bundle-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let installer = root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.exe");
+        let signature = root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.exe.sig");
+        fs::write(&installer, b"installer").unwrap();
+        fs::write(&signature, b"test-signature\n").unwrap();
+        let summary = artifact_summary(&root, "4.0.0-alpha.1").unwrap();
+        assert_eq!(
+            summary.installer,
+            installer.file_name().unwrap().to_string_lossy()
+        );
+
+        fs::remove_file(&installer).unwrap();
+        fs::remove_file(&signature).unwrap();
+        let wrong_installer = root.join("Sky Auto Player_4.0.0-alpha.10_x64-setup.exe");
+        let wrong_signature = root.join("Sky Auto Player_4.0.0-alpha.10_x64-setup.exe.sig");
+        fs::write(&wrong_installer, b"installer").unwrap();
+        fs::write(&wrong_signature, b"test-signature\n").unwrap();
+        assert!(artifact_summary(&root, "4.0.0-alpha.1").is_err());
+
+        fs::remove_file(wrong_installer).unwrap();
+        fs::remove_file(wrong_signature).unwrap();
+        fs::write(
+            root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.msi"),
+            b"wrong target",
+        )
+        .unwrap();
+        assert!(artifact_summary(&root, "4.0.0-alpha.1").is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/rust/xtask/src/version.rs
+++ b/rust/xtask/src/version.rs
@@ -5,7 +5,12 @@ pub fn parse(value: &str) -> Result<Version> {
     if value.is_empty() || value.trim() != value || value.starts_with(['v', 'V']) {
         return Err(format!("invalid SemVer version: {value:?}").into());
     }
-    Version::parse(value).map_err(|error| format!("invalid SemVer version: {error}").into())
+    let parsed =
+        Version::parse(value).map_err(|error| format!("invalid SemVer version: {error}"))?;
+    if !parsed.build.is_empty() {
+        return Err(format!("SemVer build metadata is not allowed: {value:?}").into());
+    }
+    Ok(parsed)
 }
 
 pub fn check(tag: Option<&str>) -> Result<()> {
@@ -54,8 +59,27 @@ mod tests {
 
     #[test]
     fn rejects_pep440_and_untrusted_forms() {
-        for value in [" 4.0.0", "v4.0.0", "4.0.0rc1", "4.0"] {
+        for value in [
+            " 4.0.0",
+            "v4.0.0",
+            "4.0.0rc1",
+            "4.0",
+            "4.0.0+local",
+            "4.0.0-alpha.1+build",
+        ] {
             assert!(parse(value).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn release_tag_rejects_semver_build_metadata() {
+        for version in ["4.0.0+local", "4.0.0-alpha.1+build"] {
+            let parsed = Version::parse(version).unwrap();
+            assert!(parse(version).is_err(), "Cargo version: {version}");
+            assert!(
+                check_tag(&format!("v{version}"), version, &parsed).is_err(),
+                "release tag: v{version}"
+            );
         }
     }
 

--- a/rust/xtask/src/version.rs
+++ b/rust/xtask/src/version.rs
@@ -1,12 +1,11 @@
 use crate::{Result, repo};
-use pep440_rs::Version;
-use std::str::FromStr;
+use semver::Version;
 
 pub fn parse(value: &str) -> Result<Version> {
     if value.is_empty() || value.trim() != value || value.starts_with(['v', 'V']) {
-        return Err(format!("invalid PEP-440 version: {value:?}").into());
+        return Err(format!("invalid SemVer version: {value:?}").into());
     }
-    Version::from_str(value).map_err(|error| format!("invalid PEP-440 version: {error}").into())
+    Version::parse(value).map_err(|error| format!("invalid SemVer version: {error}").into())
 }
 
 pub fn check(tag: Option<&str>) -> Result<()> {
@@ -17,7 +16,7 @@ pub fn check(tag: Option<&str>) -> Result<()> {
         check_tag(tag, &version, &parsed)?;
     }
     println!("version={version}");
-    println!("is_prerelease={}", parsed.any_prerelease());
+    println!("is_prerelease={}", !parsed.pre.is_empty());
     Ok(())
 }
 
@@ -41,47 +40,45 @@ mod tests {
     use super::*;
 
     #[test]
-    fn preserves_project_prerelease_corpus() {
+    fn accepts_v4_semver_prerelease_corpus() {
         let values = [
-            ("3.5.0.dev1", true),
-            ("3.5.0a1", true),
-            ("3.5.0-alpha1", true),
-            ("3.5.0b1", true),
-            ("3.5.0-beta1", true),
-            ("3.5.0rc1", true),
-            ("3.5.0", false),
+            ("4.0.0-alpha.1", true),
+            ("4.0.0-beta.1", true),
+            ("4.0.0-rc.1", true),
+            ("4.0.0", false),
         ];
         for (value, expected) in values {
-            assert_eq!(parse(value).unwrap().any_prerelease(), expected, "{value}");
+            assert_eq!(!parse(value).unwrap().pre.is_empty(), expected, "{value}");
         }
     }
 
     #[test]
-    fn rejects_untrusted_tag_forms() {
-        assert!(parse(" 3.5.0").is_err());
-        assert!(parse("v3.5.0").is_err());
+    fn rejects_pep440_and_untrusted_forms() {
+        for value in [" 4.0.0", "v4.0.0", "4.0.0rc1", "4.0"] {
+            assert!(parse(value).is_err(), "{value}");
+        }
     }
 
     #[test]
     fn release_tag_requires_exact_cargo_text() {
-        let version = "3.5.0";
+        let version = "4.0.0-alpha.1";
         let parsed = parse(version).unwrap();
-        assert!(check_tag("v3.5.0", version, &parsed).is_ok());
+        assert!(check_tag("v4.0.0-alpha.1", version, &parsed).is_ok());
         for tag in [
-            "3.5.0",
-            "V3.5.0",
-            "v3.5",
-            "v3.5.00",
-            "v3.5.0+local",
-            "v3.5.0rc1",
+            "4.0.0-alpha.1",
+            "V4.0.0-alpha.1",
+            "v4.0.0",
+            "v4.0.00-alpha.1",
+            "v4.0.0-alpha1",
+            "v4.0.0rc1",
         ] {
             assert!(check_tag(tag, version, &parsed).is_err(), "{tag}");
         }
     }
 
     #[test]
-    fn release_tag_keeps_exact_prerelease_text() {
-        for version in ["3.5.0.dev1", "3.5.0a1", "3.5.0b1", "3.5.0rc1"] {
+    fn release_tag_keeps_exact_semver_prerelease_text() {
+        for version in ["4.0.0-alpha.1", "4.0.0-beta.1", "4.0.0-rc.1"] {
             let parsed = parse(version).unwrap();
             assert!(check_tag(&format!("v{version}"), version, &parsed).is_ok());
         }


### PR DESCRIPTION
Closes #103

## Summary

- Enable Tauri bundling as the canonical v4 Windows package producer.
- Set the ADR-0006 identifier to `io.github.pumni.skyautoplayer`.
- Establish Cargo `4.0.0-alpha.1` as the canonical SemVer source.
- Restrict the canonical v4 package to current-user NSIS with updater artifacts.
- Pin the official Tauri process and updater plugins for Rust and Bun.
- Add static contract checks and `cargo xtask verify-tauri-bundle` artifact qualification.
- Document the Windows test-signing overlay and expected installer/signature outputs.
- Retain the existing `sky_updater` v3 path and runtime update behavior.

## Scope and guardrails

- No production updater endpoint, trust key, or signing key is committed.
- No v4 runtime updater check is switched on.
- No v3 release namespace or legacy updater implementation is removed.
- Cargo-vet exemptions were regenerated only for the locked dependency graph required by these pinned plugins.
- No ADR-0006 deviations.

## Verification

- `cargo xtask check all` — PASS.
- `cargo test --manifest-path rust/Cargo.toml -p sky_xtask --locked` — 55 passed.
- `cargo xtask version check --tag v4.0.0-alpha.1` — PASS.
- `cargo check --manifest-path rust/Cargo.toml -p sky_updater --locked` — PASS.
- Tauri CLI 2.11.4 package build with temporary test signing material — PASS.
- `cargo xtask verify-tauri-bundle` — PASS.
  - `Sky Auto Player_4.0.0-alpha.1_x64-setup.exe` — 2,858,048 bytes.
  - Matching `.exe.sig` — 440 bytes.
  - Verified identifier, version, NSIS target, and `currentUser` install mode.
- Packaged smoke — PASS: silent current-user install to an isolated temp directory, packaged executable launch/health check, process exit, and uninstaller execution. The installer removed binaries; the app-created config file was cleaned from the isolated temp directory afterward.

## Acceptance notes

The committed config intentionally stays endpoint/key-free. Local qualification supplies a temporary updater config containing the generated test public key and a non-routable test endpoint, plus the private key through the documented environment variable. Production release authority remains deferred to the later work order.

This PR is intentionally open for review and is not merged.