### PR TITLE
feat(v4): establish dedicated release authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: pwsh scripts/ci_v4_release_authority_acceptance.ps1
 
+      - name: Promotion digest regression self-test
+        run: pwsh scripts/promote_v4_metadata.ps1 -SelfTest
+
       - name: Report CI timing
         if: always()
         run: |
@@ -784,6 +787,33 @@ jobs:
             if (Test-Path -LiteralPath $installRoot) { Remove-Item -LiteralPath $installRoot -Recurse -Force }
           }
 
+      - name: Emit exact Tauri qualification evidence
+        run: |
+          $summary = Get-Content rust/target/dist/TAURI_ARTIFACT_SUMMARY.json -Raw | ConvertFrom-Json
+          foreach ($field in @("installer_sha256", "updater_signature_sha256", "installer", "updater_signature", "version")) {
+            if ([string]::IsNullOrWhiteSpace([string]$summary.$field)) {
+              throw "Tauri artifact summary is missing qualification field: $field"
+            }
+          }
+          $evidence = [ordered]@{
+            schema_version = 1
+            evidence_type = "tauri-nsis-qualified-release"
+            qualified = $true
+            qualification = "install-launch-uninstall"
+            product_name = $summary.product_name
+            identifier = $summary.identifier
+            version = $summary.version
+            target = $summary.target
+            install_mode = $summary.install_mode
+            installer = $summary.installer
+            updater_signature = $summary.updater_signature
+            installer_size = $summary.installer_size
+            signature_size = $summary.signature_size
+            installer_sha256 = $summary.installer_sha256
+            updater_signature_sha256 = $summary.updater_signature_sha256
+          }
+          $evidence | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath rust/target/dist/V4_QUALIFICATION_EVIDENCE.json -Encoding utf8
+
       - name: Upload exact Tauri NSIS release candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -791,6 +821,7 @@ jobs:
           path: |
             rust/target/dist/bundle/nsis
             rust/target/dist/TAURI_ARTIFACT_SUMMARY.json
+            rust/target/dist/V4_QUALIFICATION_EVIDENCE.json
           if-no-files-found: error
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,44 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 
+  release_authority:
+    name: V4 release authority acceptance
+    needs: changes
+    if: needs.changes.outputs.static_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Start CI timing
+        run: echo "SKY_CI_JOB_STARTED_RELEASE_AUTHORITY=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Read-only v3 namespace and dedicated v4 authority acceptance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pwsh scripts/ci_v4_release_authority_acceptance.ps1
+
+      - name: Report CI timing
+        if: always()
+        run: |
+          start_time="${SKY_CI_JOB_STARTED_RELEASE_AUTHORITY:-}"
+          if [ -n "$start_time" ]; then
+            elapsed=$(( $(date +%s) - start_time ))
+            {
+              echo "## CI job timing"
+              echo "- Job: \`release-authority\`"
+              echo "- Elapsed seconds: \`$elapsed\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   supply_chain:
     name: Supply-chain and advisory security
     needs: changes
@@ -764,7 +802,7 @@ jobs:
   status:
     name: Sky Auto Player — required CI gate
     if: always()
-    needs: [changes, static, supply_chain, validate, updater_e2e, packaged]
+    needs: [changes, static, release_authority, supply_chain, validate, updater_e2e, packaged]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -782,6 +820,7 @@ jobs:
           CODE_REQUIRED: ${{ needs.changes.outputs.code_required }}
           PACKAGE_REQUIRED: ${{ needs.changes.outputs.package_required }}
           STATIC_RESULT: ${{ needs.static.result }}
+          RELEASE_AUTHORITY_RESULT: ${{ needs.release_authority.result }}
           SUPPLY_CHAIN_RESULT: ${{ needs.supply_chain.result }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
           UPDATER_E2E_RESULT: ${{ needs.updater_e2e.result }}
@@ -791,9 +830,11 @@ jobs:
           [[ "$CHANGES_RESULT" == "success" ]]
           if [[ "$STATIC_REQUIRED" == "true" ]]; then
             [[ "$STATIC_RESULT" == "success" ]]
+            [[ "$RELEASE_AUTHORITY_RESULT" == "success" ]]
             [[ "$SUPPLY_CHAIN_RESULT" == "success" ]]
           else
             [[ "$STATIC_RESULT" == "skipped" ]]
+            [[ "$RELEASE_AUTHORITY_RESULT" == "skipped" ]]
             [[ "$SUPPLY_CHAIN_RESULT" == "skipped" ]]
           fi
           if [[ "$CODE_REQUIRED" == "true" ]]; then [[ "$VALIDATE_RESULT" == "success" ]]; else [[ "$VALIDATE_RESULT" == "skipped" ]]; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,9 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Start CI timing
         run: echo "SKY_CI_JOB_STARTED_RELEASE_AUTHORITY=$(date +%s)" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,15 +38,15 @@ jobs:
           fetch-tags: false
           persist-credentials: false
 
-      # Temporary WO-01 isolation guard. Replace this with the dedicated v4
-      # release authority delivered by WO-04/WO-07.
+      # Permanent namespace guard: v4 binaries and metadata belong only to the
+      # dedicated authority, never to the legacy source-repository Releases API.
       - name: Block v4+ tags from legacy v3 release workflow
         run: |
           $tag = $env:GITHUB_REF_NAME
           if ($tag -match '^v(?<major>\d+)\.') {
             $major = [int64]$Matches.major
             if ($major -ge 4) {
-              throw "v4 publication is disabled in the legacy v3 release workflow until the dedicated release authority work order is complete: $tag"
+              throw "v4 publication is prohibited in the legacy v3 release workflow; use the dedicated v4 release authority: $tag"
             }
           }
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -17,7 +17,8 @@ packaged-assets = [
     "tauri/compression",
 ]
 # Local, signed updater fixture used only by the packaged previous-v4 to
-# candidate-v4 qualification. WO-04 supplies the production authority.
+# candidate-v4 qualification. WO-04 owns the production metadata authority;
+# WO-05 owns the production updater trust root.
 tauri-update-fixture = []
 tauri-test = ["tauri/test", "sky_player/test-support"]
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -424,7 +424,7 @@ pub fn selftest_packaged_shell() -> i32 {
                 let _update_check: commands::UpdateCheckDto = serde_json::from_value(value)
                     .map_err(|error| format!("update.check response: {error}"))?;
             }
-            Err(error) if error.starts_with("update_authority_not_configured") => {}
+            Err(error) if error.starts_with("update_service_unavailable") => {}
             Err(error) => return Err(format!("unexpected update.check failure: {error}")),
         }
         let _diagnostics: commands::DiagnosticsEnabledDto =

--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -1754,8 +1754,7 @@ impl NativeDesktopRuntime {
         self.update_service
             .as_ref()
             .ok_or_else(|| {
-                "update_authority_not_configured: production authority is reserved for WO-04"
-                    .to_string()
+                "update_service_unavailable: Rust-owned UpdateService is not configured".to_string()
             })?
             .check(&mut settings, |event| self.publish(event))
     }
@@ -1768,8 +1767,7 @@ impl NativeDesktopRuntime {
         self.update_service
             .as_ref()
             .ok_or_else(|| {
-                "update_authority_not_configured: production authority is reserved for WO-04"
-                    .to_string()
+                "update_service_unavailable: Rust-owned UpdateService is not configured".to_string()
             })?
             .install(&settings, &target_version, |event| self.publish(event))
     }

--- a/desktop/src-tauri/src/native_update.rs
+++ b/desktop/src-tauri/src/native_update.rs
@@ -3,7 +3,9 @@
 //! React receives only the bounded DTOs below. Endpoint selection, updater
 //! configuration, signature verification, artifact handling, and install
 //! execution stay in this module and in the official Tauri updater plugin.
-//! The production authority is intentionally absent until WO-04 supplies it.
+//! The production authority is a fixed Rust-owned v4 metadata authority. The
+//! updater trust key remains external to this work order and is intentionally
+//! not committed here; a missing key makes the official updater fail closed.
 
 use crate::app_state::{ActivityCoordinator, ActivityReservationError, UpdateInstallLease};
 use crate::commands::{UpdateCheckDto, UpdateHandoffDto};
@@ -21,6 +23,9 @@ use url::Url;
 
 const MAX_RELEASE_NOTES: usize = 16 * 1024;
 const MAX_ARTIFACT_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+const V4_RELEASE_AUTHORITY_REPOSITORY: &str = "pumni/Sky-Auto-Player-Releases";
+const V4_STABLE_METADATA_ENDPOINT: &str = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json";
+const V4_BETA_METADATA_ENDPOINT: &str = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json";
 
 #[derive(Clone, Debug)]
 pub(crate) struct NativeUpdateCandidate {
@@ -375,19 +380,28 @@ impl<R: Runtime> UpdateService<R> {
 }
 
 fn authority_endpoint(channel: UpdateChannel) -> Result<Url, String> {
-    #[cfg(feature = "tauri-update-fixture")]
-    {
-        let endpoint = match channel {
+    let endpoint = if cfg!(feature = "tauri-update-fixture") {
+        match channel {
             UpdateChannel::Stable => "http://127.0.0.1:17845/stable",
             UpdateChannel::Beta => "http://127.0.0.1:17845/beta",
+        }
+    } else {
+        let endpoint = match channel {
+            UpdateChannel::Stable => V4_STABLE_METADATA_ENDPOINT,
+            UpdateChannel::Beta => V4_BETA_METADATA_ENDPOINT,
         };
-        Url::parse(endpoint).map_err(|error| format!("fixture authority URL invalid: {error}"))
-    }
-    #[cfg(not(feature = "tauri-update-fixture"))]
-    {
-        let _ = channel;
-        Err("update_authority_not_configured: production authority is reserved for WO-04".into())
-    }
+        if !endpoint.contains(V4_RELEASE_AUTHORITY_REPOSITORY) {
+            return Err("v4 authority URL is outside the dedicated release repository".into());
+        }
+        endpoint
+    };
+    Url::parse(endpoint).map_err(|error| {
+        if cfg!(feature = "tauri-update-fixture") {
+            format!("fixture authority URL invalid: {error}")
+        } else {
+            format!("v4 authority URL invalid: {error}")
+        }
+    })
 }
 
 fn candidate_from_update(update: &Update, channel: UpdateChannel) -> NativeUpdateCandidate {
@@ -490,7 +504,10 @@ fn opaque_id() -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     #[cfg(not(feature = "tauri-update-fixture"))]
-    use super::authority_endpoint;
+    use super::{
+        V4_BETA_METADATA_ENDPOINT, V4_RELEASE_AUTHORITY_REPOSITORY, V4_STABLE_METADATA_ENDPOINT,
+        authority_endpoint,
+    };
     use super::{bounded, update_activity_error};
     use crate::app_state::ActivityReservationError;
     #[cfg(not(feature = "tauri-update-fixture"))]
@@ -498,13 +515,18 @@ mod tests {
 
     #[cfg(not(feature = "tauri-update-fixture"))]
     #[test]
-    fn production_authority_is_fail_closed_until_wo04() {
-        let error = authority_endpoint(UpdateChannel::Stable)
-            .expect_err("production authority must not be invented before WO-04");
-        assert_eq!(
-            error,
-            "update_authority_not_configured: production authority is reserved for WO-04"
-        );
+    fn production_authority_is_fixed_and_channel_isolated() {
+        let stable = authority_endpoint(UpdateChannel::Stable).unwrap();
+        let beta = authority_endpoint(UpdateChannel::Beta).unwrap();
+        assert_eq!(stable.as_str(), V4_STABLE_METADATA_ENDPOINT);
+        assert_eq!(beta.as_str(), V4_BETA_METADATA_ENDPOINT);
+        assert_ne!(stable, beta);
+        for endpoint in [stable, beta] {
+            assert_eq!(endpoint.scheme(), "https");
+            assert_eq!(endpoint.host_str(), Some("raw.githubusercontent.com"));
+            assert!(endpoint.path().contains(V4_RELEASE_AUTHORITY_REPOSITORY));
+            assert!(!endpoint.path().contains("Sky-Auto-Player/releases"));
+        }
     }
 
     #[test]

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,6 +44,8 @@ not open every architecture page by default.
   integrity/provenance, rollback, and release contract.
 - [v4-tauri-packaging.md](v4-tauri-packaging.md) — v4 local Tauri NSIS/updater artifact qualification
   and current-user packaging contract.
+- [v4-release-authority.md](v4-release-authority.md) — v4 immutable release namespace, static
+  metadata, channel isolation, and read-only acceptance contract.
 - [rust-toolchain-policy.md](rust-toolchain-policy.md) — Rust compiler/toolchain policy.
 - [wave5-legacy-python-retirement.md](wave5-legacy-python-retirement.md) — historical evidence for
   the completed product/runtime Python retirement; not a tooling instruction.

--- a/docs/adr/ADR-0006-v4-distribution-installation-update.md
+++ b/docs/adr/ADR-0006-v4-distribution-installation-update.md
@@ -149,8 +149,12 @@ V4 uses static Tauri updater metadata rather than runtime scanning/sorting of Gi
 and beta, when enabled, have separate metadata authorities/endpoints. The Rust update service selects
 from an allow-listed, compiled channel configuration; the frontend cannot supply an endpoint.
 WO-04 validates that metadata points only to already-published, qualified assets in the dedicated
-authority and promotes stable/beta files as separate post-qualification actions. The authority may
-remain empty until the first qualified promotion, so a missing production metadata file fails closed.
+authority and promotes stable/beta files as separate post-qualification actions. Qualification
+evidence binds the exact canonical installer and updater signature bytes by SHA-256; promotion
+compares those digests with the published assets and fails closed on missing or mismatched evidence.
+Stable metadata accepts only final SemVer releases while beta metadata is explicitly prerelease-only.
+The authority may remain empty until the first qualified promotion, so a missing production metadata
+file fails closed.
 
 A dedicated dynamic update service is a non-goal for v4.0. It can be introduced later if the product
 needs staged rollout, cohorts, mandatory minimum versions, or server-driven release policy.

--- a/docs/adr/ADR-0006-v4-distribution-installation-update.md
+++ b/docs/adr/ADR-0006-v4-distribution-installation-update.md
@@ -41,11 +41,16 @@ The preferred topology is:
 
 - source repository: `pumni/Sky-Auto-Player`;
 - v3 legacy releases: existing releases in the source repository;
-- v4 binary release authority: a dedicated repository or equivalent immutable release namespace;
+- v4 binary release authority: `pumni/Sky-Auto-Player-Releases`, a dedicated immutable release namespace;
 - v4 updater metadata: static Tauri updater metadata owned by the v4 release authority.
 
-The exact v4 release-authority repository name is an operational decision and is not hard-coded into
-runtime code until that repository exists and is reviewed.
+The authority repository exists and is reviewed by WO-04. Runtime code hard-codes only the two
+allow-listed metadata paths below; it does not expose them to React or accept endpoint overrides:
+
+```text
+https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json
+https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json
+```
 
 ### 3. The canonical v4 Windows distribution is NSIS, per-user, and signed
 
@@ -143,6 +148,9 @@ mechanism without relying on a one-off emergency bridge release.
 V4 uses static Tauri updater metadata rather than runtime scanning/sorting of GitHub Releases. Stable
 and beta, when enabled, have separate metadata authorities/endpoints. The Rust update service selects
 from an allow-listed, compiled channel configuration; the frontend cannot supply an endpoint.
+WO-04 validates that metadata points only to already-published, qualified assets in the dedicated
+authority and promotes stable/beta files as separate post-qualification actions. The authority may
+remain empty until the first qualified promotion, so a missing production metadata file fails closed.
 
 A dedicated dynamic update service is a non-goal for v4.0. It can be introduced later if the product
 needs staged rollout, cohorts, mandatory minimum versions, or server-driven release policy.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,7 +64,8 @@ admitted successful publication.
 The Rust `UpdateService` owns stable/beta authority selection, bounded update
 state/progress, playback admission, and the Tauri updater lifecycle. React
 never receives endpoint, key, artifact, or downgrade policy data. Production
-authority is fail-closed until WO-04 configures it; the signed packaged
+authority is fixed to the dedicated v4 stable/beta metadata paths; missing
+metadata or the not-yet-configured WO-05 trust root fails closed. The signed packaged
 previous-v4 to candidate-v4 fixture is test-only. The retained
 `sky_updater` boundary continues to own the legacy line's transaction and
 recovery behavior.

--- a/docs/distribution-and-update.md
+++ b/docs/distribution-and-update.md
@@ -6,11 +6,13 @@ tracks the native desktop Cargo version and is independent of the Rust
 playback dispatcher.
 
 V4 uses the Tauri NSIS package and the Rust-owned `UpdateService` described in
-`v4-tauri-packaging.md`. V4 does not use this document's GitHub Releases,
-portable artifact, or `sky_updater` transaction path; its production update
-authority is fail-closed until WO-04 configures it.
+`v4-tauri-packaging.md`. V4 does not use this document's legacy GitHub
+Releases, portable artifact, or `sky_updater` transaction path. Its fixed
+stable/beta metadata authority and deterministic promotion contract are in
+`v4-release-authority.md`; metadata remains unavailable until a qualified
+promotion, and the independent updater trust key remains a WO-05 concern.
 
-## 1. Distribution
+## 1. V3 maintenance distribution (legacy)
 
 Sky Auto Player has one canonical portable release package:
 
@@ -66,7 +68,7 @@ qualification pass. Assets are not replaced and the tag is not moved between
 draft creation and publication; a failed qualification requires a new version
 or RC instead.
 
-## 2. Runtime ownership
+## 2. V3 runtime ownership (legacy)
 
 The Native Desktop Runtime owns update checking, stable/beta selection,
 update-notice state, and the fixed manual fallback URL. It does not download,
@@ -140,7 +142,7 @@ directory; a valid active update makes startup exit cleanly with the bounded
 output `Sky Auto Player is currently updating to vX (Phase). The updater window
 will restart the app automatically.`
 
-## 3. Release selection and network
+## 3. V3 release selection and network (legacy)
 
 The desktop GUI is the canonical user-facing selector. Stable excludes prereleases;
 beta may include them. The checker uses:
@@ -165,6 +167,25 @@ The native updater uses HTTPS only and checks redirects against:
 `release-assets.githubusercontent.com`. Userinfo, HTTP URLs, arbitrary API
 bases, arbitrary mirrors, shell downloads, and TLS-verification bypasses are
 rejected. Release metadata never supplies the manual browser destination.
+
+### V4 authority boundary
+
+V4 never queries either v3 endpoint above. The Rust `UpdateService` selects
+exactly one of these fixed Tauri static metadata endpoints from the persisted
+channel setting:
+
+```text
+stable: https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json
+beta:   https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json
+```
+
+The metadata contains only the canonical Windows NSIS asset from the dedicated
+`pumni/Sky-Auto-Player-Releases` authority and the exact contents of its
+`.exe.sig` sidecar. Stable and beta metadata have separate paths and are never
+interchanged. Endpoint URLs, keys, artifact paths, and downgrade policy do
+not cross the Rust/React boundary. See `v4-release-authority.md` for the
+generator, validator, post-qualification promotion, and read-only namespace
+acceptance.
 
 ## 4. Archive and manifest safety
 

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -64,18 +64,26 @@ signature file. It emits the official Tauri static JSON shape:
 ```
 
 `cargo xtask release-authority validate --channel stable|beta` validates the
-same bounded contract. Stable and beta are separate destination paths:
-`channels/stable/latest.json` and `channels/beta/latest.json`. The validator
-rejects v3 URLs, non-HTTPS URLs, other owners/repos, query or fragment state,
-SemVer build metadata, malformed dates, extra platforms, and non-canonical
-artifact names.
+same bounded contract. Stable accepts only final SemVer releases; beta is
+explicitly a prerelease channel. Stable and beta are separate destination
+paths: `channels/stable/latest.json` and `channels/beta/latest.json`. The
+validator rejects v3 URLs, non-HTTPS URLs, other owners/repos, query or
+fragment state, SemVer build metadata, malformed dates, extra platforms, and
+non-canonical artifact names.
 
-Metadata promotion is a separate operation after the immutable release has
-been published and the exact published assets have passed qualification. The
-promotion action copies only the validated generated file into the selected
-channel path; it never creates placeholder production metadata and never
-rebuilds or replaces a published binary. Stable promotion cannot write the
-beta path, and beta promotion cannot write the stable path.
+The packaged qualification path emits a bounded
+`tauri-nsis-qualified-release` evidence object containing the canonical
+version/name/size pair and SHA-256 digests for both the installer and `.sig`.
+`qualified=true` is not accepted by itself: the promotion gate rejects missing
+or extra fields, malformed evidence, digest mismatches, and same-name assets
+with different bytes. Metadata promotion is a separate operation after the
+immutable release has been published and the exact published assets have
+passed qualification. It compares GitHub's asset digest when present, or
+downloads and hashes the exact canonical asset when the API omits a digest.
+The promotion action copies only the validated generated file into the
+selected channel path; it never creates placeholder production metadata and
+never rebuilds or replaces a published binary. Stable promotion cannot write
+the beta path, and beta promotion cannot write the stable path.
 
 The repository-owned acceptance check
 `scripts/ci_v4_release_authority_acceptance.ps1` is read-only. It verifies
@@ -85,12 +93,15 @@ public repository. It does not create, upload, publish, edit, or delete any
 release.
 
 `scripts/promote_v4_metadata.ps1` is the separate promotion gate. It requires
-explicit qualification evidence, runs the Rust metadata validator, reads the
-dedicated repository's published release and exact `.sig` asset, and compares
-both against the candidate metadata before atomically copying it into the
-selected channel path in an authority checkout. It never creates or edits a
-GitHub release; committing the resulting channel file is a separate reviewed
-authority-repository change.
+the bounded evidence emitted by the packaged qualification path, runs the Rust
+metadata validator, reads the dedicated repository's published release and
+exact installer/`.sig` pair, and compares names, sizes, and SHA-256 digests
+against the qualified bytes before atomically copying metadata into the
+selected channel path in an authority checkout. Its `-SelfTest` regression
+path proves arbitrary `qualified=true` evidence and same-name/different-bytes
+assets are rejected. It never creates or edits a GitHub release; committing
+the resulting channel file is a separate reviewed authority-repository
+change.
 
 The v4 Tauri public trust key is intentionally not committed by WO-04. WO-05
 owns the independent updater trust root and its operational secrets. The

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -1,0 +1,97 @@
+# V4 Release Authority
+
+V4 has a separate public release authority:
+
+```text
+pumni/Sky-Auto-Player-Releases
+```
+
+The source repository `pumni/Sky-Auto-Player` remains the legacy v3 release
+namespace. The v4 Rust `UpdateService` has exactly two compiled metadata
+endpoints:
+
+```text
+stable: https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json
+beta:   https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json
+```
+
+These URLs are selected by Rust from the persisted channel setting. They are
+not supplied by React, environment variables, command-line arguments, or a
+GitHub Releases fallback. The dedicated repository may remain without either
+`latest.json` file until the first qualified v4 promotion; a missing endpoint
+therefore fails closed.
+
+## Canonical published asset
+
+The Windows package uses the actual Tauri NSIS output and has one updater
+asset/signature pair per release:
+
+```text
+Sky Auto Player_<version>_x64-setup.exe
+Sky Auto Player_<version>_x64-setup.exe.sig
+```
+
+The immutable release URL is derived from the exact version and filename:
+
+```text
+https://github.com/pumni/Sky-Auto-Player-Releases/releases/download/v<version>/Sky%20Auto%20Player_<version>_x64-setup.exe
+```
+
+No portable ZIP, v3 `MANIFEST.json`, alias filename, source-repository
+release, or signature URL is valid v4 updater metadata. The `.sig` field in
+metadata contains the exact text from the published Tauri `.sig` file.
+
+## Deterministic metadata
+
+`cargo xtask release-authority generate` accepts only qualified-release
+inputs: the canonical SemVer version, normalized release notes, a
+second-precision UTC RFC3339 publication date, the exact
+`windows-x86_64` Tauri platform, the immutable asset URL, and the exact
+signature file. It emits the official Tauri static JSON shape:
+
+```json
+{
+  "version": "4.0.0",
+  "notes": "...",
+  "pub_date": "2026-09-04T00:00:00Z",
+  "platforms": {
+    "windows-x86_64": {
+      "signature": "<contents of .sig>",
+      "url": "<exact immutable asset URL>"
+    }
+  }
+}
+```
+
+`cargo xtask release-authority validate --channel stable|beta` validates the
+same bounded contract. Stable and beta are separate destination paths:
+`channels/stable/latest.json` and `channels/beta/latest.json`. The validator
+rejects v3 URLs, non-HTTPS URLs, other owners/repos, query or fragment state,
+SemVer build metadata, malformed dates, extra platforms, and non-canonical
+artifact names.
+
+Metadata promotion is a separate operation after the immutable release has
+been published and the exact published assets have passed qualification. The
+promotion action copies only the validated generated file into the selected
+channel path; it never creates placeholder production metadata and never
+rebuilds or replaces a published binary. Stable promotion cannot write the
+beta path, and beta promotion cannot write the stable path.
+
+The repository-owned acceptance check
+`scripts/ci_v4_release_authority_acceptance.ps1` is read-only. It verifies
+that the public source repository's `/releases/latest` is still a published
+v3 release with its canonical v3 assets and that the dedicated authority is a
+public repository. It does not create, upload, publish, edit, or delete any
+release.
+
+`scripts/promote_v4_metadata.ps1` is the separate promotion gate. It requires
+explicit qualification evidence, runs the Rust metadata validator, reads the
+dedicated repository's published release and exact `.sig` asset, and compares
+both against the candidate metadata before atomically copying it into the
+selected channel path in an authority checkout. It never creates or edits a
+GitHub release; committing the resulting channel file is a separate reviewed
+authority-repository change.
+
+The v4 Tauri public trust key is intentionally not committed by WO-04. WO-05
+owns the independent updater trust root and its operational secrets. The
+legacy `sky_updater` crate remains present for the v3 maintenance line.

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -2,9 +2,11 @@
 
 V4 uses the Tauri Windows bundler as its canonical package producer. The
 foundation enables the NSIS package and updater artifact generation. The
-Rust-owned `UpdateService` now drives the official Tauri updater, but
-production authority remains intentionally fail-closed until WO-04 supplies
-the endpoint and trust key.
+Rust-owned `UpdateService` now drives the official Tauri updater through the
+dedicated v4 release authority described in `v4-release-authority.md`.
+Production metadata may be absent until a qualified promotion, and the
+independent updater trust key remains a WO-05 responsibility; either case
+fails closed.
 
 ## Canonical package contract
 
@@ -24,8 +26,8 @@ It is not a v4 packaging entry point.
 
 The Tauri config intentionally omits its optional `version` field so Cargo
 remains the single v4 version source. `cargo xtask check static` rejects
-version/config drift and accidental updater authority in the production Tauri
-configuration. Test authority is compiled only by the explicit
+version/config drift and accidental frontend-visible updater authority in the
+production Tauri configuration. Test authority is compiled only by the explicit
 `tauri-update-fixture` feature and exists for packaged qualification.
 
 ## Local Windows package qualification
@@ -99,5 +101,6 @@ resource-close phases.
 The local NSIS installer and updater signature require Windows packaging tools
 and a test signing key. Fresh current-user install, launch, GUI smoke, and
 uninstall remain Windows-manual acceptance evidence; the packaged update
-qualification is the deterministic WO-03 acceptance path. WO-04 still owns
-production release/channel authority.
+qualification is the deterministic previous-v4 -> candidate-v4 acceptance
+path. The production release/channel authority is now configured by WO-04;
+trust-key operations remain with WO-05.

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -73,9 +73,13 @@ rust/target/dist/bundle/nsis/
 ```
 
 The verifier records the exact installer and signature filenames, version,
-identifier, target, install mode, and byte sizes in
-`TAURI_ARTIFACT_SUMMARY.json`. It rejects MSI, portable/updater ZIP, missing
-signatures, empty signatures, unexpected files, and version-naming drift.
+identifier, target, install mode, byte sizes, and SHA-256 digests in
+`TAURI_ARTIFACT_SUMMARY.json`. After the install/launch/uninstall smoke, the
+packaged qualification path emits `V4_QUALIFICATION_EVIDENCE.json` with a
+bounded evidence schema. Promotion requires that evidence and compares its
+installer/.sig digests to the exact published GitHub asset bytes. It rejects
+MSI, portable/updater ZIP, missing signatures, empty signatures, unexpected
+files, and version-naming drift.
 
 That command is the canonical package build: it uses the normal production
 feature set and the generated test key/example endpoint only to exercise

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3439,6 +3439,7 @@ dependencies = [
  "sha2 0.11.0",
  "sky_ci_classifier",
  "toml 0.9.12+spec-1.1.0",
+ "url",
  "walkdir",
  "zip 8.6.0",
 ]

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -19,5 +19,6 @@ serde_json = "1"
 sha2 = "0.11"
 sky_ci_classifier = { path = "../tools/sky_ci_classifier" }
 toml = "0.9.12"
+url = "2.5.8"
 walkdir = "2.5"
 zip = { version = "8.6.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -232,8 +232,8 @@ fn legacy_release_guard_source(source: &str) -> Result<()> {
         "$tag = $env:GITHUB_REF_NAME",
         r#"$tag -match '^v(?<major>\d+)\.'"#,
         "$major -ge 4",
-        "v4 publication is disabled in the legacy v3 release workflow until the dedicated release authority work order is complete",
-        "WO-04/WO-07",
+        "v4 publication is prohibited in the legacy v3 release workflow; use the dedicated v4 release authority",
+        "dedicated v4 release authority",
     ] {
         if !source.contains(marker) {
             return Err(format!(
@@ -250,6 +250,154 @@ fn legacy_release_guard(root: &Path) -> Result<()> {
     legacy_release_guard_source(&fs::read_to_string(&path)?)
         .map_err(|error| format!("{}: {error}", path.display()))?;
     println!("[xtask] legacy v3 release workflow v4 guard: PASS");
+    Ok(())
+}
+
+fn release_authority_contract(root: &Path) -> Result<()> {
+    let native_path = root.join("desktop/src-tauri/src/native_update.rs");
+    let native = fs::read_to_string(&native_path)?;
+    for marker in [
+        "V4_RELEASE_AUTHORITY_REPOSITORY",
+        "V4_STABLE_METADATA_ENDPOINT",
+        "V4_BETA_METADATA_ENDPOINT",
+        "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json",
+        "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json",
+        "endpoints(vec![endpoint])",
+        "production_authority_is_fixed_and_channel_isolated",
+    ] {
+        if !native.contains(marker) {
+            return Err(format!(
+                "Rust updater authority is missing the fixed v4 contract marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "api.github.com/repos/pumni/Sky-Auto-Player/releases",
+        "update_authority_not_configured",
+        "std::env::var(\"",
+    ] {
+        if native.contains(forbidden) {
+            return Err(format!(
+                "Rust v4 updater authority contains a forbidden fallback/injection marker: {forbidden}"
+            )
+            .into());
+        }
+    }
+
+    let generator_path = root.join("rust/xtask/src/release_authority.rs");
+    let generator = fs::read_to_string(&generator_path)?;
+    for marker in [
+        "AUTHORITY_REPOSITORY: &str = \"pumni/Sky-Auto-Player-Releases\"",
+        "STABLE_METADATA_PATH: &str = \"channels/stable/latest.json\"",
+        "BETA_METADATA_PATH: &str = \"channels/beta/latest.json\"",
+        "WINDOWS_PLATFORM: &str = \"windows-x86_64\"",
+        "canonical_installer_name",
+        "canonical_asset_url",
+        "valid_utc_timestamp",
+        "valid_signature",
+        "version::parse",
+        "parsed_version.major != 4",
+    ] {
+        if !generator.contains(marker) {
+            return Err(format!(
+                "v4 metadata generator is missing its deterministic validation marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "pumni/Sky-Auto-Player/releases",
+        "example.invalid",
+        "dangerousInsecureTransportProtocol",
+    ] {
+        if generator.contains(forbidden) {
+            return Err(format!(
+                "v4 metadata generator contains a forbidden authority marker: {forbidden}"
+            )
+            .into());
+        }
+    }
+
+    let acceptance_path = root.join("scripts/ci_v4_release_authority_acceptance.ps1");
+    let acceptance = fs::read_to_string(&acceptance_path)?;
+    for marker in [
+        "This is deliberately read-only",
+        "$sourceRepository = \"pumni/Sky-Auto-Player\"",
+        "$authorityRepository = \"pumni/Sky-Auto-Player-Releases\"",
+        "releases/latest",
+        "read_only=true",
+    ] {
+        if !acceptance.contains(marker) {
+            return Err(format!(
+                "v4 release authority acceptance is missing its read-only marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "gh release create",
+        "gh release upload",
+        "gh release delete",
+        "softprops/action-gh-release",
+    ] {
+        if acceptance.contains(forbidden) {
+            return Err(format!(
+                "read-only v4 authority acceptance contains a release mutation: {forbidden}"
+            )
+            .into());
+        }
+    }
+
+    let promotion_path = root.join("scripts/promote_v4_metadata.ps1");
+    let promotion = fs::read_to_string(&promotion_path)?;
+    for marker in [
+        "[ValidateSet(\"stable\", \"beta\")]",
+        "$authorityRepository = \"pumni/Sky-Auto-Player-Releases\"",
+        "$QualificationEvidence",
+        "release-authority validate --channel $Channel",
+        "releases/tags/v$version",
+        "published_at",
+        "Copy-Item -LiteralPath $Metadata",
+        "never publishes or mutates a GitHub release",
+    ] {
+        if !promotion.contains(marker) {
+            return Err(format!(
+                "v4 metadata promotion is missing its post-publication marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "gh release create",
+        "gh release upload",
+        "softprops/action-gh-release",
+        "pumni/Sky-Auto-Player/releases",
+    ] {
+        if promotion.contains(forbidden) {
+            return Err(format!(
+                "v4 metadata promotion contains a forbidden release mutation/fallback: {forbidden}"
+            )
+            .into());
+        }
+    }
+
+    let ci_path = root.join(".github/workflows/ci.yml");
+    let ci = fs::read_to_string(&ci_path)?;
+    for marker in [
+        "release_authority:",
+        "name: V4 release authority acceptance",
+        "scripts/ci_v4_release_authority_acceptance.ps1",
+        "RELEASE_AUTHORITY_RESULT",
+        "needs: [changes, static, release_authority, supply_chain, validate, updater_e2e, packaged]",
+    ] {
+        if !ci.contains(marker) {
+            return Err(
+                format!("CI is missing the v4 release authority gate marker: {marker}").into(),
+            );
+        }
+    }
+    println!("[xtask] v4 release authority contract: PASS");
     Ok(())
 }
 
@@ -335,7 +483,7 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
     }
 
     for marker in [
-        "needs: [changes, static, supply_chain, validate, updater_e2e, packaged]",
+        "needs: [changes, static, release_authority, supply_chain, validate, updater_e2e, packaged]",
         "UPDATER_E2E_RESULT",
     ] {
         if !normalized.contains(marker) {
@@ -1660,6 +1808,7 @@ pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
             branding::validate(&root)?;
             tauri_bundle::validate_config(&root)?;
             legacy_release_guard(&root)?;
+            release_authority_contract(&root)?;
             packaged_ci_contract(&root)?;
             retirement(&root)?;
         }
@@ -1889,7 +2038,7 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
     }
 
     #[test]
-    fn legacy_release_guard_requires_the_v4_fail_closed_contract() {
+    fn legacy_release_guard_requires_the_permanent_v4_namespace_guard() {
         let source = r#"
       - name: Block v4+ tags from legacy v3 release workflow
         run: |
@@ -1897,15 +2046,48 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
           if ($tag -match '^v(?<major>\d+)\.') {
             $major = [int64]$Matches.major
             if ($major -ge 4) {
-              throw "v4 publication is disabled in the legacy v3 release workflow until the dedicated release authority work order is complete: $tag"
+              throw "v4 publication is prohibited in the legacy v3 release workflow; use the dedicated v4 release authority: $tag"
             }
           }
-      # WO-04/WO-07
 "#;
         assert!(legacy_release_guard_source(source).is_ok());
         assert!(
             legacy_release_guard_source(&source.replace("$major -ge 4", "$major -gt 4")).is_err()
         );
+    }
+
+    #[test]
+    fn release_authority_contract_requires_rust_owned_channels_and_read_only_acceptance() {
+        let native = r#"
+const V4_RELEASE_AUTHORITY_REPOSITORY: &str = "pumni/Sky-Auto-Player-Releases";
+const V4_STABLE_METADATA_ENDPOINT: &str = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json";
+const V4_BETA_METADATA_ENDPOINT: &str = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json";
+endpoints(vec![endpoint])
+fn production_authority_is_fixed_and_channel_isolated() {}
+"#;
+        for marker in [
+            "V4_RELEASE_AUTHORITY_REPOSITORY",
+            "V4_STABLE_METADATA_ENDPOINT",
+            "V4_BETA_METADATA_ENDPOINT",
+            "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json",
+            "https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json",
+            "endpoints(vec![endpoint])",
+            "production_authority_is_fixed_and_channel_isolated",
+        ] {
+            assert!(native.contains(marker), "{marker}");
+        }
+        assert!(!native.contains("api.github.com/repos/pumni/Sky-Auto-Player/releases"));
+
+        let acceptance = r#"
+# This is deliberately read-only.
+$sourceRepository = "pumni/Sky-Auto-Player"
+$authorityRepository = "pumni/Sky-Auto-Player-Releases"
+releases/latest
+read_only=true
+"#;
+        assert!(acceptance.contains("This is deliberately read-only"));
+        assert!(acceptance.contains("releases/latest"));
+        assert!(!acceptance.contains("gh release create"));
     }
 
     #[test]
@@ -1935,7 +2117,7 @@ packaged-assets = ["tauri/custom-protocol", "tauri/compression"]
        - uses: actions/upload-artifact@v7
          path: rust/target/dist/bundle/nsis
   status:
-    needs: [changes, static, supply_chain, validate, updater_e2e, packaged]
+    needs: [changes, static, release_authority, supply_chain, validate, updater_e2e, packaged]
     env: { UPDATER_E2E_RESULT: success }
         "#;
         assert!(packaged_ci_contract_source(source).is_ok());

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -319,6 +319,22 @@ fn release_authority_contract(root: &Path) -> Result<()> {
         }
     }
 
+    let bundle_path = root.join("rust/xtask/src/tauri_bundle.rs");
+    let bundle = fs::read_to_string(&bundle_path)?;
+    for marker in [
+        "schema_version: 2",
+        "evidence_type: \"tauri-nsis-artifact\"",
+        "installer_sha256",
+        "updater_signature_sha256",
+    ] {
+        if !bundle.contains(marker) {
+            return Err(format!(
+                "Tauri artifact evidence is missing its exact-byte marker: {marker}"
+            )
+            .into());
+        }
+    }
+
     let acceptance_path = root.join("scripts/ci_v4_release_authority_acceptance.ps1");
     let acceptance = fs::read_to_string(&acceptance_path)?;
     for marker in [
@@ -358,6 +374,12 @@ fn release_authority_contract(root: &Path) -> Result<()> {
         "release-authority validate --channel $Channel",
         "releases/tags/v$version",
         "published_at",
+        "installer_sha256",
+        "updater_signature_sha256",
+        "Get-PublishedAssetSha256",
+        "Assert-PublishedAsset",
+        "Invoke-PromotionSelfTest",
+        "same-name/different-bytes",
         "Copy-Item -LiteralPath $Metadata",
         "never publishes or mutates a GitHub release",
     ] {
@@ -388,6 +410,9 @@ fn release_authority_contract(root: &Path) -> Result<()> {
         "release_authority:",
         "name: V4 release authority acceptance",
         "scripts/ci_v4_release_authority_acceptance.ps1",
+        "scripts/promote_v4_metadata.ps1 -SelfTest",
+        "Emit exact Tauri qualification evidence",
+        "V4_QUALIFICATION_EVIDENCE.json",
         "RELEASE_AUTHORITY_RESULT",
         "needs: [changes, static, release_authority, supply_chain, validate, updater_e2e, packaged]",
     ] {

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -7,6 +7,7 @@ mod classifier;
 mod dist;
 mod manifest;
 mod process;
+mod release_authority;
 mod repo;
 mod supply_chain;
 mod tauri_bundle;
@@ -19,7 +20,7 @@ use std::path::Path;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn usage() -> &'static str {
-    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> [--summary <path>]\n  cargo xtask verify-dist --release-dir <dir>"
+    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> [--summary <path>]\n  cargo xtask verify-dist --release-dir <dir>\n  cargo xtask release-authority generate --channel <stable|beta> --version <semver> --notes-file <path> --pub-date <rfc3339> --platform windows-x86_64 --asset-url <url> --signature-file <path> --output <path>\n  cargo xtask release-authority validate --channel <stable|beta> --metadata <path>"
 }
 
 fn required_value(args: &[String], index: &mut usize, option: &str) -> Result<String> {
@@ -221,6 +222,116 @@ fn main() -> Result<()> {
                 summary.as_deref().map(Path::new),
             )
         }
+        "release-authority" => match args.get(1).map(String::as_str) {
+            Some("generate") => {
+                let mut channel = None;
+                let mut version = None;
+                let mut notes_file = None;
+                let mut pub_date = None;
+                let mut platform = None;
+                let mut asset_url = None;
+                let mut signature_file = None;
+                let mut output = None;
+                let mut i = 2;
+                while i < args.len() {
+                    match args[i].as_str() {
+                        "--channel" => channel = Some(required_value(&args, &mut i, "--channel")?),
+                        "--version" => version = Some(required_value(&args, &mut i, "--version")?),
+                        "--notes-file" => {
+                            notes_file = Some(required_value(&args, &mut i, "--notes-file")?)
+                        }
+                        "--pub-date" => {
+                            pub_date = Some(required_value(&args, &mut i, "--pub-date")?)
+                        }
+                        "--platform" => {
+                            platform = Some(required_value(&args, &mut i, "--platform")?)
+                        }
+                        "--asset-url" => {
+                            asset_url = Some(required_value(&args, &mut i, "--asset-url")?)
+                        }
+                        "--signature-file" => {
+                            signature_file =
+                                Some(required_value(&args, &mut i, "--signature-file")?)
+                        }
+                        "--output" => output = Some(required_value(&args, &mut i, "--output")?),
+                        option => {
+                            return Err(format!(
+                                "unknown release-authority generate option: {option}"
+                            )
+                            .into());
+                        }
+                    }
+                    i += 1;
+                }
+                release_authority::generate(release_authority::GenerateInput {
+                    channel: release_authority::Channel::parse(
+                        channel
+                            .as_deref()
+                            .ok_or("release-authority generate requires --channel <stable|beta>")?,
+                    )?,
+                    version: version
+                        .as_deref()
+                        .ok_or("release-authority generate requires --version <semver>")?,
+                    notes_path: Path::new(
+                        notes_file
+                            .as_deref()
+                            .ok_or("release-authority generate requires --notes-file <path>")?,
+                    ),
+                    pub_date: pub_date
+                        .as_deref()
+                        .ok_or("release-authority generate requires --pub-date <rfc3339>")?,
+                    platform: platform
+                        .as_deref()
+                        .ok_or("release-authority generate requires --platform windows-x86_64")?,
+                    asset_url: asset_url
+                        .as_deref()
+                        .ok_or("release-authority generate requires --asset-url <url>")?,
+                    signature_path: Path::new(
+                        signature_file
+                            .as_deref()
+                            .ok_or("release-authority generate requires --signature-file <path>")?,
+                    ),
+                    output: Path::new(
+                        output
+                            .as_deref()
+                            .ok_or("release-authority generate requires --output <path>")?,
+                    ),
+                })
+            }
+            Some("validate") => {
+                let mut channel = None;
+                let mut metadata = None;
+                let mut i = 2;
+                while i < args.len() {
+                    match args[i].as_str() {
+                        "--channel" => channel = Some(required_value(&args, &mut i, "--channel")?),
+                        "--metadata" => {
+                            metadata = Some(required_value(&args, &mut i, "--metadata")?)
+                        }
+                        option => {
+                            return Err(format!(
+                                "unknown release-authority validate option: {option}"
+                            )
+                            .into());
+                        }
+                    }
+                    i += 1;
+                }
+                release_authority::validate(
+                    release_authority::Channel::parse(
+                        channel
+                            .as_deref()
+                            .ok_or("release-authority validate requires --channel <stable|beta>")?,
+                    )?,
+                    Path::new(
+                        metadata
+                            .as_deref()
+                            .ok_or("release-authority validate requires --metadata <path>")?,
+                    ),
+                )
+            }
+            _ => Err("release-authority requires generate or validate".into()),
+        },
         _ => {
             eprintln!("{}", usage());
             Err(format!("unknown command: {}", args[0]).into())

--- a/rust/xtask/src/release_authority.rs
+++ b/rust/xtask/src/release_authority.rs
@@ -137,7 +137,7 @@ fn build_metadata(
     Ok(metadata)
 }
 
-fn validate_metadata(metadata: &TauriMetadata, _channel: Channel) -> Result<()> {
+fn validate_metadata(metadata: &TauriMetadata, channel: Channel) -> Result<()> {
     let parsed_version = version::parse(&metadata.version)?;
     if parsed_version.major != 4 {
         return Err(format!(
@@ -145,6 +145,23 @@ fn validate_metadata(metadata: &TauriMetadata, _channel: Channel) -> Result<()> 
             metadata.version
         )
         .into());
+    }
+    match channel {
+        Channel::Stable if !parsed_version.pre.is_empty() => {
+            return Err(format!(
+                "stable metadata must not contain a prerelease version: {}",
+                metadata.version
+            )
+            .into());
+        }
+        Channel::Beta if parsed_version.pre.is_empty() => {
+            return Err(format!(
+                "beta metadata must contain a prerelease version: {}",
+                metadata.version
+            )
+            .into());
+        }
+        _ => {}
     }
     if metadata.notes.chars().count() > MAX_NOTES_CHARS || metadata.notes.contains('\0') {
         return Err("updater notes are empty-safe but must be bounded and NUL-free".into());
@@ -375,5 +392,23 @@ mod tests {
             .unwrap()
             .signature = "signature-path.sig".into();
         assert!(validate_metadata(&bad_signature, Channel::Stable).is_err());
+    }
+
+    #[test]
+    fn channel_policy_keeps_stable_and_beta_candidates_isolated() {
+        let stable_url = canonical_asset_url("4.0.0");
+        assert!(validate_metadata(&metadata("4.0.0", &stable_url), Channel::Stable).is_ok());
+        for prerelease in ["4.0.0-beta.1", "4.0.0-rc.1"] {
+            let url = canonical_asset_url(prerelease);
+            assert!(
+                validate_metadata(&metadata(prerelease, &url), Channel::Stable).is_err(),
+                "stable accepted {prerelease}"
+            );
+            assert!(
+                validate_metadata(&metadata(prerelease, &url), Channel::Beta).is_ok(),
+                "beta rejected {prerelease}"
+            );
+        }
+        assert!(validate_metadata(&metadata("4.0.0", &stable_url), Channel::Beta).is_err());
     }
 }

--- a/rust/xtask/src/release_authority.rs
+++ b/rust/xtask/src/release_authority.rs
@@ -1,0 +1,379 @@
+use crate::{Result, version};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use url::Url;
+
+pub const AUTHORITY_REPOSITORY: &str = "pumni/Sky-Auto-Player-Releases";
+pub const SOURCE_REPOSITORY: &str = "pumni/Sky-Auto-Player";
+pub const STABLE_METADATA_PATH: &str = "channels/stable/latest.json";
+pub const BETA_METADATA_PATH: &str = "channels/beta/latest.json";
+pub const WINDOWS_PLATFORM: &str = "windows-x86_64";
+pub const PRODUCT_NAME: &str = "Sky Auto Player";
+pub const WINDOWS_ARCH: &str = "x64";
+const MAX_NOTES_CHARS: usize = 16 * 1024;
+const MAX_SIGNATURE_CHARS: usize = 8 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Channel {
+    Stable,
+    Beta,
+}
+
+impl Channel {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "stable" => Ok(Self::Stable),
+            "beta" => Ok(Self::Beta),
+            _ => Err(format!("channel must be stable or beta, got {value:?}").into()),
+        }
+    }
+
+    pub const fn metadata_path(self) -> &'static str {
+        match self {
+            Self::Stable => STABLE_METADATA_PATH,
+            Self::Beta => BETA_METADATA_PATH,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PlatformMetadata {
+    pub signature: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct TauriMetadata {
+    pub version: String,
+    pub notes: String,
+    pub pub_date: String,
+    pub platforms: BTreeMap<String, PlatformMetadata>,
+}
+
+#[derive(Clone, Copy)]
+pub struct GenerateInput<'a> {
+    pub channel: Channel,
+    pub version: &'a str,
+    pub notes_path: &'a Path,
+    pub pub_date: &'a str,
+    pub platform: &'a str,
+    pub asset_url: &'a str,
+    pub signature_path: &'a Path,
+    pub output: &'a Path,
+}
+
+pub fn canonical_installer_name(version: &str) -> String {
+    format!("{PRODUCT_NAME}_{version}_{WINDOWS_ARCH}-setup.exe")
+}
+
+pub fn canonical_asset_url(version: &str) -> String {
+    format!(
+        "https://github.com/{AUTHORITY_REPOSITORY}/releases/download/v{version}/{}",
+        canonical_installer_name(version).replace(' ', "%20")
+    )
+}
+
+pub fn generate(input: GenerateInput<'_>) -> Result<()> {
+    let notes = normalise_notes(&fs::read_to_string(input.notes_path)?)?;
+    let signature = normalise_signature(&fs::read_to_string(input.signature_path)?)?;
+    let metadata = build_metadata(
+        input.channel,
+        input.version,
+        notes,
+        input.pub_date,
+        input.platform,
+        input.asset_url,
+        signature,
+    )?;
+    let payload = serde_json::to_string_pretty(&metadata)? + "\n";
+    fs::write(input.output, payload.as_bytes())?;
+    println!(
+        "[xtask] generated {} v{} metadata: {}",
+        channel_name(input.channel),
+        metadata.version,
+        input.output.display()
+    );
+    Ok(())
+}
+
+pub fn validate(channel: Channel, metadata_path: &Path) -> Result<()> {
+    let metadata: TauriMetadata = serde_json::from_slice(&fs::read(metadata_path)?)?;
+    validate_metadata(&metadata, channel)?;
+    println!(
+        "[xtask] v4 {} metadata: PASS (v{}, destination {})",
+        channel_name(channel),
+        metadata.version,
+        channel.metadata_path()
+    );
+    Ok(())
+}
+
+fn build_metadata(
+    channel: Channel,
+    version_value: &str,
+    notes: String,
+    pub_date: &str,
+    platform: &str,
+    asset_url: &str,
+    signature: String,
+) -> Result<TauriMetadata> {
+    let mut platforms = BTreeMap::new();
+    platforms.insert(
+        platform.to_owned(),
+        PlatformMetadata {
+            signature,
+            url: asset_url.to_owned(),
+        },
+    );
+    let metadata = TauriMetadata {
+        version: version_value.to_owned(),
+        notes,
+        pub_date: pub_date.to_owned(),
+        platforms,
+    };
+    validate_metadata(&metadata, channel)?;
+    Ok(metadata)
+}
+
+fn validate_metadata(metadata: &TauriMetadata, _channel: Channel) -> Result<()> {
+    let parsed_version = version::parse(&metadata.version)?;
+    if parsed_version.major != 4 {
+        return Err(format!(
+            "v4 updater metadata must contain a major version of 4: {}",
+            metadata.version
+        )
+        .into());
+    }
+    if metadata.notes.chars().count() > MAX_NOTES_CHARS || metadata.notes.contains('\0') {
+        return Err("updater notes are empty-safe but must be bounded and NUL-free".into());
+    }
+    if !valid_utc_timestamp(&metadata.pub_date) {
+        return Err(format!(
+            "pub_date must be a second-precision RFC3339 UTC timestamp: {}",
+            metadata.pub_date
+        )
+        .into());
+    }
+    if metadata.platforms.len() != 1 || !metadata.platforms.contains_key(WINDOWS_PLATFORM) {
+        return Err(format!(
+            "metadata must contain exactly the canonical {WINDOWS_PLATFORM} platform"
+        )
+        .into());
+    }
+    let platform = metadata
+        .platforms
+        .get(WINDOWS_PLATFORM)
+        .expect("platform presence checked above");
+    if !valid_signature(&platform.signature) {
+        return Err("Tauri updater signature must be non-empty base64 text".into());
+    }
+    let expected_asset_url = canonical_asset_url(&metadata.version);
+    if platform.url.contains(&format!("/{SOURCE_REPOSITORY}/")) {
+        return Err("v4 metadata must not point at the v3 source repository".into());
+    }
+    if platform.url != expected_asset_url {
+        return Err(format!(
+            "asset URL must be the exact immutable authority URL {expected_asset_url}"
+        )
+        .into());
+    }
+    let parsed_url = Url::parse(&platform.url)?;
+    if parsed_url.scheme() != "https"
+        || parsed_url.host_str() != Some("github.com")
+        || parsed_url.username() != ""
+        || parsed_url.password().is_some()
+        || parsed_url.query().is_some()
+        || parsed_url.fragment().is_some()
+    {
+        return Err(
+            "asset URL must be an HTTPS GitHub authority URL without credentials or query state"
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+fn normalise_notes(value: &str) -> Result<String> {
+    let normalised = value.replace("\r\n", "\n");
+    let normalised = normalised.trim_end_matches('\n').to_owned();
+    if normalised.chars().count() > MAX_NOTES_CHARS || normalised.contains('\0') {
+        return Err("release notes exceed the bounded metadata input contract".into());
+    }
+    Ok(normalised)
+}
+
+fn normalise_signature(value: &str) -> Result<String> {
+    let signature = value.trim();
+    if !valid_signature(signature) {
+        return Err("Tauri .sig input must be non-empty base64 text".into());
+    }
+    Ok(signature.to_owned())
+}
+
+fn valid_signature(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= MAX_SIGNATURE_CHARS
+        && value.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '+' | '/' | '=')
+        })
+}
+
+fn valid_utc_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 20
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes[10] != b'T'
+        || bytes[13] != b':'
+        || bytes[16] != b':'
+        || bytes[19] != b'Z'
+    {
+        return false;
+    }
+    if !bytes
+        .iter()
+        .enumerate()
+        .all(|(index, value)| matches!(index, 4 | 7 | 10 | 13 | 16 | 19) || value.is_ascii_digit())
+    {
+        return false;
+    }
+    let number = |start: usize, end: usize| {
+        value[start..end]
+            .parse::<u32>()
+            .expect("digit positions were checked")
+    };
+    let year = number(0, 4);
+    let month = number(5, 7);
+    let day = number(8, 10);
+    let hour = number(11, 13);
+    let minute = number(14, 16);
+    let second = number(17, 19);
+    let days_in_month = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 400 == 0 || (year % 4 == 0 && year % 100 != 0) => 29,
+        2 => 28,
+        _ => 0,
+    };
+    (1..=12).contains(&month)
+        && (1..=days_in_month).contains(&day)
+        && hour <= 23
+        && minute <= 59
+        && second <= 59
+}
+
+fn channel_name(channel: Channel) -> &'static str {
+    match channel {
+        Channel::Stable => "stable",
+        Channel::Beta => "beta",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metadata(version: &str, url: &str) -> TauriMetadata {
+        TauriMetadata {
+            version: version.into(),
+            notes: "qualified candidate".into(),
+            pub_date: "2026-09-04T00:00:00Z".into(),
+            platforms: BTreeMap::from([(
+                WINDOWS_PLATFORM.into(),
+                PlatformMetadata {
+                    signature: "c2lnbmF0dXJl".into(),
+                    url: url.into(),
+                },
+            )]),
+        }
+    }
+
+    #[test]
+    fn canonical_metadata_is_deterministic_and_uses_the_real_tauri_name() {
+        let url = canonical_asset_url("4.0.0-beta.1");
+        assert_eq!(
+            url,
+            "https://github.com/pumni/Sky-Auto-Player-Releases/releases/download/v4.0.0-beta.1/Sky%20Auto%20Player_4.0.0-beta.1_x64-setup.exe"
+        );
+        let first = serde_json::to_string_pretty(&metadata("4.0.0-beta.1", &url)).unwrap();
+        let second = serde_json::to_string_pretty(&metadata("4.0.0-beta.1", &url)).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn generator_normalises_inputs_and_emits_valid_static_metadata() {
+        let root =
+            std::env::temp_dir().join(format!("sky-v4-release-authority-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let notes = root.join("notes.md");
+        let signature = root.join("installer.exe.sig");
+        let output = root.join("latest.json");
+        fs::write(&notes, "qualified candidate\r\n").unwrap();
+        fs::write(&signature, "c2lnbmF0dXJl\n").unwrap();
+        let asset_url = canonical_asset_url("4.0.0-beta.1");
+        let input = GenerateInput {
+            channel: Channel::Beta,
+            version: "4.0.0-beta.1",
+            notes_path: &notes,
+            pub_date: "2026-09-04T00:00:00Z",
+            platform: WINDOWS_PLATFORM,
+            asset_url: &asset_url,
+            signature_path: &signature,
+            output: &output,
+        };
+        generate(input).unwrap();
+        let first = fs::read(&output).unwrap();
+        validate(Channel::Beta, &output).unwrap();
+        generate(input).unwrap();
+        assert_eq!(first, fs::read(&output).unwrap());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn stable_and_beta_destinations_are_structurally_distinct() {
+        assert_ne!(
+            Channel::Stable.metadata_path(),
+            Channel::Beta.metadata_path()
+        );
+        assert!(Channel::Stable.metadata_path().contains("channels/stable/"));
+        assert!(Channel::Beta.metadata_path().contains("channels/beta/"));
+    }
+
+    #[test]
+    fn validator_rejects_source_repo_and_noncanonical_assets() {
+        let valid = canonical_asset_url("4.0.0");
+        assert!(validate_metadata(&metadata("4.0.0", &valid), Channel::Stable).is_ok());
+        for url in [
+            valid.replace(AUTHORITY_REPOSITORY, SOURCE_REPOSITORY),
+            valid.replace("https://", "http://"),
+            valid.replace("_x64-setup.exe", "_x64-setup.exe?channel=beta"),
+            valid.replace("Sky%20Auto%20Player", "Sky-Auto-Player-v4"),
+        ] {
+            assert!(
+                validate_metadata(&metadata("4.0.0", &url), Channel::Stable).is_err(),
+                "{url}"
+            );
+        }
+    }
+
+    #[test]
+    fn validator_rejects_build_metadata_bad_dates_and_bad_signatures() {
+        let url = canonical_asset_url("4.0.0");
+        for version_value in ["4.0.0+build", "3.9.9", "v4.0.0"] {
+            assert!(validate_metadata(&metadata(version_value, &url), Channel::Stable).is_err());
+        }
+        let mut bad_date = metadata("4.0.0", &url);
+        bad_date.pub_date = "2026-09-04T00:00:00+00:00".into();
+        assert!(validate_metadata(&bad_date, Channel::Stable).is_err());
+        let mut bad_signature = metadata("4.0.0", &url);
+        bad_signature
+            .platforms
+            .get_mut(WINDOWS_PLATFORM)
+            .unwrap()
+            .signature = "signature-path.sig".into();
+        assert!(validate_metadata(&bad_signature, Channel::Stable).is_err());
+    }
+}

--- a/rust/xtask/src/tauri_bundle.rs
+++ b/rust/xtask/src/tauri_bundle.rs
@@ -1,4 +1,4 @@
-use crate::{Result, repo, version};
+use crate::{Result, manifest, repo, version};
 use serde::Serialize;
 use serde_json::{Value, json};
 use std::fs;
@@ -14,6 +14,7 @@ const WINDOWS_ARCH: &str = "x64";
 #[derive(Debug, Serialize)]
 struct ArtifactSummary {
     schema_version: u32,
+    evidence_type: &'static str,
     product_name: &'static str,
     identifier: &'static str,
     version: String,
@@ -23,6 +24,8 @@ struct ArtifactSummary {
     updater_signature: String,
     installer_size: u64,
     signature_size: u64,
+    installer_sha256: String,
+    updater_signature_sha256: String,
 }
 
 fn object<'a>(value: &'a Value, key: &str) -> Result<&'a serde_json::Map<String, Value>> {
@@ -208,7 +211,8 @@ fn artifact_summary(bundle_dir: &Path, project_version: &str) -> Result<Artifact
     }
 
     Ok(ArtifactSummary {
-        schema_version: 1,
+        schema_version: 2,
+        evidence_type: "tauri-nsis-artifact",
         product_name: PRODUCT_NAME,
         identifier: V4_IDENTIFIER,
         version: project_version.to_owned(),
@@ -222,6 +226,8 @@ fn artifact_summary(bundle_dir: &Path, project_version: &str) -> Result<Artifact
             .into_owned(),
         installer_size: installer.metadata()?.len(),
         signature_size: signature.metadata()?.len(),
+        installer_sha256: manifest::sha256(installer)?,
+        updater_signature_sha256: manifest::sha256(&signature)?,
     })
 }
 

--- a/rust/xtask/src/tauri_bundle.rs
+++ b/rust/xtask/src/tauri_bundle.rs
@@ -9,6 +9,7 @@ const V4_IDENTIFIER: &str = "io.github.pumni.skyautoplayer";
 const PRODUCT_NAME: &str = "Sky Auto Player";
 const NSIS_TARGET: &str = "nsis";
 const CURRENT_USER_INSTALL_MODE: &str = "currentUser";
+const WINDOWS_ARCH: &str = "x64";
 
 #[derive(Debug, Serialize)]
 struct ArtifactSummary {
@@ -99,7 +100,7 @@ fn validate_config_value(config: &Value, project_version: &str) -> Result<()> {
         })
     {
         return Err(
-            "WO-01 must not commit v4 updater endpoints or trust keys before the release authority exists".into(),
+            "checked-in Tauri updater endpoints and trust keys are forbidden: endpoints are Rust-owned and the v4 trust root belongs to WO-05".into(),
         );
     }
     Ok(())
@@ -198,10 +199,10 @@ fn artifact_summary(bundle_dir: &Path, project_version: &str) -> Result<Artifact
         return Err("Tauri updater signature is empty".into());
     }
     let installer_name = installer.file_name().unwrap().to_string_lossy();
-    let expected_prefix = format!("{PRODUCT_NAME}_{project_version}_");
-    if !installer_name.starts_with(&expected_prefix) {
+    let expected_name = format!("{PRODUCT_NAME}_{project_version}_{WINDOWS_ARCH}-setup.exe");
+    if installer_name != expected_name {
         return Err(format!(
-            "Tauri installer name does not match canonical product/version {expected_prefix}: {installer_name}"
+            "Tauri installer name does not match canonical product/version {expected_name}: {installer_name}"
         )
         .into());
     }
@@ -288,7 +289,7 @@ mod tests {
     }
 
     #[test]
-    fn config_contract_rejects_v4_updater_authority_before_wo03() {
+    fn config_contract_rejects_unowned_v4_updater_configuration() {
         let mut config = valid_config();
         config["plugins"] = json!({"updater": {"endpoints": ["https://example.invalid"]}});
         assert!(validate_config_value(&config, "4.0.0-alpha.1").is_err());

--- a/scripts/ci_v4_release_authority_acceptance.ps1
+++ b/scripts/ci_v4_release_authority_acceptance.ps1
@@ -1,0 +1,56 @@
+$ErrorActionPreference = "Stop"
+
+# This is deliberately read-only. It proves the public v3 discovery response
+# still resolves to a v3 release while the dedicated v4 authority exists. It
+# never creates, edits, publishes, or deletes a release.
+$sourceRepository = "pumni/Sky-Auto-Player"
+$authorityRepository = "pumni/Sky-Auto-Player-Releases"
+
+function Get-GitHubJson([string]$Path) {
+    $payload = & gh api $Path --header "Accept: application/vnd.github+json"
+    if ($LASTEXITCODE -ne 0) {
+        throw "GitHub read failed for $Path"
+    }
+    return ($payload -join "`n") | ConvertFrom-Json
+}
+
+$source = Get-GitHubJson "repos/$sourceRepository/releases/latest"
+if ($source.url -notlike "https://api.github.com/repos/$sourceRepository/releases/*") {
+    throw "Unexpected source repository in latest-release response: $($source.url)"
+}
+if ($source.draft -or $source.prerelease) {
+    throw "The v3 latest release must be published and non-prerelease: $($source.tag_name)"
+}
+if ($source.tag_name -notmatch '^v(?<version>3\.\d+\.\d+)$') {
+    throw "The source repository latest release is not a canonical v3 tag: $($source.tag_name)"
+}
+
+$version = $Matches.version
+$assetNames = @($source.assets | ForEach-Object { $_.name })
+$requiredV3Assets = @(
+    "Sky-Auto-Player-v$version.zip",
+    "Sky-Auto-Player-v$version.zip.sha256",
+    "MANIFEST.json"
+)
+foreach ($asset in $requiredV3Assets) {
+    if ($assetNames -notcontains $asset) {
+        throw "The v3 latest release is missing its canonical asset: $asset"
+    }
+}
+if ($assetNames | Where-Object { $_ -match '^Sky Auto Player_4(?:\.\d+|-)'} ) {
+    throw "A canonical v4 Tauri artifact appeared in the v3 source release namespace"
+}
+
+$authority = Get-GitHubJson "repos/$authorityRepository"
+if ($authority.full_name -ne $authorityRepository -or $authority.private) {
+    throw "The dedicated v4 release authority is not the expected public repository"
+}
+
+@"
+V4 release-authority acceptance: PASS
+source_latest_tag=$($source.tag_name)
+source_latest_release=$($source.html_url)
+v4_authority=$($authority.html_url)
+v3_canonical_assets=$($requiredV3Assets -join ',')
+read_only=true
+"@ | Write-Host

--- a/scripts/promote_v4_metadata.ps1
+++ b/scripts/promote_v4_metadata.ps1
@@ -1,0 +1,97 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("stable", "beta")]
+    [string]$Channel,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Metadata,
+
+    [Parameter(Mandatory = $true)]
+    [string]$QualificationEvidence,
+
+    [Parameter(Mandatory = $true)]
+    [string]$AuthorityCheckout,
+
+    [string]$SourceCheckout = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = "Stop"
+$authorityRepository = "pumni/Sky-Auto-Player-Releases"
+$platform = "windows-x86_64"
+$productName = "Sky Auto Player"
+$installerNameSuffix = "_x64-setup.exe"
+
+function Get-GitHubJson([string]$Path) {
+    $payload = & gh api $Path --header "Accept: application/vnd.github+json"
+    if ($LASTEXITCODE -ne 0) { throw "GitHub read failed for $Path" }
+    return ($payload -join "`n") | ConvertFrom-Json
+}
+
+if (-not (Test-Path -LiteralPath $Metadata -PathType Leaf)) {
+    throw "Metadata file does not exist: $Metadata"
+}
+if (-not (Test-Path -LiteralPath $QualificationEvidence -PathType Leaf)) {
+    throw "Qualification evidence does not exist: $QualificationEvidence"
+}
+if (-not (Test-Path -LiteralPath $AuthorityCheckout -PathType Container)) {
+    throw "Authority checkout does not exist: $AuthorityCheckout"
+}
+
+$metadataJson = Get-Content -LiteralPath $Metadata -Raw | ConvertFrom-Json
+$platformJson = $metadataJson.platforms.$platform
+if ($null -eq $platformJson) { throw "Metadata has no $platform entry" }
+$version = [string]$metadataJson.version
+$expectedInstaller = "$productName`_$version$installerNameSuffix"
+$expectedSignature = "$expectedInstaller.sig"
+$evidence = Get-Content -LiteralPath $QualificationEvidence -Raw | ConvertFrom-Json
+if (-not [bool]$evidence.qualified -or [string]$evidence.version -ne $version) {
+    throw "Qualification evidence is not an explicit qualified result for v$version"
+}
+if ([string]$evidence.installer -ne $expectedInstaller -or
+    [string]$evidence.updater_signature -ne $expectedSignature) {
+    throw "Qualification evidence does not identify the canonical Tauri artifact pair"
+}
+
+$sourceRoot = (Resolve-Path -LiteralPath $SourceCheckout).Path
+$metadataPath = (Resolve-Path -LiteralPath $Metadata).Path
+$validation = & cargo run --manifest-path (Join-Path $sourceRoot "rust/Cargo.toml") --locked -p sky_xtask -- `
+    release-authority validate --channel $Channel --metadata $metadataPath
+if ($LASTEXITCODE -ne 0) { throw "v4 metadata structural validation failed" }
+
+$release = Get-GitHubJson "repos/$authorityRepository/releases/tags/v$version"
+if ($release.draft -or [string]::IsNullOrWhiteSpace([string]$release.published_at)) {
+    throw "Cannot promote metadata before the v4 release is published: v$version"
+}
+if ($Channel -eq "stable" -and $release.prerelease) {
+    throw "Stable metadata cannot point at a prerelease: v$version"
+}
+
+$asset = @($release.assets | Where-Object { $_.name -eq $expectedInstaller })
+$signatureAsset = @($release.assets | Where-Object { $_.name -eq $expectedSignature })
+if ($asset.Count -ne 1 -or $signatureAsset.Count -ne 1) {
+    throw "Published release is missing the exact Tauri installer/signature pair"
+}
+if ([string]$asset[0].browser_download_url -ne [string]$platformJson.url) {
+    throw "Metadata URL is not the exact published Tauri asset URL"
+}
+
+$publishedSignature = & gh api $signatureAsset[0].url --header "Accept: application/octet-stream"
+if ($LASTEXITCODE -ne 0) { throw "Could not read the published Tauri signature asset" }
+if (($publishedSignature -join "`n").Trim() -ne ([string]$platformJson.signature).Trim()) {
+    throw "Metadata signature does not match the exact published .sig contents"
+}
+
+$checkoutRoot = (Resolve-Path -LiteralPath $AuthorityCheckout).Path
+$destination = Join-Path $checkoutRoot "channels\$Channel\latest.json"
+$destinationParent = Split-Path -Parent $destination
+New-Item -ItemType Directory -Path $destinationParent -Force | Out-Null
+$temporary = "$destination.$PID.tmp"
+try {
+    Copy-Item -LiteralPath $Metadata -Destination $temporary -Force
+    Move-Item -LiteralPath $temporary -Destination $destination -Force
+} finally {
+    Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Promoted validated v4 $Channel metadata for v$version to $destination"
+Write-Host "The authority checkout must be reviewed and committed separately; this action never publishes or mutates a GitHub release."

--- a/scripts/promote_v4_metadata.ps1
+++ b/scripts/promote_v4_metadata.ps1
@@ -1,30 +1,235 @@
 param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = "Promotion")]
     [ValidateSet("stable", "beta")]
     [string]$Channel,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = "Promotion")]
     [string]$Metadata,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = "Promotion")]
     [string]$QualificationEvidence,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, ParameterSetName = "Promotion")]
     [string]$AuthorityCheckout,
 
-    [string]$SourceCheckout = (Split-Path -Parent $PSScriptRoot)
+    [Parameter(ParameterSetName = "Promotion")]
+    [string]$SourceCheckout = (Split-Path -Parent $PSScriptRoot),
+
+    [Parameter(Mandatory = $true, ParameterSetName = "SelfTest")]
+    [switch]$SelfTest
 )
 
 $ErrorActionPreference = "Stop"
 $authorityRepository = "pumni/Sky-Auto-Player-Releases"
 $platform = "windows-x86_64"
 $productName = "Sky Auto Player"
+$productIdentifier = "io.github.pumni.skyautoplayer"
 $installerNameSuffix = "_x64-setup.exe"
+$evidenceType = "tauri-nsis-qualified-release"
+$evidenceSchemaVersion = 1
 
 function Get-GitHubJson([string]$Path) {
     $payload = & gh api $Path --header "Accept: application/vnd.github+json"
     if ($LASTEXITCODE -ne 0) { throw "GitHub read failed for $Path" }
     return ($payload -join "`n") | ConvertFrom-Json
+}
+
+function Get-RequiredEvidenceString([object]$Evidence, [string]$Name, [int]$MaxLength = 512) {
+    $property = $Evidence.PSObject.Properties[$Name]
+    if ($null -eq $property -or $property.Value -isnot [string]) {
+        throw "Qualification evidence field $Name must be a string"
+    }
+    $value = [string]$property.Value
+    if ([string]::IsNullOrWhiteSpace($value) -or $value.Length -gt $MaxLength) {
+        throw "Qualification evidence field $Name is empty or unbounded"
+    }
+    return $value
+}
+
+function Get-RequiredEvidenceSize([object]$Evidence, [string]$Name) {
+    $property = $Evidence.PSObject.Properties[$Name]
+    if ($null -eq $property -or $property.Value -is [bool] -or
+        ($property.Value -isnot [int] -and $property.Value -isnot [long] -and
+         $property.Value -isnot [uint32] -and $property.Value -isnot [uint64])) {
+        throw "Qualification evidence field $Name must be an integer size"
+    }
+    try { $value = [uint64]$property.Value } catch { throw "Qualification evidence field $Name is invalid" }
+    if ($value -gt 2GB) { throw "Qualification evidence field $Name exceeds the bounded artifact size" }
+    return $value
+}
+
+function Get-RequiredEvidenceSha256([object]$Evidence, [string]$Name) {
+    $value = Get-RequiredEvidenceString $Evidence $Name 128
+    if ($value -notmatch '^[0-9a-fA-F]{64}$') {
+        throw "Qualification evidence field $Name must be a 64-character SHA-256 digest"
+    }
+    return $value.ToLowerInvariant()
+}
+
+function Assert-QualificationEvidence(
+    [object]$Evidence,
+    [string]$Version,
+    [string]$ExpectedInstaller,
+    [string]$ExpectedSignature
+) {
+    if ($null -eq $Evidence -or $Evidence -is [array]) {
+        throw "Qualification evidence must be one JSON object"
+    }
+    $required = @(
+        "schema_version", "evidence_type", "qualified", "qualification",
+        "product_name", "identifier", "version", "target", "install_mode",
+        "installer", "updater_signature", "installer_size", "signature_size",
+        "installer_sha256", "updater_signature_sha256"
+    )
+    $actual = @($Evidence.PSObject.Properties.Name)
+    $unknown = @($actual | Where-Object { $_ -notin $required })
+    $missing = @($required | Where-Object { $_ -notin $actual })
+    if ($unknown.Count -gt 0 -or $missing.Count -gt 0 -or $actual.Count -ne $required.Count) {
+        throw "Qualification evidence schema is not the bounded Tauri qualification schema"
+    }
+    $schemaProperty = $Evidence.PSObject.Properties["schema_version"]
+    if ($schemaProperty.Value -is [bool] -or
+        ($schemaProperty.Value -isnot [int] -and $schemaProperty.Value -isnot [long])) {
+        throw "Qualification evidence schema_version must be an integer"
+    }
+    if ([int]$schemaProperty.Value -ne $evidenceSchemaVersion) {
+        throw "Unsupported qualification evidence schema version"
+    }
+    if ((Get-RequiredEvidenceString $Evidence "evidence_type") -ne $evidenceType -or
+        (Get-RequiredEvidenceString $Evidence "qualification") -ne "install-launch-uninstall") {
+        throw "Qualification evidence type is not the canonical Tauri qualification path"
+    }
+    $qualified = $Evidence.PSObject.Properties["qualified"]
+    if ($qualified.Value -isnot [bool] -or -not $qualified.Value) {
+        throw "Qualification evidence is not an explicit successful result"
+    }
+    foreach ($pair in @(
+        @{ Name = "product_name"; Expected = $productName },
+        @{ Name = "identifier"; Expected = $productIdentifier },
+        @{ Name = "version"; Expected = $Version },
+        @{ Name = "target"; Expected = "nsis" },
+        @{ Name = "install_mode"; Expected = "currentUser" },
+        @{ Name = "installer"; Expected = $ExpectedInstaller },
+        @{ Name = "updater_signature"; Expected = $ExpectedSignature }
+    )) {
+        if ((Get-RequiredEvidenceString $Evidence $pair.Name) -ne $pair.Expected) {
+            throw "Qualification evidence field $($pair.Name) does not match the canonical artifact"
+        }
+    }
+    return [ordered]@{
+        InstallerSize = Get-RequiredEvidenceSize $Evidence "installer_size"
+        SignatureSize = Get-RequiredEvidenceSize $Evidence "signature_size"
+        InstallerSha256 = Get-RequiredEvidenceSha256 $Evidence "installer_sha256"
+        SignatureSha256 = Get-RequiredEvidenceSha256 $Evidence "updater_signature_sha256"
+    }
+}
+
+function Get-CanonicalReleaseAssetUrl([string]$Version, [string]$Name) {
+    return "https://github.com/$authorityRepository/releases/download/v$Version/$([Uri]::EscapeDataString($Name))"
+}
+
+function Get-PublishedAssetSha256([object]$Asset, [string]$ExpectedUrl, [string]$Kind) {
+    $digest = [string]$Asset.digest
+    if (-not [string]::IsNullOrWhiteSpace($digest)) {
+        if ($digest -notmatch '^sha256:[0-9a-fA-F]{64}$') {
+            throw "Published $Kind asset has a malformed SHA-256 digest"
+        }
+        return $digest.Substring(7).ToLowerInvariant()
+    }
+
+    $downloadUrl = [string]$Asset.browser_download_url
+    if ($downloadUrl -ne $ExpectedUrl) {
+        throw "Published $Kind asset has no digest and its download URL is not canonical"
+    }
+    $temporary = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-published-" + [guid]::NewGuid().ToString("N") + ".bin")
+    try {
+        $null = Invoke-WebRequest -UseBasicParsing -Uri $downloadUrl -OutFile $temporary -MaximumRedirection 5
+        return (Get-FileHash -LiteralPath $temporary -Algorithm SHA256).Hash.ToLowerInvariant()
+    } catch {
+        throw "Could not download/hash published $Kind asset: $($_.Exception.Message)"
+    } finally {
+        Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-PublishedAsset(
+    [object]$Asset,
+    [string]$ExpectedName,
+    [string]$ExpectedUrl,
+    [uint64]$ExpectedSize,
+    [string]$ExpectedSha256,
+    [string]$Kind
+) {
+    if ([string]$Asset.name -ne $ExpectedName) {
+        throw "Published $Kind asset name is not canonical"
+    }
+    if ([string]$Asset.browser_download_url -ne $ExpectedUrl) {
+        throw "Published $Kind asset URL is not canonical"
+    }
+    if ($Asset.size -is [bool] -or $null -eq $Asset.size) {
+        throw "Published $Kind asset size is missing or malformed"
+    }
+    try { $actualSize = [uint64]$Asset.size } catch { throw "Published $Kind asset size is malformed" }
+    if ($actualSize -ne $ExpectedSize) {
+        throw "Published $Kind asset size does not match qualification evidence"
+    }
+    $actualSha256 = Get-PublishedAssetSha256 $Asset $ExpectedUrl $Kind
+    if ($actualSha256 -ne $ExpectedSha256) {
+        throw "Published $Kind asset SHA-256 mismatch: expected $ExpectedSha256, got $actualSha256"
+    }
+}
+
+function Invoke-PromotionSelfTest {
+    $version = "4.0.0"
+    $installer = "$productName`_$version$installerNameSuffix"
+    $signature = "$installer.sig"
+    $url = Get-CanonicalReleaseAssetUrl $version $installer
+    $evidence = [pscustomobject]@{
+        schema_version = 1
+        evidence_type = $evidenceType
+        qualified = $true
+        qualification = "install-launch-uninstall"
+        product_name = $productName
+        identifier = $productIdentifier
+        version = $version
+        target = "nsis"
+        install_mode = "currentUser"
+        installer = $installer
+        updater_signature = $signature
+        installer_size = [int64]10
+        signature_size = [int64]10
+        installer_sha256 = "a" * 64
+        updater_signature_sha256 = "a" * 64
+    }
+    $digests = Assert-QualificationEvidence $evidence $version $installer $signature
+    $differentBytes = [pscustomobject]@{
+        name = $installer
+        browser_download_url = $url
+        size = [int64]10
+        digest = "sha256:" + ("b" * 64)
+    }
+    $rejected = $false
+    try {
+        Assert-PublishedAsset $differentBytes $installer $url $digests.InstallerSize $digests.InstallerSha256 "installer"
+    } catch {
+        if ($_.Exception.Message -notmatch "SHA-256 mismatch") { throw }
+        $rejected = $true
+    }
+    if (-not $rejected) { throw "Self-test failed: same-name/different-bytes asset was accepted" }
+
+    $booleanOnly = [pscustomobject]@{ qualified = $true; version = $version }
+    try {
+        Assert-QualificationEvidence $booleanOnly $version $installer $signature
+        throw "Self-test failed: arbitrary qualified=true evidence was accepted"
+    } catch {
+        if ($_.Exception.Message -like "Self-test failed:*") { throw }
+    }
+    Write-Host "V4 promotion evidence self-test: PASS (bounded schema; same-name/different-bytes rejected)"
+}
+
+if ($SelfTest) {
+    Invoke-PromotionSelfTest
+    exit 0
 }
 
 if (-not (Test-Path -LiteralPath $Metadata -PathType Leaf)) {
@@ -44,19 +249,15 @@ $version = [string]$metadataJson.version
 $expectedInstaller = "$productName`_$version$installerNameSuffix"
 $expectedSignature = "$expectedInstaller.sig"
 $evidence = Get-Content -LiteralPath $QualificationEvidence -Raw | ConvertFrom-Json
-if (-not [bool]$evidence.qualified -or [string]$evidence.version -ne $version) {
-    throw "Qualification evidence is not an explicit qualified result for v$version"
-}
-if ([string]$evidence.installer -ne $expectedInstaller -or
-    [string]$evidence.updater_signature -ne $expectedSignature) {
-    throw "Qualification evidence does not identify the canonical Tauri artifact pair"
-}
+$evidenceDigests = $null
 
 $sourceRoot = (Resolve-Path -LiteralPath $SourceCheckout).Path
 $metadataPath = (Resolve-Path -LiteralPath $Metadata).Path
 $validation = & cargo run --manifest-path (Join-Path $sourceRoot "rust/Cargo.toml") --locked -p sky_xtask -- `
     release-authority validate --channel $Channel --metadata $metadataPath
 if ($LASTEXITCODE -ne 0) { throw "v4 metadata structural validation failed" }
+
+$evidenceDigests = Assert-QualificationEvidence $evidence $version $expectedInstaller $expectedSignature
 
 $release = Get-GitHubJson "repos/$authorityRepository/releases/tags/v$version"
 if ($release.draft -or [string]::IsNullOrWhiteSpace([string]$release.published_at)) {
@@ -71,9 +272,15 @@ $signatureAsset = @($release.assets | Where-Object { $_.name -eq $expectedSignat
 if ($asset.Count -ne 1 -or $signatureAsset.Count -ne 1) {
     throw "Published release is missing the exact Tauri installer/signature pair"
 }
-if ([string]$asset[0].browser_download_url -ne [string]$platformJson.url) {
+$expectedInstallerUrl = Get-CanonicalReleaseAssetUrl $version $expectedInstaller
+$expectedSignatureUrl = Get-CanonicalReleaseAssetUrl $version $expectedSignature
+if ([string]$platformJson.url -ne $expectedInstallerUrl) {
     throw "Metadata URL is not the exact published Tauri asset URL"
 }
+Assert-PublishedAsset $asset[0] $expectedInstaller $expectedInstallerUrl `
+    $evidenceDigests.InstallerSize $evidenceDigests.InstallerSha256 "installer"
+Assert-PublishedAsset $signatureAsset[0] $expectedSignature $expectedSignatureUrl `
+    $evidenceDigests.SignatureSize $evidenceDigests.SignatureSha256 "signature"
 
 $publishedSignature = & gh api $signatureAsset[0].url --header "Accept: application/octet-stream"
 if ($LASTEXITCODE -ne 0) { throw "Could not read the published Tauri signature asset" }


### PR DESCRIPTION
Implements WO-04 for #106. Configures fixed Rust-owned stable/beta Tauri metadata authority at pumni/Sky-Auto-Player-Releases; adds deterministic xtask metadata generation and validation for the exact Tauri NSIS installer and .sig pair; adds post-publication qualification evidence checks, read-only namespace acceptance, and a permanent v3 release namespace guard. Preserves the official Tauri updater boundary, channel isolation, fail-closed trust behavior until WO-05, and legacy sky_updater. Validation: cargo xtask check all PASS; public GitHub acceptance PASS with source latest v3.5.0 and a separate public authority. No production metadata or signing key was created or published. Closes #106.