### PR TITLE
fix(v4): harden updater key verifier secret output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -761,6 +761,13 @@ jobs:
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_production_orchestrator.ps1
           if ($LASTEXITCODE -ne 0) { throw "V4 production release orchestrator contract test failed with exit code $LASTEXITCODE" }
 
+      - name: Run V4 updater private-key verifier secret-output regression
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_updater_private_key.ps1
+          if ($LASTEXITCODE -ne 0) { throw "V4 updater private-key verifier regression failed with exit code $LASTEXITCODE" }
+
       - name: Verify Tauri Authenticode signature
         env:
           RUSTUP_TOOLCHAIN: 1.98.0

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -58,8 +58,11 @@ cargo xtask updater-trust inventory
 4. **In-Memory & Ephemeral Signing Rules**:
    - When signing candidate update artifacts for release qualification, the key file or
      passphrase must only be loaded into ephemeral process memory.
-   - When automated workflows handle the passphrase, `::add-mask::<passphrase>` must be
-     emitted before any other output to prevent log leakage.
+   - Release and verifier processes never print secret values to stdout, stderr, or log files.
+     External automation is responsible for its own secret-management and log-masking controls;
+     the child release or verifier process does not need to emit the secret or a masking command.
+   - This is an output-secrecy guarantee only. PowerShell/.NET managed strings are not claimed
+     to be cryptographically zeroized by this runbook.
 
 ## 3. Local Private Key Verification
 
@@ -73,7 +76,7 @@ the verification tools avoid command-line password flags.
 
 ### Interactive Operator Verification (Recommended)
 
-For interactive operator use, run the PowerShell verifier. It performs a non-echoing, masked
+For interactive operator use, run the PowerShell verifier. It performs a non-echoing secure
 interactive prompt via `Read-Host -AsSecureString` to prevent passphrase exposure in terminal
 logs or history files:
 
@@ -97,7 +100,8 @@ cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.ke
 
 Expected output:
 ```text
-[PASS] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)
+[xtask] Local updater private key matches canonical production v4 root (Key ID: <canonical public-root identity>)
+[PASS] Local updater private key matches canonical production v4 root
 ```
 
 If the key does not match or the password is wrong, the tool exits with code 1 and emits a

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -501,6 +501,9 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
         "- name: Run V4 production release orchestrator contract test",
         "scripts/test_v4_production_orchestrator.ps1",
         "V4 production release orchestrator contract test failed with exit code",
+        "- name: Run V4 updater private-key verifier secret-output regression",
+        "scripts/test_v4_updater_private_key.ps1",
+        "V4 updater private-key verifier regression failed with exit code",
         "- name: Verify Tauri Authenticode signature",
         "- name: Generate Tauri SPDX SBOM",
         "- name: Verify Tauri SPDX SBOM",
@@ -871,6 +874,30 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
             "v4 updater key verification script must delegate to updater-trust verify-private-key"
                 .into(),
         );
+    }
+    for forbidden in ["::add-mask::", "F6355260A0C663D5"] {
+        if key_verifier.contains(forbidden) {
+            return Err(format!(
+                "v4 updater key verification script must not emit or hard-code production secret/output data: {forbidden}"
+            )
+            .into());
+        }
+    }
+    let key_verifier_test =
+        fs::read_to_string(root.join("scripts/test_v4_updater_private_key.ps1"))?;
+    for marker in [
+        "V4_TEST_ONLY_PASS_PHRASE_MARKER",
+        "verify_v4_updater_private_key.ps1",
+        "Verifier mismatch path",
+        "Verifier success path",
+        "throwaway.key",
+    ] {
+        if !key_verifier_test.contains(marker) {
+            return Err(format!(
+                "v4 updater key verifier regression is missing its required marker: {marker}"
+            )
+            .into());
+        }
     }
     let orchestrator =
         fs::read_to_string(root.join("scripts/orchestrate_v4_production_release.ps1"))?;
@@ -2707,6 +2734,9 @@ read_only=true
       - name: Run V4 production release orchestrator contract test
         run: pwsh scripts/test_v4_production_orchestrator.ps1
         # V4 production release orchestrator contract test failed with exit code
+      - name: Run V4 updater private-key verifier secret-output regression
+        run: pwsh scripts/test_v4_updater_private_key.ps1
+        # V4 updater private-key verifier regression failed with exit code
       - name: Verify Tauri Authenticode signature
         run: pwsh scripts/verify_v4_authenticode.ps1
         # Authenticode verification failed with exit code

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -302,8 +302,9 @@ fn main() -> Result<()> {
                 Path::new(&key_file),
                 password.as_deref(),
             )?;
+            let key_id = updater_trust::canonical_key_id()?;
             println!(
-                "[xtask] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)"
+                "[xtask] Local updater private key matches canonical production v4 root (Key ID: {key_id})"
             );
             Ok(())
         }

--- a/rust/xtask/src/updater_trust.rs
+++ b/rust/xtask/src/updater_trust.rs
@@ -254,9 +254,14 @@ pub fn verify_updater_signature(installer_path: &Path, signature_path: &Path) ->
     public_key
         .verify(&installer_bytes, &signature, false)
         .map_err(|_| "updater signature does not match the canonical production v4 public root")?;
-    let key_id = extract_key_id_from_public_key(crate::tauri_bundle::V4_TAURI_UPDATER_PUBLIC_KEY)?;
+    let key_id = canonical_key_id()?;
     println!("[xtask] V4 Updater Signature Verification: PASS (Key ID: {key_id})");
     Ok(())
+}
+
+/// Return the identity parsed from the canonical compiled public root.
+pub fn canonical_key_id() -> Result<String> {
+    extract_key_id_from_public_key(crate::tauri_bundle::V4_TAURI_UPDATER_PUBLIC_KEY)
 }
 
 pub fn extract_key_id_from_public_key(value: &str) -> Result<String> {

--- a/scripts/test_v4_updater_private_key.ps1
+++ b/scripts/test_v4_updater_private_key.ps1
@@ -1,0 +1,96 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$fixtureRoot = Join-Path ([IO.Path]::GetTempPath()) ('sky-v4-updater-key-test-' + [guid]::NewGuid().ToString('N'))
+$throwawayKeyPath = Join-Path $fixtureRoot 'throwaway.key'
+$cargoShimPath = Join-Path $fixtureRoot 'cargo.cmd'
+$passwordEnvName = 'SKY_V4_TEST_UPDATER_PASSWORD'
+$passwordMarker = 'V4_TEST_ONLY_PASS_PHRASE_MARKER_7F3C91D2'
+
+$savedPath = $env:Path
+$savedActions = $env:GITHUB_ACTIONS
+$savedPassword = [Environment]::GetEnvironmentVariable($passwordEnvName, 'Process')
+
+function Assert-NoPasswordMarker {
+    param(
+        [string]$Name,
+        [string]$Output
+    )
+
+    if ($Output.Contains($passwordMarker)) {
+        throw "FAILED: $Name emitted the throwaway password marker"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+
+    # Generate only throwaway key material outside the repository.
+    Push-Location (Join-Path $repoRoot 'desktop')
+    try {
+        & bun run tauri signer generate --ci --password '' --force -w $throwawayKeyPath *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Throwaway updater key generation failed with exit code $LASTEXITCODE"
+        }
+    } finally {
+        Pop-Location
+    }
+
+    # Exercise the real verifier mismatch path while forcing the old CI-mask
+    # branch, if present, to expose the marker in captured output.
+    $env:GITHUB_ACTIONS = 'true'
+    [Environment]::SetEnvironmentVariable($passwordEnvName, $passwordMarker, 'Process')
+    $failureOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'verify_v4_updater_private_key.ps1') `
+        -KeyPath $throwawayKeyPath `
+        -PasswordEnv $passwordEnvName 2>&1 | Out-String
+    $failureExitCode = $LASTEXITCODE
+
+    if ($failureExitCode -eq 0) {
+        throw 'FAILED: Throwaway updater key unexpectedly passed canonical-root verification'
+    }
+    Assert-NoPasswordMarker -Name 'Verifier mismatch path' -Output $failureOutput
+    if ($failureOutput -notmatch '\[FAIL\]') {
+        throw "FAILED: Verifier mismatch path did not report failure. Output:`n$failureOutput"
+    }
+
+    # Reach the wrapper success path without a production key. The temporary
+    # cargo shim checks that the marker crossed the environment boundary and
+    # returns success without printing it.
+    $cargoShim = @"
+@echo off
+if "%TAURI_SIGNING_PRIVATE_KEY_PASSWORD%"=="$passwordMarker" exit /b 0
+exit /b 1
+"@
+    Set-Content -LiteralPath $cargoShimPath -Value $cargoShim -Encoding ASCII
+    $env:Path = "$fixtureRoot;$savedPath"
+
+    $successOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'verify_v4_updater_private_key.ps1') `
+        -KeyPath $throwawayKeyPath `
+        -PasswordEnv $passwordEnvName 2>&1 | Out-String
+    $successExitCode = $LASTEXITCODE
+
+    Assert-NoPasswordMarker -Name 'Verifier success path' -Output $successOutput
+    if ($successExitCode -ne 0) {
+        throw "FAILED: Verifier success path failed with exit code $successExitCode. Output:`n$successOutput"
+    }
+    if ($successOutput -notmatch '\[PASS\]') {
+        throw "FAILED: Verifier success path did not report success. Output:`n$successOutput"
+    }
+
+    Write-Host '[PASS] V4 updater private-key verifier secret-output regression passed'
+} finally {
+    $env:Path = $savedPath
+    if ($null -ne $savedActions) {
+        $env:GITHUB_ACTIONS = $savedActions
+    } else {
+        Remove-Item Env:GITHUB_ACTIONS -ErrorAction SilentlyContinue
+    }
+    if ($null -ne $savedPassword) {
+        [Environment]::SetEnvironmentVariable($passwordEnvName, $savedPassword, 'Process')
+    } else {
+        [Environment]::SetEnvironmentVariable($passwordEnvName, $null, 'Process')
+    }
+    Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/verify_v4_updater_private_key.ps1
+++ b/scripts/verify_v4_updater_private_key.ps1
@@ -45,23 +45,29 @@ $passwordValue = if (-not [string]::IsNullOrWhiteSpace($envVal)) {
     ""
 }
 
-# 3. Mask password if running in GitHub Actions to prevent log leakage
-if (-not [string]::IsNullOrWhiteSpace($passwordValue) -and $env:GITHUB_ACTIONS -eq "true") {
-    Write-Output "::add-mask::$passwordValue"
-}
-
 $prevPwd = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $passwordValue
 try {
-    & cargo xtask updater-trust verify-private-key --key-file $keyFile
+    # The child owns verification and emits only sanitized status. Keep a final
+    # redaction guard around the boundary so this process never forwards a
+    # password if a dependency unexpectedly includes it in diagnostic output.
+    $verificationOutput = & cargo xtask updater-trust verify-private-key --key-file $keyFile 2>&1 | Out-String
+    if (-not [string]::IsNullOrEmpty($passwordValue)) {
+        $verificationOutput = $verificationOutput.Replace($passwordValue, "[REDACTED]")
+    }
+    Write-Output $verificationOutput.TrimEnd()
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[FAIL] Local updater private key does not match canonical production v4 root"
         exit 1
     }
-    Write-Host "[PASS] Local updater private key matches canonical production v4 root (Key ID: F6355260A0C663D5)"
+    Write-Host "[PASS] Local updater private key matches canonical production v4 root"
     exit 0
 } catch {
-    Write-Host "[FAIL] Updater private key verification failed: $($_.Exception.Message)"
+    $errorMessage = $_.Exception.Message
+    if (-not [string]::IsNullOrEmpty($passwordValue)) {
+        $errorMessage = $errorMessage.Replace($passwordValue, "[REDACTED]")
+    }
+    Write-Host "[FAIL] Updater private key verification failed: $errorMessage"
     exit 1
 } finally {
     if ($null -ne $prevPwd) {


### PR DESCRIPTION
Refs #123

Summary:
- Removes updater-passphrase output and CI masking-command emission from the PowerShell verifier.
- Uses the existing updater-trust canonical parser for dynamic public-root Key ID output.
- Documents output secrecy and external automation ownership without claiming managed .NET string zeroization.
- Adds Windows/PowerShell throwaway-key regression coverage for mismatch and success-boundary paths.

No production updater key, passphrase, or real-key readiness check is included.