### PR TITLE
feat(v4): prepare production signing readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,6 +727,13 @@ jobs:
             -Source rust/target/dist/sky_desktop_shell.exe
           if ($LASTEXITCODE -ne 0) { throw "Authenticode tamper regression failed with exit code $LASTEXITCODE" }
 
+      - name: Run V4 production signing contract test
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_production_signing_contract.ps1
+          if ($LASTEXITCODE -ne 0) { throw "V4 production signing contract test failed with exit code $LASTEXITCODE" }
+
       - name: Verify Tauri Authenticode signature
         env:
           RUSTUP_TOOLCHAIN: 1.98.0

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,6 +46,10 @@ not open every architecture page by default.
   and current-user packaging contract.
 - [v4-release-authority.md](v4-release-authority.md) — v4 immutable release namespace, static
   metadata, channel isolation, and read-only acceptance contract.
+- [v4-updater-key-custody.md](v4-updater-key-custody.md) — v4 updater trust root custody, backup,
+  loss, compromise, rotation, and recovery runbook.
+- [v4-authenticode-provider-seam.md](v4-authenticode-provider-seam.md) — v4 production Authenticode
+  provider seam specification and contract.
 - [rust-toolchain-policy.md](rust-toolchain-policy.md) — Rust compiler/toolchain policy.
 - [wave5-legacy-python-retirement.md](wave5-legacy-python-retirement.md) — historical evidence for
   the completed product/runtime Python retirement; not a tooling instruction.
@@ -75,12 +79,10 @@ when a task touches those boundaries.
 - `docs/releases/` contains release-specific acceptance/history, not startup context.
 - `docs/perf-baselines/` contains named performance evidence. A baseline is evidence for the
   environment and revision it records, not a universal instruction.
-- Completed implementation plans, migration playbooks, superseded audits, and implementation briefs
-  live in Git history instead of the active documentation tree. Use `git log`, `git show`, or
-  repository history only when historical rationale is actually needed.
+- Completed plans, migration playbooks, superseded audits, and implementation briefs
+  live in Git history. Use `git log` or `git show` only when historical rationale is needed.
 
 ## Documentation maintenance
 
 Keep active docs about the current system. Convert durable decisions into ADRs or current architecture
-contracts; retire completed plans to Git history rather than accumulating prompt-shaped working notes.
-Keep this router concise and prefer source/tests/executable checks over additional routing layers.
+contracts; retire completed plans to Git history. Keep this router concise.

--- a/docs/v4-authenticode-provider-seam.md
+++ b/docs/v4-authenticode-provider-seam.md
@@ -62,10 +62,14 @@ When `SKY_AUTHENTICODE_MODE=production`, the release runner must supply:
    - Identifies the provider mechanism for auditing and telemetry.
    - Examples: `azure-trusted-signing`, `signtool-hsm`, `custom-script`.
 
-3. **Signing Invocation** (Exactly one required):
-   - **`SKY_AUTHENTICODE_PROVIDER_SCRIPT`**: Full path to a PowerShell script accepting `-Path <file>`.
+3. **Signing Invocation** (Exactly one required, mutually exclusive):
+   - **`SKY_AUTHENTICODE_PROVIDER_SCRIPT`** (Preferred): Full path to a structured PowerShell script
+     accepting `-Path <file>`. Structured scripts are preferred over string commands to ensure clean
+     argument passing and error propagation.
    - **`SKY_AUTHENTICODE_PROVIDER_COMMAND`**: Command line template where `%1` or `$Path` is replaced
      by the target file path.
+   - **Mutual Exclusivity**: If both `SKY_AUTHENTICODE_PROVIDER_SCRIPT` and `SKY_AUTHENTICODE_PROVIDER_COMMAND`
+     are set (or if neither is set), signing fails closed immediately.
 
 ### Provider Execution and Post-Signing Verification
 

--- a/docs/v4-authenticode-provider-seam.md
+++ b/docs/v4-authenticode-provider-seam.md
@@ -1,0 +1,122 @@
+# V4 Authenticode Provider Seam Specification
+
+This document formalizes the production Windows Authenticode provider seam for Sky Auto Player v4.
+It defines the provider-neutral contract between the Tauri NSIS packaging pipeline and external code
+signing providers.
+
+This specification is governed by `docs/adr/ADR-0006-v4-distribution-installation-update.md` and
+`SECURITY.md`.
+
+## 1. Provider-Neutral Architecture
+
+Windows binaries (executables and DLLs) shipped in the canonical v4 NSIS installer and the installer
+itself must be signed with an approved Authenticode code signing certificate.
+
+Because signing providers vary across deployment environments (e.g., Azure Trusted Signing,
+hardware tokens/HSMs, cloud key management services, or specialized CI runners), Sky Auto Player
+isolates all signing invocation behind a single provider-neutral script seam:
+
+```text
+scripts/sign_v4_authenticode.ps1 <Path>
+```
+
+Tauri's bundle configuration binds directly to this seam in `desktop/src-tauri/tauri.conf.json`:
+
+```json
+"bundle": {
+  "windows": {
+    "signCommand": "pwsh -NoProfile -ExecutionPolicy Bypass -File ../../scripts/sign_v4_authenticode.ps1 %1"
+  }
+}
+```
+
+## 2. Modes and Security Invariants
+
+The signer operates in two strictly separated modes:
+
+| Mode | Purpose | Trust Model | Rejection Policy |
+| :--- | :--- | :--- | :--- |
+| `test` | Local developer builds and CI qualification | Ephemeral self-signed PFX generated in `RUNNER_TEMP` | Platform status `Valid` not required; cryptographic integrity enforced |
+| `production` | Official release builds and release qualification | External approved code signing certificate | Fail-closed: requires approved thumbprint and provider; CI test certs rejected |
+
+### Strict mode isolation
+
+1. **Fail-Closed by Default**: When `SKY_AUTHENTICODE_MODE` is unset, the signer defaults to `production`.
+2. **Rejection of Test Material**: In `production` mode, the presence of any test credentials
+   (`SKY_AUTHENTICODE_TEST_PFX_PATH`, `SKY_AUTHENTICODE_TEST_PFX_PASSWORD`, `SKY_AUTHENTICODE_TEST_THUMBPRINT`)
+   causes an immediate, non-recoverable error.
+3. **No Certificate Store Tampering**: Neither mode alters Windows system certificate stores or registers
+   ephemeral certificates as Trusted Publishers.
+
+## 3. Production Seam Contract
+
+### Required Environment Variables
+
+When `SKY_AUTHENTICODE_MODE=production`, the release runner must supply:
+
+1. **`SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT`** (Required):
+   - A 40-character hexadecimal SHA-1 thumbprint identifying the authorized publisher certificate.
+   - Example: `A1B2C3D4E5F60718293A4B5C6D7E8F9012345678`
+
+2. **`SKY_AUTHENTICODE_PROVIDER`** (Required):
+   - Identifies the provider mechanism for auditing and telemetry.
+   - Examples: `azure-trusted-signing`, `signtool-hsm`, `custom-script`.
+
+3. **Signing Invocation** (Exactly one required):
+   - **`SKY_AUTHENTICODE_PROVIDER_SCRIPT`**: Full path to a PowerShell script accepting `-Path <file>`.
+   - **`SKY_AUTHENTICODE_PROVIDER_COMMAND`**: Command line template where `%1` or `$Path` is replaced
+     by the target file path.
+
+### Provider Execution and Post-Signing Verification
+
+When the provider completes signing the target file, `scripts/sign_v4_authenticode.ps1` executes
+an immediate post-condition verification:
+
+1. Target file must have an embedded Authenticode signature.
+2. Signer certificate thumbprint must match `SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT` byte-for-byte.
+3. Signer certificate Subject must not contain `CI V4 Test Code Signing`.
+4. Cryptographic integrity must pass independent verification via `scripts/v4_authenticode_crypto.ps1`:
+   - Valid PKCS#7 SignedCms envelope.
+   - Exact PE indirect-data hash match (`signed_digest == computed_digest`).
+
+If any check fails, the signer immediately exits with a non-zero code, aborting packaging.
+
+## 4. Supported Provider Integration Patterns
+
+### Pattern A: Azure Trusted Signing (dlib / cli)
+
+Set the following environment variables on the release runner:
+
+```powershell
+$env:SKY_AUTHENTICODE_MODE = "production"
+$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "<approved_thumbprint>"
+$env:SKY_AUTHENTICODE_PROVIDER = "azure-trusted-signing"
+$env:SKY_AUTHENTICODE_PROVIDER_COMMAND = 'trusted-signing-cli sign --endpoint https://wus.codesigning.azure.net --account <account> --profile <profile> --file %1'
+```
+
+### Pattern B: Hardware Token / HSM (via SignTool)
+
+```powershell
+$env:SKY_AUTHENTICODE_MODE = "production"
+$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "<approved_thumbprint>"
+$env:SKY_AUTHENTICODE_PROVIDER = "signtool-hsm"
+$env:SKY_AUTHENTICODE_PROVIDER_COMMAND = 'signtool.exe sign /sha1 <approved_thumbprint> /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 %1'
+```
+
+### Pattern C: Custom Provider Script
+
+```powershell
+$env:SKY_AUTHENTICODE_MODE = "production"
+$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "<approved_thumbprint>"
+$env:SKY_AUTHENTICODE_PROVIDER = "custom-script"
+$env:SKY_AUTHENTICODE_PROVIDER_SCRIPT = "C:\ops\sign_artifact.ps1"
+```
+
+## 5. Contract Verification Tooling
+
+To run automated verification proving that ephemeral CI test certificates cannot satisfy
+production mode:
+
+```powershell
+pwsh scripts/test_v4_production_signing_contract.ps1
+```

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -82,8 +82,10 @@ cargo xtask verify-tauri-bundle `
 
 The build config invokes `scripts/sign_v4_authenticode.ps1`; it signs only in
 test mode with the ephemeral certificate. In production mode it fails closed
-until an approved Authenticode provider is configured. To create the evidence
-used above, run:
+until an approved Authenticode provider is configured. See
+`v4-authenticode-provider-seam.md` for the formalized provider seam specification
+and `v4-updater-key-custody.md` for the private key custody and rotation runbook.
+To create the evidence used above, run:
 
 ```powershell
 pwsh scripts/verify_v4_authenticode.ps1 `

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -1,0 +1,189 @@
+# V4 Updater Key Custody, Rotation, and Recovery Runbook
+
+This runbook defines the operational lifecycle, physical and cryptographic custody,
+backup procedures, loss and compromise response, scheduled rotation, and disaster
+recovery for the production v4 Tauri updater trust root.
+
+This document is governed by `docs/adr/ADR-0006-v4-distribution-installation-update.md`
+and `SECURITY.md`.
+
+## 1. Trust Root Architecture and Inventory
+
+The production v4 update pipeline uses an independent Minisign/Ed25519 trust root,
+completely isolated from legacy v3 release keys (`release-2026`).
+
+The canonical production v4 updater public trust root is:
+
+```text
+Key ID: F6355260A0C663D5
+Algorithm: Ed25519 (Minisign)
+Public Key (Base64):
+dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY2MzU1MjYwQTBDNjYzRDUKUldUVlk4YWdZRkkxOWdWRnNkRTNVY0habzA0YlQ4OFkxZk42WEM3OGVnSW5WNlc5SHlSbGF3QWEK
+```
+
+### Verified repository locations
+
+The canonical public root is committed in exactly three authoritative locations:
+1. `desktop/src-tauri/tauri.conf.json` (`plugins.updater.pubkey`)
+2. `desktop/src-tauri/src/native_update.rs` (`V4_TAURI_UPDATER_PUBLIC_KEY`)
+3. `rust/xtask/src/tauri_bundle.rs` (`V4_TAURI_UPDATER_PUBLIC_KEY`)
+
+To inventory and verify that all three locations match byte-for-byte and that no
+extraneous public keys or legacy keys exist:
+
+```powershell
+cargo xtask updater-trust inventory
+```
+
+## 2. Key Custody
+
+1. **Storage Isolation**:
+   - The production private updater key must NEVER be committed to Git, stored in
+     cloud storage, transmitted over email/chat, or configured in GitHub Actions
+     repository secrets.
+   - The private key is held exclusively on offline, air-gapped, encrypted physical media
+     (e.g., hardware security module, encrypted FIPS 140-2 Level 2+ USB drive, or an
+     air-gapped workstation).
+
+2. **Access Control**:
+   - Only authorized Release Operators have access to the physical media and its
+     decryption passphrase.
+   - Access requires multi-person verification (dual custody) for production releases.
+
+3. **Passphrase Standards**:
+   - The private key passphrase must be generated with high entropy (minimum 128 bits).
+   - The passphrase must be managed via a dedicated password manager and never stored in
+     plaintext scripts or shell history.
+
+4. **In-Memory & Ephemeral Signing Rules**:
+   - When signing candidate update artifacts for release qualification, the key file or
+     passphrase must only be loaded into ephemeral process memory.
+   - When automated workflows handle the passphrase, `::add-mask::<passphrase>` must be
+     emitted before any other output to prevent log leakage.
+
+## 3. Local Private Key Verification
+
+Release Operators must verify that their local private key matches the canonical public root
+prior to initiating release packaging. The verification tool signs an ephemeral cryptographic
+nonce and verifies the resulting signature against the compiled public root, without ever
+printing private key material or passphrases to stdout, stderr, or log files.
+
+### Running verification via xtask
+
+```powershell
+$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "<secure_passphrase>"
+cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key"
+```
+
+### Running verification via script
+
+```powershell
+pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key" -Password "<secure_passphrase>"
+```
+
+Expected output:
+```text
+[PASS] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)
+```
+
+If the key does not match or the password is wrong, the tool exits with code 1 and emits a
+sanitized error without leaking secret bytes.
+
+## 4. Backup Procedures
+
+1. **Cold Encrypted Backups**:
+   - Two cold backup copies of the private updater key file must exist in separate physical
+     locations (e.g., Primary Safe, Offsite Safe).
+   - Each backup copy is stored on dedicated encrypted offline storage.
+
+2. **Passphrase Recovery Split**:
+   - The passphrase for the encrypted backup media should be split using Shamir's Secret
+     Sharing (or equivalent dual-custody envelopes) among project maintainers.
+
+3. **Periodic Integrity Audit**:
+   - Annually, operators must perform an air-gapped read test of backup media to ensure data
+     retention and media integrity, using `cargo xtask updater-trust verify-private-key`.
+
+## 5. Key Loss Incident Response
+
+If the operational private updater key is permanently lost (e.g., physical destruction
+without accessible backups):
+
+1. **Immediate Assessment**:
+   - Confirm key unrecoverability across all backup vaults.
+   - Deployed v4 clients will continue functioning and will reject any forged updates
+     because they verify signatures against the trusted public root. However, no new
+     automatic updates can be signed with the lost key.
+
+2. **Generate Replacement Root**:
+   - Generate a new v4 updater key pair under clean, documented custody:
+     ```powershell
+     Push-Location desktop
+     bun run tauri signer generate -w "E:\secure\v4-updater-replacement.key"
+     Pop-Location
+     ```
+
+3. **Release Recovery Build**:
+   - Update `tauri.conf.json`, `native_update.rs`, and `tauri_bundle.rs` with the new public
+     root.
+   - Because existing clients cannot auto-update to a package signed with an unknown root,
+     the recovery release must be published as a signed standalone installer (NSIS setup executable)
+     signed with the approved Authenticode certificate.
+   - Publish a security notice on GitHub and project channels directing users to perform a
+     manual update via the official installer.
+
+## 6. Key Compromise Incident Response
+
+If the private updater key is suspected or confirmed to be compromised:
+
+1. **Severity 1 Incident Declaration**:
+   - Immediately invoke the security process in `SECURITY.md`.
+
+2. **Freeze Release Authority Channels**:
+   - Immediately delete or overwrite `channels/stable/latest.json` and `channels/beta/latest.json`
+     in `pumni/Sky-Auto-Player-Releases` with emergency quarantine metadata (empty or revoked).
+   - This halts all background update polling by existing clients.
+
+3. **Generate Clean Trust Root**:
+   - On an uncompromised, air-gapped machine, generate a new key pair:
+     ```powershell
+     Push-Location desktop
+     bun run tauri signer generate -w "E:\secure\v4-updater-emergency.key"
+     Pop-Location
+     ```
+
+4. **Publish Authenticode-Signed Emergency Installer**:
+   - Build and sign a new release with the new public root.
+   - Windows Authenticode signatures (signed by the publisher certificate) provide an
+     independent layer of integrity, ensuring that attackers with only the updater key cannot
+     forge Windows-valid installers.
+   - Direct all users to install the emergency update manually.
+
+## 7. Scheduled Key Rotation
+
+Scheduled rotation occurs every 24 months or upon operational requirement. Rotation follows
+the two-phase Bridge/Cutover model:
+
+### Phase 1: Bridge Release (`v4.N`)
+
+1. Generate new updater key pair `new.key` / `new.key.pub`.
+2. Update `native_update.rs` to carry dual trust roots: `[old_root, new_root]`.
+3. Sign the `v4.N` installer with the `old.key` so that existing `v4.N-1` clients (which only trust
+   `old_root`) successfully verify and download the update.
+4. Once installed, `v4.N` clients trust both `old_root` and `new_root`.
+
+### Phase 2: Cutover Release (`v4.N+1`)
+
+1. Update `tauri.conf.json`, `native_update.rs`, and `tauri_bundle.rs` to carry only `[new_root]`.
+2. Sign `v4.N+1` exclusively with `new.key`.
+3. `v4.N` bridge clients verify the update against `new_root` and install successfully.
+4. Old root `old.key` is permanently retired.
+
+### Rehearsal and Evidence
+
+Rotation procedures are validated automatically using:
+
+```powershell
+pwsh scripts/test_v4_updater_key_rotation.ps1
+pwsh scripts/ci_tauri_update_e2e.ps1 -BundleDir rust/target/dist/bundle/nsis
+```

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -69,24 +69,30 @@ nonce and verifies the resulting signature against the compiled public root, wit
 printing private key material or passphrases to stdout, stderr, or log files.
 
 To prevent password exposure in shell history (such as `PSReadLine` history files) or process listings,
-the tool avoids command-line password flags. Passwords should be entered interactively via masked
-input or supplied via an in-memory environment variable:
+the verification tools avoid command-line password flags.
 
-### Running verification via xtask
+### Interactive Operator Verification (Recommended)
+
+For interactive operator use, run the PowerShell verifier. It performs a non-echoing, masked
+interactive prompt via `Read-Host -AsSecureString` to prevent passphrase exposure in terminal
+logs or history files:
 
 ```powershell
-# Interactively prompts for passphrase if the key is encrypted:
-cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key"
-
-# Or with an in-memory environment variable name:
-cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key" --password-env MY_KEY_PASS
+# Prompts securely for passphrase if the private key is encrypted:
+pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key"
 ```
 
-### Running verification via script
+### Non-Interactive / Automation Verification via xtask
+
+`cargo xtask updater-trust verify-private-key` is designed for automated, non-interactive environments
+and does not read from stdin. Passphrases must be supplied via an in-memory environment variable:
 
 ```powershell
-# Interactive prompt:
-pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key"
+# Reads from custom environment variable name:
+cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key" --password-env MY_KEY_PASS
+
+# Or reads from standard TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key"
 ```
 
 Expected output:

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -68,17 +68,25 @@ prior to initiating release packaging. The verification tool signs an ephemeral 
 nonce and verifies the resulting signature against the compiled public root, without ever
 printing private key material or passphrases to stdout, stderr, or log files.
 
+To prevent password exposure in shell history (such as `PSReadLine` history files) or process listings,
+the tool avoids command-line password flags. Passwords should be entered interactively via masked
+input or supplied via an in-memory environment variable:
+
 ### Running verification via xtask
 
 ```powershell
-$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "<secure_passphrase>"
+# Interactively prompts for passphrase if the key is encrypted:
 cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key"
+
+# Or with an in-memory environment variable name:
+cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.key" --password-env MY_KEY_PASS
 ```
 
 ### Running verification via script
 
 ```powershell
-pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key" -Password "<secure_passphrase>"
+# Interactive prompt:
+pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key"
 ```
 
 Expected output:
@@ -109,40 +117,58 @@ sanitized error without leaking secret bytes.
 If the operational private updater key is permanently lost (e.g., physical destruction
 without accessible backups):
 
-1. **Immediate Assessment**:
+1. **Pre-GA Key Loss**:
+   - An unrecoverable pre-GA key requires replacing the committed public root across
+     `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/src/native_update.rs`, and
+     `rust/xtask/src/tauri_bundle.rs`, followed by full re-qualification of the release
+     trust chain before the first production v4 release.
+
+2. **Post-GA Key Loss Assessment**:
    - Confirm key unrecoverability across all backup vaults.
-   - Deployed v4 clients will continue functioning and will reject any forged updates
+   - Deployed v4 clients will continue functioning normally and will reject any forged updates
      because they verify signatures against the trusted public root. However, no new
      automatic updates can be signed with the lost key.
 
-2. **Generate Replacement Root**:
+3. **Post-GA Replacement Root and Out-of-Band Recovery**:
    - Generate a new v4 updater key pair under clean, documented custody:
      ```powershell
      Push-Location desktop
      bun run tauri signer generate -w "E:\secure\v4-updater-replacement.key"
      Pop-Location
      ```
-
-3. **Release Recovery Build**:
-   - Update `tauri.conf.json`, `native_update.rs`, and `tauri_bundle.rs` with the new public
-     root.
+   - Update `tauri.conf.json`, `native_update.rs`, and `tauri_bundle.rs` with the new public root.
    - Because existing clients cannot auto-update to a package signed with an unknown root,
-     the recovery release must be published as a signed standalone installer (NSIS setup executable)
+     the recovery release must be published as a standalone installer (NSIS setup executable)
      signed with the approved Authenticode certificate.
    - Publish a security notice on GitHub and project channels directing users to perform a
      manual update via the official installer.
 
 ## 6. Key Compromise Incident Response
 
+### Threat Model and Architecture Boundary
+
+Current runtime auto-update trust in Sky Auto Player v4 relies on Tauri updater signature
+verification at download time, followed immediately by `Update::install(bytes)`.
+Windows Authenticode is an OS / SmartScreen / install-time gate during manual installation;
+**it is not currently a client-side authorization gate during background auto-update**.
+
+Consequently, an attacker who possesses the private updater key could forge update signatures
+that deployed client instances would accept as valid if the attacker can serve them via an
+update channel. Therefore, **the primary and immediate authorization gate against updater key
+compromise is the Release Authority channel freeze**.
+
+### Incident Response Procedure
+
 If the private updater key is suspected or confirmed to be compromised:
 
 1. **Severity 1 Incident Declaration**:
    - Immediately invoke the security process in `SECURITY.md`.
 
-2. **Freeze Release Authority Channels**:
+2. **Freeze Release Authority Channels (Critical Containment)**:
    - Immediately delete or overwrite `channels/stable/latest.json` and `channels/beta/latest.json`
      in `pumni/Sky-Auto-Player-Releases` with emergency quarantine metadata (empty or revoked).
-   - This halts all background update polling by existing clients.
+   - This immediately halts all background update polling by existing clients, preventing them
+     from fetching attacker-signed payloads.
 
 3. **Generate Clean Trust Root**:
    - On an uncompromised, air-gapped machine, generate a new key pair:
@@ -152,12 +178,12 @@ If the private updater key is suspected or confirmed to be compromised:
      Pop-Location
      ```
 
-4. **Publish Authenticode-Signed Emergency Installer**:
-   - Build and sign a new release with the new public root.
-   - Windows Authenticode signatures (signed by the publisher certificate) provide an
-     independent layer of integrity, ensuring that attackers with only the updater key cannot
-     forge Windows-valid installers.
-   - Direct all users to install the emergency update manually.
+4. **Publish Authenticode-Signed Emergency Standalone Installer**:
+   - Build and sign a new release containing the new public trust root.
+   - Publish the recovery release as an official standalone installer signed with the approved
+     publisher Authenticode certificate. Windows Authenticode and SmartScreen provide publisher
+     provenance and integrity for users performing the manual installation.
+   - Direct all users to install the emergency update manually to migrate to the new trust root.
 
 ## 7. Scheduled Key Rotation
 

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -671,6 +671,7 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
     let decoded = STANDARD.decode(config_key)?;
     let decoded = String::from_utf8(decoded)?;
     PublicKey::decode(&decoded)?;
+    crate::updater_trust::inventory_public_trust_roots(root)?;
 
     let ci_path = root.join(".github/workflows/ci.yml");
     let ci = fs::read_to_string(&ci_path)?;
@@ -815,12 +816,14 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "/f $pfxPath",
         "/p $pfxPassword",
         "EphemeralKeySet",
+        "SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT",
+        "SKY_AUTHENTICODE_PROVIDER",
+        "SKY_AUTHENTICODE_PROVIDER_COMMAND",
     ] {
         if !signer.contains(marker) {
-            return Err(format!(
-                "v4 Authenticode signer is missing its required PFX marker: {marker}"
-            )
-            .into());
+            return Err(
+                format!("v4 Authenticode signer is missing its required marker: {marker}").into(),
+            );
         }
     }
     let tamper = fs::read_to_string(root.join("scripts/test_v4_authenticode_integrity.ps1"))?;
@@ -839,6 +842,29 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
             )
             .into());
         }
+    }
+    let contract_test =
+        fs::read_to_string(root.join("scripts/test_v4_production_signing_contract.ps1"))?;
+    for marker in [
+        "Unconfigured production mode fails closed",
+        "Production signing rejects test credentials",
+        "Production verification rejects CI test certificate",
+        "Production verification rejects test thumbprint",
+        "CI test certificate cannot satisfy production mode",
+    ] {
+        if !contract_test.contains(marker) {
+            return Err(format!(
+                "v4 production signing contract test is missing its required marker: {marker}"
+            )
+            .into());
+        }
+    }
+    let key_verifier = fs::read_to_string(root.join("scripts/verify_v4_updater_private_key.ps1"))?;
+    if !key_verifier.contains("updater-trust verify-private-key") {
+        return Err(
+            "v4 updater key verification script must delegate to updater-trust verify-private-key"
+                .into(),
+        );
     }
 
     let private_begin = ["BEGIN", "PRIVATE", "KEY"].join(" ");

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -495,6 +495,9 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
         "SKY_GH_PATH=$ghPath",
         "- name: Run Authenticode tamper regression",
         "scripts/test_v4_authenticode_integrity.ps1",
+        "- name: Run V4 production signing contract test",
+        "scripts/test_v4_production_signing_contract.ps1",
+        "V4 production signing contract test failed with exit code",
         "- name: Verify Tauri Authenticode signature",
         "- name: Generate Tauri SPDX SBOM",
         "- name: Verify Tauri SPDX SBOM",
@@ -2619,6 +2622,9 @@ read_only=true
         # Tauri build failed with exit code
       - name: Run Authenticode tamper regression
         run: pwsh scripts/test_v4_authenticode_integrity.ps1
+      - name: Run V4 production signing contract test
+        run: pwsh scripts/test_v4_production_signing_contract.ps1
+        # V4 production signing contract test failed with exit code
       - name: Verify Tauri Authenticode signature
         run: pwsh scripts/verify_v4_authenticode.ps1
         # Authenticode verification failed with exit code

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn usage() -> &'static str {
-    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> --authenticode-evidence <path> --sbom <path> [--summary <path>]\n  cargo xtask sbom <generate|verify> --artifact-dir <dir> --output|--sbom <path>\n  cargo xtask updater-trust rotation-self-test --old-public <path> --new-public <path> --old-signature <path> --new-signature <path> --payload <path>\n  cargo xtask verify-dist --release-dir <dir>\n  cargo xtask release-authority generate --channel <stable|beta> --version <semver> --notes-file <path> --pub-date <rfc3339> --platform windows-x86_64 --asset-url <url> --signature-file <path> --output <path>\n  cargo xtask release-authority validate --channel <stable|beta> --metadata <path>"
+    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask manifest sign --manifest <path> --output <path>\n  cargo xtask manifest verify --manifest <path> --signature <path>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask dist --profile dist --output <dir>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> --authenticode-evidence <path> --sbom <path> [--summary <path>]\n  cargo xtask sbom <generate|verify> --artifact-dir <dir> --output|--sbom <path>\n  cargo xtask updater-trust <inventory|verify-private-key|rotation-self-test>\n  cargo xtask verify-dist --release-dir <dir>\n  cargo xtask release-authority generate --channel <stable|beta> --version <semver> --notes-file <path> --pub-date <rfc3339> --platform windows-x86_64 --asset-url <url> --signature-file <path> --output <path>\n  cargo xtask release-authority validate --channel <stable|beta> --metadata <path>"
 }
 
 fn required_value(args: &[String], index: &mut usize, option: &str) -> Result<String> {
@@ -264,6 +264,48 @@ fn main() -> Result<()> {
                 Some("verify") => sbom::verify(&repo::root(), &artifact_dir, &output),
                 _ => Err("sbom requires generate or verify".into()),
             }
+        }
+        "updater-trust" if args.get(1).map(String::as_str) == Some("inventory") => {
+            updater_trust::print_inventory(&repo::root())
+        }
+        "updater-trust" if args.get(1).map(String::as_str) == Some("verify-private-key") => {
+            let mut key_file = None;
+            let mut password_env = None;
+            let mut i = 2;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--key-file" => key_file = Some(required_value(&args, &mut i, "--key-file")?),
+                    "--password-env" => {
+                        password_env = Some(required_value(&args, &mut i, "--password-env")?)
+                    }
+                    option => {
+                        return Err(format!(
+                            "unknown updater-trust verify-private-key option: {option}"
+                        )
+                        .into());
+                    }
+                }
+                i += 1;
+            }
+            let key_file = key_file
+                .or_else(|| env::var("TAURI_SIGNING_PRIVATE_KEY_PATH").ok())
+                .ok_or(
+                    "verify-private-key requires --key-file <path> or TAURI_SIGNING_PRIVATE_KEY_PATH env var",
+                )?;
+            let password = if let Some(env_var) = password_env {
+                env::var(env_var).ok()
+            } else {
+                env::var("TAURI_SIGNING_PRIVATE_KEY_PASSWORD").ok()
+            };
+            updater_trust::verify_local_private_key(
+                &repo::root(),
+                Path::new(&key_file),
+                password.as_deref(),
+            )?;
+            println!(
+                "[xtask] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)"
+            );
+            Ok(())
         }
         "updater-trust" if args.get(1).map(String::as_str) == Some("rotation-self-test") => {
             let mut old_public = None;

--- a/rust/xtask/src/tauri_bundle.rs
+++ b/rust/xtask/src/tauri_bundle.rs
@@ -713,4 +713,121 @@ mod tests {
         );
         fs::remove_dir_all(root).unwrap();
     }
+
+    #[test]
+    fn ci_test_certificate_cannot_satisfy_production_mode() {
+        let root = std::env::temp_dir().join(format!(
+            "sky-xtask-tauri-auth-contract-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let installer = root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.exe");
+        let signature = root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.exe.sig");
+        fs::write(&installer, b"installer").unwrap();
+        fs::write(&signature, b"test-signature\n").unwrap();
+        let summary = artifact_summary(&root, "4.0.0-alpha.1").unwrap();
+
+        let test_thumbprint = "11".repeat(20);
+        let prod_thumbprint = "22".repeat(20);
+
+        let test_evidence = json!({
+            "schema_version": 1,
+            "evidence_type": "authenticode-verification",
+            "mode": "test",
+            "expected_signer_thumbprint": test_thumbprint.clone(),
+            "files": [{
+                "name": summary.installer.clone(),
+                "status": "UnknownError",
+                "platform_status": "UnknownError",
+                "verification": "signature-valid-independent-cryptographic-integrity",
+                "trust_exception": "test-platform-status-not-used-for-integrity",
+                "integrity_verifier": "signedcms-spc-indirect-data-authenticode-hash",
+                "integrity_status": "Valid",
+                "signed_digest": "A".repeat(64),
+                "computed_digest": "a".repeat(64),
+                "signer_thumbprint": test_thumbprint.clone(),
+                "sha256": summary.installer_sha256.clone(),
+            }]
+        });
+
+        // Test mode accepts test evidence
+        assert!(
+            validate_authenticode_evidence_value(
+                &test_evidence,
+                &summary,
+                "test",
+                &test_thumbprint
+            )
+            .is_ok()
+        );
+
+        // Production mode rejects test evidence with expected_signer_thumbprint = prod_thumbprint
+        assert!(
+            validate_authenticode_evidence_value(
+                &test_evidence,
+                &summary,
+                "production",
+                &prod_thumbprint
+            )
+            .is_err()
+        );
+
+        // Production mode rejects test evidence even if expected_signer_thumbprint was set to test_thumbprint
+        assert!(
+            validate_authenticode_evidence_value(
+                &test_evidence,
+                &summary,
+                "production",
+                &test_thumbprint
+            )
+            .is_err()
+        );
+
+        // Forged mode: "production" while retaining trust_exception
+        let mut forged_mode = test_evidence.clone();
+        forged_mode["mode"] = json!("production");
+        assert!(
+            validate_authenticode_evidence_value(
+                &forged_mode,
+                &summary,
+                "production",
+                &test_thumbprint
+            )
+            .is_err()
+        );
+
+        // Forged mode: "production" without trust_exception but non-Valid platform status
+        let mut forged_no_exception = forged_mode.clone();
+        forged_no_exception["files"][0]["trust_exception"] = Value::Null;
+        assert!(
+            validate_authenticode_evidence_value(
+                &forged_no_exception,
+                &summary,
+                "production",
+                &test_thumbprint
+            )
+            .is_err()
+        );
+
+        // Forged platform_status: "Valid" but signer_thumbprint is test_thumbprint
+        let mut forged_valid_status = forged_no_exception.clone();
+        forged_valid_status["files"][0]["status"] = json!("Valid");
+        forged_valid_status["files"][0]["platform_status"] = json!("Valid");
+        assert!(
+            validate_authenticode_evidence_value(
+                &forged_valid_status,
+                &summary,
+                "production",
+                &prod_thumbprint
+            )
+            .is_err()
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/rust/xtask/src/updater_trust.rs
+++ b/rust/xtask/src/updater_trust.rs
@@ -3,8 +3,267 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use minisign_verify::{PublicKey, Signature};
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 const MAX_PUBLIC_KEY_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdaterTrustInventory {
+    pub canonical_key_id: String,
+    pub canonical_public_key: String,
+    pub algorithm: &'static str,
+    pub verified_locations: Vec<String>,
+    pub legacy_v3_root_isolated: bool,
+    pub unique_production_v4_root: bool,
+}
+
+pub fn inventory_public_trust_roots(root: &Path) -> Result<UpdaterTrustInventory> {
+    let canonical = crate::tauri_bundle::V4_TAURI_UPDATER_PUBLIC_KEY;
+    let _decoded_key = decode_public_key(canonical)?;
+    let key_id = extract_key_id_from_public_key(canonical)?;
+    if key_id != "F6355260A0C663D5" {
+        return Err(format!("unexpected canonical key id: {key_id}").into());
+    }
+
+    let mut verified_locations = Vec::new();
+
+    // 1. desktop/src-tauri/tauri.conf.json
+    let config_path = root.join("desktop/src-tauri/tauri.conf.json");
+    let config_content = fs::read_to_string(&config_path)?;
+    let config_json: serde_json::Value = serde_json::from_str(&config_content)?;
+    let config_key = config_json
+        .get("plugins")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|p| p.get("updater"))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|u| u.get("pubkey"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or("desktop/src-tauri/tauri.conf.json is missing plugins.updater.pubkey")?;
+    if config_key != canonical {
+        return Err("tauri.conf.json updater pubkey does not match canonical root".into());
+    }
+    verified_locations.push("desktop/src-tauri/tauri.conf.json".to_string());
+
+    // 2. desktop/src-tauri/src/native_update.rs
+    let native_path = root.join("desktop/src-tauri/src/native_update.rs");
+    let native_content = fs::read_to_string(&native_path)?;
+    let native_key = extract_rust_string_constant(&native_content, "V4_TAURI_UPDATER_PUBLIC_KEY")?;
+    if native_key != canonical {
+        return Err(
+            "native_update.rs V4_TAURI_UPDATER_PUBLIC_KEY does not match canonical root".into(),
+        );
+    }
+    if !native_content
+        .contains("const V4_TAURI_UPDATER_PUBLIC_KEYS: &[&str] = &[V4_TAURI_UPDATER_PUBLIC_KEY];")
+    {
+        return Err(
+            "native_update.rs does not enforce single V4_TAURI_UPDATER_PUBLIC_KEYS array".into(),
+        );
+    }
+    verified_locations.push("desktop/src-tauri/src/native_update.rs".to_string());
+
+    // 3. rust/xtask/src/tauri_bundle.rs
+    let bundle_path = root.join("rust/xtask/src/tauri_bundle.rs");
+    let bundle_content = fs::read_to_string(&bundle_path)?;
+    let bundle_key = extract_rust_string_constant(&bundle_content, "V4_TAURI_UPDATER_PUBLIC_KEY")?;
+    if bundle_key != canonical {
+        return Err(
+            "tauri_bundle.rs V4_TAURI_UPDATER_PUBLIC_KEY does not match canonical root".into(),
+        );
+    }
+    verified_locations.push("rust/xtask/src/tauri_bundle.rs".to_string());
+
+    // 4. Verify isolation of legacy v3 update trust root
+    let cargo_toml_path = root.join("rust/Cargo.toml");
+    let cargo_toml: toml::Value = toml::from_str(&fs::read_to_string(&cargo_toml_path)?)?;
+    let legacy_v3_root_isolated = if let Some(workspace) =
+        cargo_toml.get("workspace").and_then(toml::Value::as_table)
+        && let Some(metadata) = workspace.get("metadata").and_then(toml::Value::as_table)
+        && let Some(update_signing) = metadata
+            .get("sky-update-signing")
+            .and_then(toml::Value::as_table)
+        && let Some(key_id) = update_signing.get("key-id").and_then(toml::Value::as_str)
+    {
+        if key_id != "release-2026" {
+            return Err("legacy update root key-id in rust/Cargo.toml is not release-2026".into());
+        }
+        if config_key.contains("release-2026")
+            || native_key.contains("release-2026")
+            || bundle_key.contains("release-2026")
+            || config_content.contains("release-2026")
+        {
+            return Err("v4 code contains legacy v3 release-2026 reference".into());
+        }
+        true
+    } else {
+        false
+    };
+
+    Ok(UpdaterTrustInventory {
+        canonical_key_id: key_id,
+        canonical_public_key: canonical.to_string(),
+        algorithm: "Ed25519 (Minisign)",
+        verified_locations,
+        legacy_v3_root_isolated,
+        unique_production_v4_root: true,
+    })
+}
+
+pub fn print_inventory(root: &Path) -> Result<()> {
+    let inventory = inventory_public_trust_roots(root)?;
+    println!("[xtask] V4 Updater Public Trust Root Inventory: PASS");
+    println!("  Key ID: {}", inventory.canonical_key_id);
+    println!("  Algorithm: {}", inventory.algorithm);
+    println!("  Public Root: {}", inventory.canonical_public_key);
+    println!("  Verified Locations (byte-for-byte identical):");
+    for location in &inventory.verified_locations {
+        println!("    - {location}");
+    }
+    println!("  Legacy v3 Root: isolated to rust/Cargo.toml (release-2026) and rejected by v4");
+    println!("  Unique Production v4 Root: verified exactly 1 public trust root");
+    Ok(())
+}
+
+/// Verify local updater private key without printing private material or password.
+pub fn verify_local_private_key(
+    root: &Path,
+    key_path: &Path,
+    password: Option<&str>,
+) -> Result<()> {
+    if !key_path.is_file() {
+        return Err(format!("private key file does not exist: {}", key_path.display()).into());
+    }
+    let key_bytes = fs::read(key_path)?;
+    if key_bytes.is_empty() || key_bytes.len() > MAX_PUBLIC_KEY_BYTES {
+        return Err("private key file is empty or unbounded".into());
+    }
+    let key_str = String::from_utf8_lossy(&key_bytes);
+    if key_str.contains("release-2026") {
+        return Err("provided key contains legacy v3 material, not v4".into());
+    }
+
+    let mut nonce = [0u8; 64];
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    for (i, b) in nonce.iter_mut().enumerate() {
+        *b = ((timestamp >> ((i % 16) * 4)) ^ (std::process::id() as u128 >> ((i % 4) * 8))) as u8;
+    }
+    let temp_dir = std::env::temp_dir().join(format!(
+        "sky-v4-keycheck-{}-{}",
+        std::process::id(),
+        timestamp % 1_000_000
+    ));
+    let _ = fs::remove_dir_all(&temp_dir);
+    fs::create_dir_all(&temp_dir)?;
+
+    let payload_path = temp_dir.join("nonce.bin");
+    let signature_path = temp_dir.join("nonce.bin.sig");
+    fs::write(&payload_path, nonce)?;
+
+    let desktop_dir = root.join("desktop");
+    let canonical_key_path = fs::canonicalize(key_path)?;
+
+    let mut command = Command::new("bun");
+    command
+        .args([
+            "run",
+            "tauri",
+            "signer",
+            "sign",
+            payload_path.to_str().unwrap(),
+        ])
+        .current_dir(&desktop_dir)
+        .env("TAURI_SIGNING_PRIVATE_KEY_PATH", &canonical_key_path)
+        .env("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", password.unwrap_or(""))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let output = command.output();
+    let result = match output {
+        Ok(out) if out.status.success() => {
+            if signature_path.is_file() {
+                match decode_signature(&signature_path) {
+                    Ok(signature) => {
+                        match decode_public_key(crate::tauri_bundle::V4_TAURI_UPDATER_PUBLIC_KEY) {
+                            Ok(public_key) => match public_key.verify(&nonce, &signature, false) {
+                                Ok(_) => Ok(()),
+                                Err(_) => Err(
+                                    "private key signature does not match the canonical production v4 public root"
+                                        .into(),
+                                ),
+                            },
+                            Err(e) => {
+                                Err(format!("failed to decode canonical public root: {e}").into())
+                            }
+                        }
+                    }
+                    Err(e) => Err(format!("failed to decode generated signature: {e}").into()),
+                }
+            } else {
+                Err("signer completed but signature file was not produced".into())
+            }
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            if stderr.contains("Wrong password")
+                || stderr.contains("incorrect updater private key password")
+            {
+                Err("incorrect updater private key password".into())
+            } else {
+                Err(
+                    "updater signer rejected the private key (invalid key format or corrupt material)"
+                        .into(),
+                )
+            }
+        }
+        Err(e) => Err(format!("failed to execute bun signer: {e}").into()),
+    };
+
+    let _ = fs::remove_file(&payload_path);
+    let _ = fs::remove_file(&signature_path);
+    let _ = fs::remove_dir_all(&temp_dir);
+
+    result
+}
+
+pub fn extract_key_id_from_public_key(value: &str) -> Result<String> {
+    let decoded = STANDARD.decode(value)?;
+    let text = String::from_utf8(decoded)?;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix("untrusted comment: minisign public key: ") {
+            let key_id = rest.trim().to_ascii_uppercase();
+            if key_id.len() == 16 && key_id.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Ok(key_id);
+            }
+        }
+    }
+    Err("could not find valid minisign key id in public key comment".into())
+}
+
+fn extract_rust_string_constant(source: &str, name: &str) -> Result<String> {
+    let decl1 = format!("const {name}: &str = \"");
+    let decl2 = format!("pub const {name}: &str = \"");
+    for line in source.lines() {
+        let trimmed = line.trim();
+        let prefix_len = if trimmed.starts_with(&decl1) {
+            Some(decl1.len())
+        } else if trimmed.starts_with(&decl2) {
+            Some(decl2.len())
+        } else {
+            None
+        };
+        if let Some(len) = prefix_len {
+            let after_prefix = &trimmed[len..];
+            if let Some(end) = after_prefix.find('"') {
+                return Ok(after_prefix[..end].to_string());
+            }
+        }
+    }
+    Err(format!("Rust source must contain {name} string constant").into())
+}
 
 /// Verify the release-rotation bridge without ever importing or printing a
 /// private key. A bridge release trusts both roots; the cutover release trusts
@@ -134,6 +393,47 @@ mod tests {
         )
         .unwrap();
         assert!(read_public_key(&path).is_err());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn extract_key_id_matches_canonical_v4() {
+        let canonical = crate::tauri_bundle::V4_TAURI_UPDATER_PUBLIC_KEY;
+        let key_id = extract_key_id_from_public_key(canonical).unwrap();
+        assert_eq!(key_id, "F6355260A0C663D5");
+    }
+
+    #[test]
+    fn inventory_proves_single_canonical_v4_root() {
+        let repo_root = crate::repo::root();
+        let inventory = inventory_public_trust_roots(&repo_root).unwrap();
+        assert_eq!(inventory.canonical_key_id, "F6355260A0C663D5");
+        assert_eq!(
+            inventory.canonical_public_key,
+            crate::tauri_bundle::V4_TAURI_UPDATER_PUBLIC_KEY
+        );
+        assert_eq!(inventory.verified_locations.len(), 3);
+        assert!(inventory.legacy_v3_root_isolated);
+        assert!(inventory.unique_production_v4_root);
+    }
+
+    #[test]
+    fn verify_local_private_key_rejects_nonexistent_or_v3_material() {
+        let root = fixture_root();
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        let nonexistent = root.join("nonexistent.key");
+        assert!(verify_local_private_key(&crate::repo::root(), &nonexistent, None).is_err());
+
+        let v3_fake = root.join("v3.key");
+        fs::write(&v3_fake, "untrusted comment: release-2026 key material").unwrap();
+        assert!(verify_local_private_key(&crate::repo::root(), &v3_fake, None).is_err());
+
+        let empty_key = root.join("empty.key");
+        fs::write(&empty_key, "").unwrap();
+        assert!(verify_local_private_key(&crate::repo::root(), &empty_key, None).is_err());
+
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/scripts/sign_v4_authenticode.ps1
+++ b/scripts/sign_v4_authenticode.ps1
@@ -38,8 +38,13 @@ if ($mode -eq "production") {
 
     $providerCommand = [string]$env:SKY_AUTHENTICODE_PROVIDER_COMMAND
     $providerScript = [string]$env:SKY_AUTHENTICODE_PROVIDER_SCRIPT
-    if ([string]::IsNullOrWhiteSpace($providerCommand) -and [string]::IsNullOrWhiteSpace($providerScript)) {
-        throw "V4 Authenticode signing is fail-closed: provider '$provider' requires SKY_AUTHENTICODE_PROVIDER_COMMAND or SKY_AUTHENTICODE_PROVIDER_SCRIPT"
+    $hasCommand = -not [string]::IsNullOrWhiteSpace($providerCommand)
+    $hasScript = -not [string]::IsNullOrWhiteSpace($providerScript)
+    if (-not $hasCommand -and -not $hasScript) {
+        throw "V4 Authenticode signing is fail-closed: provider '$provider' requires exactly one of SKY_AUTHENTICODE_PROVIDER_SCRIPT or SKY_AUTHENTICODE_PROVIDER_COMMAND"
+    }
+    if ($hasCommand -and $hasScript) {
+        throw "V4 Authenticode signing is fail-closed: mutually exclusive configuration (both SKY_AUTHENTICODE_PROVIDER_SCRIPT and SKY_AUTHENTICODE_PROVIDER_COMMAND are set; specify exactly one)"
     }
 
     Write-Host "V4 Authenticode production signer invoked: provider=$provider, approved_thumbprint=$approvedThumbprint, target=$Path"

--- a/scripts/sign_v4_authenticode.ps1
+++ b/scripts/sign_v4_authenticode.ps1
@@ -15,8 +15,78 @@ $mode = if ([string]::IsNullOrWhiteSpace($env:SKY_AUTHENTICODE_MODE)) {
 } else {
     $env:SKY_AUTHENTICODE_MODE.Trim().ToLowerInvariant()
 }
+
+if ($mode -eq "production") {
+    # Guard: Fail closed if ephemeral CI test credentials are provided in production mode
+    if (-not [string]::IsNullOrWhiteSpace($env:SKY_AUTHENTICODE_TEST_PFX_PATH) -or
+        -not [string]::IsNullOrWhiteSpace($env:SKY_AUTHENTICODE_TEST_PFX_PASSWORD) -or
+        -not [string]::IsNullOrWhiteSpace($env:SKY_AUTHENTICODE_TEST_THUMBPRINT)) {
+        throw "V4 production Authenticode signing is fail-closed: ephemeral CI test credentials cannot satisfy production mode"
+    }
+
+    $approvedThumbprint = [string]$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT
+    if ($approvedThumbprint -notmatch '^[0-9a-fA-F]{40}$') {
+        throw "V4 production Authenticode signing requires the approved 40-character SHA-1 certificate thumbprint in SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT"
+    }
+    $approvedThumbprint = $approvedThumbprint.Trim().ToUpperInvariant()
+
+    $provider = [string]$env:SKY_AUTHENTICODE_PROVIDER
+    if ([string]::IsNullOrWhiteSpace($provider)) {
+        throw "V4 Authenticode signing is fail-closed: no approved production provider is configured (set SKY_AUTHENTICODE_PROVIDER and SKY_AUTHENTICODE_PROVIDER_COMMAND or SKY_AUTHENTICODE_PROVIDER_SCRIPT)"
+    }
+    $provider = $provider.Trim().ToLowerInvariant()
+
+    $providerCommand = [string]$env:SKY_AUTHENTICODE_PROVIDER_COMMAND
+    $providerScript = [string]$env:SKY_AUTHENTICODE_PROVIDER_SCRIPT
+    if ([string]::IsNullOrWhiteSpace($providerCommand) -and [string]::IsNullOrWhiteSpace($providerScript)) {
+        throw "V4 Authenticode signing is fail-closed: provider '$provider' requires SKY_AUTHENTICODE_PROVIDER_COMMAND or SKY_AUTHENTICODE_PROVIDER_SCRIPT"
+    }
+
+    Write-Host "V4 Authenticode production signer invoked: provider=$provider, approved_thumbprint=$approvedThumbprint, target=$Path"
+
+    if (-not [string]::IsNullOrWhiteSpace($providerScript)) {
+        $resolvedScript = (Resolve-Path -LiteralPath $providerScript -ErrorAction Stop).Path
+        if (-not (Test-Path -LiteralPath $resolvedScript -PathType Leaf)) {
+            throw "Production Authenticode provider script does not exist: $providerScript"
+        }
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $resolvedScript -Path $Path
+        if ($LASTEXITCODE -ne 0) {
+            throw "Production Authenticode provider script failed with exit code $LASTEXITCODE"
+        }
+    } else {
+        $expandedCommand = $providerCommand.Replace('%1', "`"$Path`"").Replace('$Path', "`"$Path`"")
+        & pwsh -NoProfile -NonInteractive -Command $expandedCommand
+        if ($LASTEXITCODE -ne 0) {
+            throw "Production Authenticode provider command failed with exit code $LASTEXITCODE"
+        }
+    }
+
+    # Post-signing seam contract verification:
+    $signature = Get-AuthenticodeSignature -LiteralPath $Path
+    if ($null -eq $signature.SignerCertificate) {
+        throw "Production Authenticode provider seam failed: target $Path has no embedded signer certificate after signing"
+    }
+    $actualThumbprint = ([string]$signature.SignerCertificate.Thumbprint).Trim().ToUpperInvariant()
+    if ($actualThumbprint -ne $approvedThumbprint) {
+        throw "Production Authenticode signer thumbprint mismatch: expected $approvedThumbprint, got $actualThumbprint"
+    }
+    if ($signature.SignerCertificate.Subject -match 'CI V4 Test Code Signing') {
+        throw "Production Authenticode signing rejected: signer certificate is a CI test certificate"
+    }
+    if ([string]$signature.Status -eq "NotSigned") {
+        throw "Production Authenticode signing rejected: target remains unsigned"
+    }
+    . (Join-Path $PSScriptRoot "v4_authenticode_crypto.ps1")
+    $integrity = Get-AuthenticodeIntegrityProof -Path $Path -ExpectedThumbprint $approvedThumbprint
+    if ($integrity.IntegrityStatus -ne "Valid" -or $integrity.Verification -ne "signature-valid-independent-cryptographic-integrity") {
+        throw "Production Authenticode provider seam failed: cryptographic integrity verification failed on signed target"
+    }
+    Write-Host "V4 Authenticode production signing PASS: verified signed target $Path against approved thumbprint $approvedThumbprint"
+    exit 0
+}
+
 if ($mode -ne "test") {
-    throw "V4 Authenticode signing is fail-closed: no approved production provider is configured"
+    throw "V4 Authenticode signing is fail-closed: unrecognized mode '$mode' (must be 'test' or 'production')"
 }
 
 $thumbprint = [string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT

--- a/scripts/test_v4_production_signing_contract.ps1
+++ b/scripts/test_v4_production_signing_contract.ps1
@@ -24,6 +24,28 @@ if ($null -eq $sourcePe) {
     $sourcePe = Get-Item -LiteralPath (Join-Path $env:SystemRoot 'System32\notepad.exe')
 }
 
+# Save outer environment variables to restore in finally block
+$savedEnv = @{
+    'SKY_AUTHENTICODE_MODE' = $env:SKY_AUTHENTICODE_MODE
+    'SKY_AUTHENTICODE_TEST_PFX_PATH' = $env:SKY_AUTHENTICODE_TEST_PFX_PATH
+    'SKY_AUTHENTICODE_TEST_PFX_PASSWORD' = $env:SKY_AUTHENTICODE_TEST_PFX_PASSWORD
+    'SKY_AUTHENTICODE_TEST_THUMBPRINT' = $env:SKY_AUTHENTICODE_TEST_THUMBPRINT
+    'SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT' = $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT
+    'SKY_AUTHENTICODE_PROVIDER' = $env:SKY_AUTHENTICODE_PROVIDER
+    'SKY_AUTHENTICODE_PROVIDER_SCRIPT' = $env:SKY_AUTHENTICODE_PROVIDER_SCRIPT
+    'SKY_AUTHENTICODE_PROVIDER_COMMAND' = $env:SKY_AUTHENTICODE_PROVIDER_COMMAND
+}
+
+function Restore-SavedEnvironment {
+    foreach ($entry in $savedEnv.GetEnumerator()) {
+        if ($null -ne $entry.Value) {
+            [Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "Process")
+        } else {
+            [Environment]::SetEnvironmentVariable($entry.Key, $null, "Process")
+        }
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
     Copy-Item -LiteralPath $sourcePe.FullName -Destination $targetExe -Force
@@ -41,20 +63,46 @@ try {
         & $signToolCandidate remove /s $targetExe 2>$null | Out-Null
     }
 
+    # Clear all outer Authenticode environment variables so Test 1 runs in truly unconfigured production mode
+    foreach ($varName in @(
+        'SKY_AUTHENTICODE_MODE',
+        'SKY_AUTHENTICODE_TEST_PFX_PATH',
+        'SKY_AUTHENTICODE_TEST_PFX_PASSWORD',
+        'SKY_AUTHENTICODE_TEST_THUMBPRINT',
+        'SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT',
+        'SKY_AUTHENTICODE_PROVIDER',
+        'SKY_AUTHENTICODE_PROVIDER_SCRIPT',
+        'SKY_AUTHENTICODE_PROVIDER_COMMAND'
+    )) {
+        [Environment]::SetEnvironmentVariable($varName, $null, "Process")
+    }
+
     # Contract Test 1: Unconfigured production mode fails closed
     Write-Host "Contract Test 1: Unconfigured production mode fails closed..."
-    $failedClosed = $false
-    try {
-        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
-            -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
-            -Path $targetExe
-        if ($LASTEXITCODE -ne 0) { $failedClosed = $true }
-    } catch {
-        $failedClosed = $true
+
+    # 1a. Completely unconfigured (default mode = production, no thumbprint)
+    $output1a = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+        -Path $targetExe 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0) {
+        throw "FAILED: sign_v4_authenticode succeeded when completely unconfigured"
     }
-    if (-not $failedClosed) {
-        throw "FAILED: sign_v4_authenticode did not fail closed when production provider is unconfigured"
+    if ($output1a -notmatch "SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT") {
+        throw "FAILED: sign_v4_authenticode did not fail closed on missing approved thumbprint"
     }
+
+    # 1b. Approved thumbprint provided, but provider is unconfigured (asserts missing-provider branch specifically)
+    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "0123456789ABCDEF0123456789ABCDEF01234567"
+    $output1b = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+        -Path $targetExe 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0) {
+        throw "FAILED: sign_v4_authenticode succeeded when provider is unconfigured"
+    }
+    if ($output1b -notmatch "no approved production provider is configured") {
+        throw "FAILED: sign_v4_authenticode did not fail closed specifically on missing provider"
+    }
+    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = ""
     Write-Host "Contract Test 1: PASS"
 
     # Set up ephemeral CI test certificate
@@ -80,17 +128,14 @@ try {
     $env:SKY_AUTHENTICODE_PROVIDER = "custom"
     $env:SKY_AUTHENTICODE_PROVIDER_COMMAND = "echo signing %1"
 
-    $rejectedCredentials = $false
-    try {
-        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
-            -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
-            -Path $targetExe 2>$null
-        if ($LASTEXITCODE -ne 0) { $rejectedCredentials = $true }
-    } catch {
-        $rejectedCredentials = $true
-    }
-    if (-not $rejectedCredentials) {
+    $output2 = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+        -Path $targetExe 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0) {
         throw "FAILED: Production signing accepted ephemeral CI test credentials"
+    }
+    if ($output2 -notmatch "ephemeral CI test credentials cannot satisfy production mode") {
+        throw "FAILED: Production signing did not fail closed specifically on test credentials"
     }
     Write-Host "Contract Test 2: PASS"
 
@@ -204,6 +249,7 @@ try {
     if (Test-Path -LiteralPath $fixtureRoot) {
         Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
     }
+    Restore-SavedEnvironment
 }
 
 Write-Host "[PASS] V4 Authenticode contract tests: CI test certificate cannot satisfy production mode"

--- a/scripts/test_v4_production_signing_contract.ps1
+++ b/scripts/test_v4_production_signing_contract.ps1
@@ -147,6 +147,56 @@ try {
         throw "FAILED: Production verification accepted test thumbprint"
     }
     Write-Host "Contract Test 4: PASS"
+
+    # Contract Test 5: Production signing rejects mutually exclusive provider script and command
+    Write-Host "Contract Test 5: Mutually exclusive provider script and command fails closed..."
+    $env:SKY_AUTHENTICODE_MODE = "production"
+    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "1234567890ABCDEF1234567890ABCDEF12345678"
+    $env:SKY_AUTHENTICODE_PROVIDER = "custom"
+    $env:SKY_AUTHENTICODE_PROVIDER_COMMAND = "echo %1"
+    $dummyScript = Join-Path $fixtureRoot "dummy_provider.ps1"
+    Set-Content -LiteralPath $dummyScript -Value 'param([string]$Path) exit 0'
+    $env:SKY_AUTHENTICODE_PROVIDER_SCRIPT = $dummyScript
+
+    # Ensure no test credentials exist in env
+    $env:SKY_AUTHENTICODE_TEST_PFX_PATH = ""
+    $env:SKY_AUTHENTICODE_TEST_PFX_PASSWORD = ""
+    $env:SKY_AUTHENTICODE_TEST_THUMBPRINT = ""
+
+    $rejectedMutualExclusive = $false
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+            -Path $targetExe 2>$null
+        if ($LASTEXITCODE -ne 0) { $rejectedMutualExclusive = $true }
+    } catch {
+        $rejectedMutualExclusive = $true
+    }
+    if (-not $rejectedMutualExclusive) {
+        throw "FAILED: Production signing accepted mutually exclusive SCRIPT and COMMAND"
+    }
+    Write-Host "Contract Test 5: PASS"
+
+    # Contract Test 6: Production signing executes structured provider script and enforces exit code
+    Write-Host "Contract Test 6: Structured provider script failure propagation..."
+    $env:SKY_AUTHENTICODE_PROVIDER_COMMAND = ""
+    $failingScript = Join-Path $fixtureRoot "failing_provider.ps1"
+    Set-Content -LiteralPath $failingScript -Value 'param([string]$Path) exit 42'
+    $env:SKY_AUTHENTICODE_PROVIDER_SCRIPT = $failingScript
+
+    $rejectedFailedProvider = $false
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+            -Path $targetExe 2>$null
+        if ($LASTEXITCODE -ne 0) { $rejectedFailedProvider = $true }
+    } catch {
+        $rejectedFailedProvider = $true
+    }
+    if (-not $rejectedFailedProvider) {
+        throw "FAILED: Production signing did not fail closed when provider script failed"
+    }
+    Write-Host "Contract Test 6: PASS"
 } finally {
     # Clean up test certificate
     & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `

--- a/scripts/test_v4_production_signing_contract.ps1
+++ b/scripts/test_v4_production_signing_contract.ps1
@@ -1,0 +1,160 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Starting V4 production Authenticode contract tests..."
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$temporaryRoot = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+    [IO.Path]::GetTempPath()
+} else {
+    $env:RUNNER_TEMP
+}
+$temporaryRoot = [IO.Path]::GetFullPath($temporaryRoot)
+$fixtureRoot = Join-Path $temporaryRoot ('sky-v4-prod-signing-contract-' + [guid]::NewGuid().ToString('N'))
+$envFile = Join-Path $fixtureRoot 'test-signing.env'
+$targetExe = Join-Path $fixtureRoot 'target.exe'
+
+# Find a valid PE file to use as target
+$sourcePe = Get-ChildItem -LiteralPath (Join-Path $repoRoot 'rust\target') -Filter '*.exe' -Recurse -File -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -notmatch '\\deps\\' } |
+    Select-Object -First 1
+
+if ($null -eq $sourcePe) {
+    # Fallback to xtask.exe or any system PE
+    $sourcePe = Get-Item -LiteralPath (Join-Path $env:SystemRoot 'System32\notepad.exe')
+}
+
+try {
+    New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+    Copy-Item -LiteralPath $sourcePe.FullName -Destination $targetExe -Force
+
+    # Remove any existing signature on target
+    $signToolCandidate = $null
+    $kits = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots' -ErrorAction SilentlyContinue
+    if ($null -ne $kits -and -not [string]::IsNullOrWhiteSpace($kits.KitsRoot10)) {
+        $matches = @(Get-ChildItem -LiteralPath (Join-Path $kits.KitsRoot10 'bin') -Filter signtool.exe -File -Recurse -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+            Sort-Object FullName -Descending)
+        if ($matches.Count -gt 0) { $signToolCandidate = $matches[0].FullName }
+    }
+    if ($null -ne $signToolCandidate) {
+        & $signToolCandidate remove /s $targetExe 2>$null | Out-Null
+    }
+
+    # Contract Test 1: Unconfigured production mode fails closed
+    Write-Host "Contract Test 1: Unconfigured production mode fails closed..."
+    $failedClosed = $false
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+            -Path $targetExe
+        if ($LASTEXITCODE -ne 0) { $failedClosed = $true }
+    } catch {
+        $failedClosed = $true
+    }
+    if (-not $failedClosed) {
+        throw "FAILED: sign_v4_authenticode did not fail closed when production provider is unconfigured"
+    }
+    Write-Host "Contract Test 1: PASS"
+
+    # Set up ephemeral CI test certificate
+    Write-Host "Setting up ephemeral test certificate..."
+    & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'setup_v4_test_signing.ps1') `
+        -EnvFile $envFile
+    if ($LASTEXITCODE -ne 0) {
+        throw "setup_v4_test_signing.ps1 failed"
+    }
+    Get-Content -LiteralPath $envFile | ForEach-Object {
+        $line = [string]$_
+        if ($line -match '^([^=]+)=(.*)$') {
+            [Environment]::SetEnvironmentVariable($matches[1], $matches[2], "Process")
+        }
+    }
+    $testThumbprint = [string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT
+
+    # Contract Test 2: Production signing rejects test credentials
+    Write-Host "Contract Test 2: Production signing rejects test credentials..."
+    $env:SKY_AUTHENTICODE_MODE = "production"
+    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "0123456789ABCDEF0123456789ABCDEF01234567"
+    $env:SKY_AUTHENTICODE_PROVIDER = "custom"
+    $env:SKY_AUTHENTICODE_PROVIDER_COMMAND = "echo signing %1"
+
+    $rejectedCredentials = $false
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+            -Path $targetExe 2>$null
+        if ($LASTEXITCODE -ne 0) { $rejectedCredentials = $true }
+    } catch {
+        $rejectedCredentials = $true
+    }
+    if (-not $rejectedCredentials) {
+        throw "FAILED: Production signing accepted ephemeral CI test credentials"
+    }
+    Write-Host "Contract Test 2: PASS"
+
+    # Contract Test 3: Sign with test mode, then verify production mode rejects it
+    Write-Host "Contract Test 3: Production verification rejects CI test certificate..."
+    $env:SKY_AUTHENTICODE_MODE = "test"
+    & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+        -Path $targetExe
+    if ($LASTEXITCODE -ne 0) {
+        throw "Test-mode signing failed"
+    }
+
+    # Verify test mode succeeds
+    & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'verify_v4_authenticode.ps1') `
+        -Mode test `
+        -Artifact $targetExe
+    if ($LASTEXITCODE -ne 0) {
+        throw "Test-mode verification failed on signed target"
+    }
+
+    # Verify production mode rejects test certificate
+    $rejectedInProduction = $false
+    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "0123456789ABCDEF0123456789ABCDEF01234567"
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'verify_v4_authenticode.ps1') `
+            -Mode production `
+            -Artifact $targetExe 2>$null
+        if ($LASTEXITCODE -ne 0) { $rejectedInProduction = $true }
+    } catch {
+        $rejectedInProduction = $true
+    }
+    if (-not $rejectedInProduction) {
+        throw "FAILED: Production verification accepted test-signed binary"
+    }
+    Write-Host "Contract Test 3: PASS"
+
+    # Contract Test 4: Production verification rejects test thumbprint
+    Write-Host "Contract Test 4: Production verification rejects test thumbprint..."
+    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = $testThumbprint
+    $rejectedThumbprint = $false
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'verify_v4_authenticode.ps1') `
+            -Mode production `
+            -Artifact $targetExe 2>$null
+        if ($LASTEXITCODE -ne 0) { $rejectedThumbprint = $true }
+    } catch {
+        $rejectedThumbprint = $true
+    }
+    if (-not $rejectedThumbprint) {
+        throw "FAILED: Production verification accepted test thumbprint"
+    }
+    Write-Host "Contract Test 4: PASS"
+} finally {
+    # Clean up test certificate
+    & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'cleanup_v4_test_signing.ps1')
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "[PASS] V4 Authenticode contract tests: CI test certificate cannot satisfy production mode"
+exit 0

--- a/scripts/verify_v4_authenticode.ps1
+++ b/scripts/verify_v4_authenticode.ps1
@@ -28,6 +28,12 @@ if ($expectedThumbprint -notmatch '^[0-9a-fA-F]{40}$') {
     throw "V4 Authenticode verification requires the exact approved signer thumbprint in $identityVariable"
 }
 $expectedThumbprint = $expectedThumbprint.ToUpperInvariant()
+if ($mode -eq "production") {
+    $testThumbprint = ([string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT).Trim().ToUpperInvariant()
+    if (-not [string]::IsNullOrWhiteSpace($testThumbprint) -and $expectedThumbprint -eq $testThumbprint) {
+        throw "V4 production Authenticode verification rejects ephemeral CI test signer thumbprint"
+    }
+}
 
 function Resolve-TestPfxPath {
     $pfxPath = ([string]$env:SKY_AUTHENTICODE_TEST_PFX_PATH).Trim()
@@ -114,6 +120,9 @@ $records = foreach ($file in $files) {
     $statusType = $signature.Status.GetType()
     if ($statusType.IsEnum -and [Enum]::GetNames($statusType) -notcontains $platformStatus) {
         throw "Unknown Authenticode status for $($file.Name): $platformStatus"
+    }
+    if ($mode -eq "production" -and [string]$signature.SignerCertificate.Subject -match 'CI V4 Test Code Signing') {
+        throw "Production Authenticode verification rejects CI test certificate for $($file.Name)"
     }
     if ($mode -eq "production" -and $platformStatus -ne "Valid") {
         throw "Production Authenticode verification requires Windows status Valid for $($file.Name): $platformStatus"

--- a/scripts/verify_v4_updater_private_key.ps1
+++ b/scripts/verify_v4_updater_private_key.ps1
@@ -4,75 +4,69 @@ param(
     [string]$KeyPath,
 
     [Parameter(Mandatory = $false)]
-    [string]$Password = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+    [string]$PasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
 )
 
 $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
-$desktopRoot = Join-Path $repoRoot "desktop"
 
+# 1. Resolve key path: strictly require a file path (no raw key in env vars or command lines)
 $keyFile = if (-not [string]::IsNullOrWhiteSpace($KeyPath)) {
     (Resolve-Path -LiteralPath $KeyPath -ErrorAction Stop).Path
 } elseif (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
     (Resolve-Path -LiteralPath $env:TAURI_SIGNING_PRIVATE_KEY_PATH -ErrorAction Stop).Path
 } else {
-    $null
+    throw "No updater private key path specified. Provide -KeyPath <path> or set TAURI_SIGNING_PRIVATE_KEY_PATH environment variable."
 }
 
-$cleanupTempKey = $false
-$tempKeyPath = $null
+if (-not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
+    throw "Private key file does not exist: $keyFile"
+}
 
+# 2. Resolve password: prefer specified environment variable or secure interactive prompt
+$envVal = [Environment]::GetEnvironmentVariable($PasswordEnv)
+$passwordValue = if (-not [string]::IsNullOrWhiteSpace($envVal)) {
+    $envVal
+} elseif ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
+    Write-Host "Enter updater private key passphrase (press Enter if unencrypted): " -NoNewline
+    $securePrompt = Read-Host -AsSecureString
+    if ($securePrompt.Length -gt 0) {
+        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($securePrompt)
+        try {
+            [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+        } finally {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
+    } else {
+        ""
+    }
+} else {
+    ""
+}
+
+# 3. Mask password if running in GitHub Actions to prevent log leakage
+if (-not [string]::IsNullOrWhiteSpace($passwordValue) -and $env:GITHUB_ACTIONS -eq "true") {
+    Write-Output "::add-mask::$passwordValue"
+}
+
+$prevPwd = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+$env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $passwordValue
 try {
-    if ($null -eq $keyFile) {
-        if (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY)) {
-            $runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
-                [IO.Path]::GetTempPath()
-            } else {
-                $env:RUNNER_TEMP
-            }
-            $tempKeyPath = Join-Path $runnerTemp ("sky-v4-keycheck-" + [guid]::NewGuid().ToString("N") + ".key")
-            [IO.File]::WriteAllText($tempKeyPath, $env:TAURI_SIGNING_PRIVATE_KEY.Trim(), [Text.UTF8Encoding]::new($false))
-            $keyFile = $tempKeyPath
-            $cleanupTempKey = $true
-        } else {
-            throw "No updater private key specified. Supply -KeyPath or set TAURI_SIGNING_PRIVATE_KEY_PATH or TAURI_SIGNING_PRIVATE_KEY"
-        }
+    & cargo xtask updater-trust verify-private-key --key-file $keyFile
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[FAIL] Local updater private key does not match canonical production v4 root"
+        exit 1
     }
-
-    if (-not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
-        throw "Private key file does not exist: $keyFile"
-    }
-
-    $passwordArg = if ($null -ne $Password) { $Password } else { "" }
-
-    # Mask password if running in GitHub Actions
-    if (-not [string]::IsNullOrWhiteSpace($passwordArg)) {
-        Write-Output "::add-mask::$passwordArg"
-    }
-
-    $prevPwd = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-    $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $passwordArg
-    try {
-        & cargo xtask updater-trust verify-private-key --key-file $keyFile
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "[FAIL] Local updater private key does not match canonical production v4 root"
-            exit 1
-        }
-        Write-Host "[PASS] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)"
-        exit 0
-    } finally {
-        if ($null -ne $prevPwd) {
-            $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $prevPwd
-        } else {
-            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
-        }
-    }
+    Write-Host "[PASS] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)"
+    exit 0
 } catch {
     Write-Host "[FAIL] Updater private key verification failed: $($_.Exception.Message)"
     exit 1
 } finally {
-    if ($cleanupTempKey -and (-not [string]::IsNullOrWhiteSpace($tempKeyPath)) -and (Test-Path -LiteralPath $tempKeyPath)) {
-        Remove-Item -LiteralPath $tempKeyPath -Force -ErrorAction SilentlyContinue
+    if ($null -ne $prevPwd) {
+        $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $prevPwd
+    } else {
+        Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
     }
 }

--- a/scripts/verify_v4_updater_private_key.ps1
+++ b/scripts/verify_v4_updater_private_key.ps1
@@ -1,0 +1,78 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$KeyPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Password = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$desktopRoot = Join-Path $repoRoot "desktop"
+
+$keyFile = if (-not [string]::IsNullOrWhiteSpace($KeyPath)) {
+    (Resolve-Path -LiteralPath $KeyPath -ErrorAction Stop).Path
+} elseif (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
+    (Resolve-Path -LiteralPath $env:TAURI_SIGNING_PRIVATE_KEY_PATH -ErrorAction Stop).Path
+} else {
+    $null
+}
+
+$cleanupTempKey = $false
+$tempKeyPath = $null
+
+try {
+    if ($null -eq $keyFile) {
+        if (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY)) {
+            $runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+                [IO.Path]::GetTempPath()
+            } else {
+                $env:RUNNER_TEMP
+            }
+            $tempKeyPath = Join-Path $runnerTemp ("sky-v4-keycheck-" + [guid]::NewGuid().ToString("N") + ".key")
+            [IO.File]::WriteAllText($tempKeyPath, $env:TAURI_SIGNING_PRIVATE_KEY.Trim(), [Text.UTF8Encoding]::new($false))
+            $keyFile = $tempKeyPath
+            $cleanupTempKey = $true
+        } else {
+            throw "No updater private key specified. Supply -KeyPath or set TAURI_SIGNING_PRIVATE_KEY_PATH or TAURI_SIGNING_PRIVATE_KEY"
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
+        throw "Private key file does not exist: $keyFile"
+    }
+
+    $passwordArg = if ($null -ne $Password) { $Password } else { "" }
+
+    # Mask password if running in GitHub Actions
+    if (-not [string]::IsNullOrWhiteSpace($passwordArg)) {
+        Write-Output "::add-mask::$passwordArg"
+    }
+
+    $prevPwd = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+    $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $passwordArg
+    try {
+        & cargo xtask updater-trust verify-private-key --key-file $keyFile
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "[FAIL] Local updater private key does not match canonical production v4 root"
+            exit 1
+        }
+        Write-Host "[PASS] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)"
+        exit 0
+    } finally {
+        if ($null -ne $prevPwd) {
+            $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $prevPwd
+        } else {
+            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+        }
+    }
+} catch {
+    Write-Host "[FAIL] Updater private key verification failed: $($_.Exception.Message)"
+    exit 1
+} finally {
+    if ($cleanupTempKey -and (-not [string]::IsNullOrWhiteSpace($tempKeyPath)) -and (Test-Path -LiteralPath $tempKeyPath)) {
+        Remove-Item -LiteralPath $tempKeyPath -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
Provider-neutral Track B / B1 groundwork for #117, based on post-merge accepted main SHA `4805f7b9301b77e7d279a10fd59fbf06522cecd3`.

Scope:
- inventory and enforce the single canonical v4 Tauri updater public trust root;
- add local/private-key match verification without emitting private key material;
- document updater-key custody, backup, loss, compromise, rotation, and recovery;
- formalize a provider-neutral production Authenticode seam;
- add fail-closed contracts proving CI self-signed test credentials cannot satisfy production mode.

This PR is **B1/provider-neutral only**. It does not prove or claim:
- a real production Authenticode provider/identity has been provisioned;
- the production updater private key is in maintainer custody/backed up;
- #107/#117 is complete;
- WO-06/#108 is unblocked.

Acceptance requires exact-head PR CI green plus security review of the production/test separation and private-key verification path. Keep Draft until review acceptance.

Related: #102, #107, #117. #108 remains blocked.