### PR TITLE
fix(ci): pin Playwright browser install to locked desktop toolchain (#121)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,14 @@ jobs:
       - name: Install Chromium for desktop browser smoke
         if: needs.changes.outputs.browser_required == 'true'
         working-directory: desktop
-        run: bunx playwright install chromium
+        run: |
+          bun install --frozen-lockfile
+          $expected = (Get-Content package.json -Raw | ConvertFrom-Json).devDependencies.playwright
+          $actual = (& bun node_modules/playwright/cli.js --version).Trim() -replace '^Version\s+', ''
+          if ($actual -ne $expected) {
+            throw "Playwright CLI mismatch: package.json=$expected, local CLI=$actual"
+          }
+          bun node_modules/playwright/cli.js install chromium
 
       - name: Construct Python-unavailable validation environment
         if: needs.changes.outputs.package_required == 'true'


### PR DESCRIPTION
## Summary

Fixes #121.

Pins the Playwright browser install in Windows CI `validate` job to the locked desktop toolchain, resolving post-merge CI #656 failure where an ephemeral `bunx playwright install` resolved an unpinned version (revision 1243) while `@playwright/test` was pinned to 1.62.1 (revision 1234).

### Key Changes
- Runs `bun install --frozen-lockfile` before browser installation in `desktop/`.
- Validates that `node_modules/playwright/cli.js --version` matches the pinned `devDependencies.playwright` version in `desktop/package.json` before download.
- Directly invokes `bun node_modules/playwright/cli.js install chromium` using the locked local CLI.
- Preserves all B2 release semantics and does not touch optimization #116 scopes.

### Verification
- `cargo xtask check static`: PASS
- `cargo xtask check desktop`: PASS (all 27 Playwright E2E tests pass)