### PR TITLE
release: adopt unsigned-zero-budget Authenticode policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,12 +736,15 @@ jobs:
             }
           }
 
+      - name: Prepare bounded ephemeral Authenticode test certificate
+        timeout-minutes: 2
+        run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
+
       - name: Run Authenticode tamper regression
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
         run: |
           # CI self-signed credentials remain test-only; canonical package evidence is unsigned.
-          pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
           pwsh scripts/test_v4_authenticode_integrity.ps1 `
             -Source rust/target/dist/sky_desktop_shell.exe
           if ($LASTEXITCODE -ne 0) { throw "Authenticode tamper regression failed with exit code $LASTEXITCODE" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,10 +654,6 @@ jobs:
         working-directory: desktop
         run: bun run build
 
-      - name: Prepare bounded ephemeral Authenticode test certificate
-        timeout-minutes: 2
-        run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
-
       - name: Construct Python-unavailable canonical environment
         run: |
           $required = @("cargo", "rustc", "rustup", "git", "bun", "bunx", "link", "rc", "sccache")
@@ -710,6 +706,7 @@ jobs:
               } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $configPath -Encoding utf8
               $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
               $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
+              $env:SKY_AUTHENTICODE_MODE = "unsigned-zero-budget"
               bun run tauri build --ci --config $configPath -- --profile dist
               if ($LASTEXITCODE -ne 0) { throw "Tauri build failed with exit code $LASTEXITCODE" }
             } finally {
@@ -743,6 +740,8 @@ jobs:
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
         run: |
+          # CI self-signed credentials remain test-only; canonical package evidence is unsigned.
+          pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
           pwsh scripts/test_v4_authenticode_integrity.ps1 `
             -Source rust/target/dist/sky_desktop_shell.exe
           if ($LASTEXITCODE -ne 0) { throw "Authenticode tamper regression failed with exit code $LASTEXITCODE" }
@@ -778,7 +777,7 @@ jobs:
           }
           $installer = $installers[0].FullName
           pwsh scripts/verify_v4_authenticode.ps1 `
-            -Mode test `
+            -Mode unsigned-zero-budget `
             -Artifact $installer `
             -Evidence rust/target/dist/TAURI_AUTHENTICODE_EVIDENCE.json
           if ($LASTEXITCODE -ne 0) { throw "Authenticode verification failed with exit code $LASTEXITCODE" }
@@ -842,7 +841,7 @@ jobs:
               Where-Object { $_.Extension.ToLowerInvariant() -in @('.exe', '.dll') -and $_.Name -ne 'uninstall.exe' })
             if ($installedPe.Count -eq 0) { throw "Installed Tauri tree contains no project PE files" }
             pwsh scripts/verify_v4_authenticode.ps1 `
-              -Mode test `
+              -Mode unsigned-zero-budget `
               -Artifact $installedPe.FullName `
               -Evidence rust/target/dist/INSTALLED_AUTHENTICODE_EVIDENCE.json
             if ($LASTEXITCODE -ne 0) { throw "Installed Authenticode verification failed with exit code $LASTEXITCODE" }
@@ -883,7 +882,7 @@ jobs:
             signature_size = $summary.signature_size
             installer_sha256 = $summary.installer_sha256
             updater_signature_sha256 = $summary.updater_signature_sha256
-            authenticode_mode = "test"
+            authenticode_mode = "unsigned-zero-budget"
             authenticode_evidence = "TAURI_AUTHENTICODE_EVIDENCE.json"
             authenticode_evidence_sha256 = (Get-FileHash -LiteralPath rust/target/dist/TAURI_AUTHENTICODE_EVIDENCE.json -Algorithm SHA256).Hash.ToLowerInvariant()
             sbom = "SBOM.spdx.json"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Sky Auto Player automatically checks GitHub for new releases and displays a noti
 Selecting **Update and Restart** launches the bundled native Rust updater (`Sky-Auto-Player-Updater.exe`), which downloads the release, cryptographically verifies the SHA256 sidecar and `MANIFEST.json`, and performs a transactional atomic replacement with automatic rollback on error. **Open GitHub Releases** remains available as a manual fallback. Preserved user data includes `config.json`, `.env`, `songs/`, and `logs/`.
 
 > [!WARNING]
-> Windows binaries in this release are intentionally unsigned and portable (no Authenticode publisher requirement). Windows SmartScreen may display an unrecognized-app warning. Download releases only from the official [GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases) and verify the published SHA256 checksums if desired.
+> Windows binaries in the current v4 release use the `unsigned-zero-budget` policy: they are intentionally Authenticode-unsigned, so Windows may show Unknown Publisher or a SmartScreen warning. This is a publisher-identity/UX trade-off, not a bypass of Tauri updater cryptographic trust. Download releases only from the official [GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases) and verify the published SHA256 checksums if desired.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,10 @@ audit in its `static` group.
 
 ## Update and release integrity
 
-The public binaries are intentionally unsigned for Authenticode and remain portable. Update
-metadata is authenticated separately: the native updater verifies the detached Ed25519 signature
+The v4 release policy is `unsigned-zero-budget`: shipped project PE files and the canonical NSIS
+installer are intentionally unsigned for Authenticode. Windows may show Unknown Publisher or a
+SmartScreen warning; this is a publisher-identity/UX trade-off, not a bypass of update trust.
+Update metadata is authenticated separately: the official Tauri updater verifies the detached Ed25519 signature
 over the exact `MANIFEST.json` bytes, using its embedded trusted key set, before trusting manifest
 hashes. It must also preserve its HTTPS allow-list, exact SHA256/archive/manifest verification,
 transaction/rollback behavior, preserve-list, bounded provenance, and user-triggered execution

--- a/docs/adr/ADR-0006-v4-distribution-installation-update.md
+++ b/docs/adr/ADR-0006-v4-distribution-installation-update.md
@@ -52,7 +52,7 @@ https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/s
 https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json
 ```
 
-### 3. The canonical v4 Windows distribution is NSIS, per-user, and signed
+### 3. The canonical v4 Windows distribution is NSIS, per-user, and updater-authenticated
 
 V4 uses the Tauri bundler with the Windows NSIS target. The default supported installation scope is
 current-user so normal installation and update do not require Administrator privileges and can live
@@ -131,11 +131,24 @@ A production `.env` file beside the executable is not part of the v4 user config
 
 ### 8. V4 has two independent signing boundaries
 
-Windows code signing and updater signing are separate requirements:
+Windows Authenticode and updater signing are separate boundaries:
 
-1. Project-owned Windows executables and the canonical installer are Authenticode signed so Windows
-   and users receive a stable publisher identity.
+1. Under the permanent project release policy `unsigned-zero-budget`, project-owned Windows
+   executables and the canonical installer are deliberately Authenticode-unsigned. Qualification
+   proves the expected `NotSigned` state and rejects test/self-signed or otherwise unexpected
+   signatures.
 2. Tauri updater artifacts use the Tauri updater signing mechanism and a new v4 update trust root.
+
+The zero-budget state is a publisher-identity and user-experience trade-off: Windows may show
+**Unknown Publisher** or a SmartScreen warning. It is not a bypass of updater cryptographic trust.
+The official Tauri updater still verifies its Ed25519/minisign `.sig` against the v4 public root;
+exact SHA-256 identity, SBOM, provenance attestations, and install/launch/uninstall qualification
+remain mandatory. The bounded `signCommand` invokes the verifier seam, whose zero-budget mode
+deliberately performs no signing and requires no production certificate, provider, or thumbprint.
+
+An optional real-signer branch may remain available for a separately approved future policy, but
+`production` Authenticode mode is not the project's current release policy and never blocks the
+current release path.
 
 V4 does not reuse the v3 `release-2026` custom manifest signing key or its signature envelope.
 
@@ -174,7 +187,7 @@ V4 `xtask` responsibilities should include, as appropriate:
 - repository and dependency-policy checks;
 - packaged application smoke tests;
 - installer/update artifact existence and structure checks;
-- Authenticode verification;
+- Authenticode state verification (`unsigned-zero-budget` in the current production policy);
 - updater signature/metadata validation;
 - fresh-install qualification;
 - previous-v4 -> candidate-v4 update qualification;
@@ -246,8 +259,9 @@ qualification must prove that the canonical v4 product no longer depends on them
 ## Consequences
 
 V4 gains a smaller product-owned update attack surface, standard Windows installation/uninstallation,
-a publisher identity, standard Tauri updater artifacts, clearer install/data ownership, and simpler
-runtime update code.
+standard Tauri updater artifacts, clearer install/data ownership, and simpler runtime update code.
+The project accepts the absence of an Authenticode publisher identity under the permanent
+`unsigned-zero-budget` policy, including possible Unknown Publisher/SmartScreen warnings.
 
 The project accepts a deliberate compatibility break with v3 and the operational requirement to keep
 v3 release discovery isolated from v4. It also accepts that recovery from a bad v4 release is normally
@@ -268,9 +282,10 @@ arbitrary previous installation at per-file granularity.
 
 ## Required implementation gates before `v4.0.0` GA
 
-- Authenticode signing is enabled and verified in release CI;
+- the governed `unsigned-zero-budget` Authenticode state is verified for every shipped project PE and
+  the final NSIS installer; test/self-signed evidence is rejected;
 - release SBOM and build provenance attestations are generated and verified;
-- exact draft artifacts complete fresh-install, update, uninstall/reinstall, SmartScreen/signature,
+- exact draft artifacts complete fresh-install, update, uninstall/reinstall, Authenticode-state,
   Defender, and packaged GUI qualification;
 - stable update metadata is promoted only to the qualified immutable release;
 - v3 and v4 release namespaces are demonstrably isolated;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,9 +65,10 @@ The Rust `UpdateService` owns stable/beta authority selection, bounded update
 state/progress, playback admission, and the Tauri updater lifecycle. React
 never receives endpoint, key, artifact, or downgrade policy data. Production
 authority is fixed to the dedicated v4 stable/beta metadata paths; missing
-metadata or missing/invalid v4 updater trust material fails closed. Authenticode
-provider credentials are a separate release boundary and are not present in the
-repository. The signed packaged previous-v4 to candidate-v4 fixture is test-only. The retained
+metadata or missing/invalid v4 updater trust material fails closed. Production
+Authenticode uses the governed `unsigned-zero-budget` policy; no provider
+credentials are required, and qualification rejects signed or unexpected PE state.
+The signed packaged previous-v4 to candidate-v4 fixture is test-only. The retained
 `sky_updater` boundary continues to own the legacy line's transaction and
 recovery behavior.
 

--- a/docs/distribution-and-update.md
+++ b/docs/distribution-and-update.md
@@ -10,9 +10,12 @@ V4 uses the Tauri NSIS package and the Rust-owned `UpdateService` described in
 Releases, portable artifact, or `sky_updater` transaction path. Its fixed
 stable/beta metadata authority and deterministic promotion contract are in
 `v4-release-authority.md`; metadata remains unavailable until a qualified
-promotion. V4 uses an independent public updater trust root; its private
-signing key and Authenticode provider credentials remain outside the repository
-and are fail-closed release inputs.
+promotion. V4 uses an independent public updater trust root and the explicitly
+governed `unsigned-zero-budget` Authenticode policy. The updater private key
+remains outside the repository/workspace, encrypted at rest, with an independent
+readable encrypted backup. No production certificate, provider, or thumbprint is
+required. Windows may show Unknown Publisher or a SmartScreen warning; this is a
+publisher-identity/UX trade-off, not a bypass of Tauri updater cryptographic trust.
 
 For v4 rotation, the bridge client carries `[old,new]` and tries artifact
 verification during the Tauri download step; the cutover client carries

--- a/docs/v4-authenticode-provider-seam.md
+++ b/docs/v4-authenticode-provider-seam.md
@@ -1,126 +1,85 @@
-# V4 Authenticode Provider Seam Specification
+# V4 Authenticode Policy and Provider Seam
 
-This document formalizes the production Windows Authenticode provider seam for Sky Auto Player v4.
-It defines the provider-neutral contract between the Tauri NSIS packaging pipeline and external code
-signing providers.
+This document defines the Windows Authenticode boundary for the canonical v4 Tauri NSIS package.
+It is governed by `docs/adr/ADR-0006-v4-distribution-installation-update.md` and `SECURITY.md`.
 
-This specification is governed by `docs/adr/ADR-0006-v4-distribution-installation-update.md` and
-`SECURITY.md`.
+## Project production policy
 
-## 1. Provider-Neutral Architecture
+The project's production policy is `unsigned-zero-budget`.
 
-Windows binaries (executables and DLLs) shipped in the canonical v4 NSIS installer and the installer
-itself must be signed with an approved Authenticode code signing certificate.
+- `scripts/sign_v4_authenticode.ps1` deliberately performs no signing in this mode.
+- No production certificate, provider, or certificate thumbprint is required.
+- Qualification checks every project-owned shipped PE and the final NSIS installer and accepts only
+  the actual Windows `NotSigned` state with no signer certificate.
+- A test/self-signed binary, a partially signed binary, or any other unexpected status fails closed.
+- Qualification evidence records `authenticode_mode: "unsigned-zero-budget"` and an unsigned state;
+  it must never be relabeled `production`.
 
-Because signing providers vary across deployment environments (e.g., Azure Trusted Signing,
-hardware tokens/HSMs, cloud key management services, or specialized CI runners), Sky Auto Player
-isolates all signing invocation behind a single provider-neutral script seam:
+This is a publisher-identity and user-experience trade-off. Windows may show **Unknown Publisher**
+or a SmartScreen warning. It is not a bypass of updater cryptographic trust: the official Tauri
+updater still verifies the `.exe.sig` Ed25519/minisign signature against the committed v4 public
+root, and exact artifact digests, SBOM, provenance, and install qualification remain mandatory.
+
+## SignCommand boundary
+
+The Tauri configuration retains one bounded hook:
 
 ```text
 scripts/sign_v4_authenticode.ps1 <Path>
 ```
 
-Tauri's bundle configuration binds directly to this seam in `desktop/src-tauri/tauri.conf.json`:
-
 ```json
-"bundle": {
-  "windows": {
-    "signCommand": "pwsh -NoProfile -ExecutionPolicy Bypass -File ../../scripts/sign_v4_authenticode.ps1 %1"
-  }
-}
+"signCommand": "pwsh -NoProfile -ExecutionPolicy Bypass -File ../../scripts/sign_v4_authenticode.ps1 %1"
 ```
 
-## 2. Modes and Security Invariants
+The default mode is `unsigned-zero-budget`. The hook is intentionally auditable and deterministic;
+its successful no-op is followed by explicit unsigned-state verification.
 
-The signer operates in two strictly separated modes:
+## Modes
 
-| Mode | Purpose | Trust Model | Rejection Policy |
-| :--- | :--- | :--- | :--- |
-| `test` | Local developer builds and CI qualification | Ephemeral self-signed PFX generated in `RUNNER_TEMP` | Platform status `Valid` not required; cryptographic integrity enforced |
-| `production` | Official release builds and release qualification | External approved code signing certificate | Fail-closed: requires approved thumbprint and provider; CI test certs rejected |
+| Mode | Purpose | Evidence status |
+| :--- | :--- | :--- |
+| `unsigned-zero-budget` | Project production packaging and promotion | Only `NotSigned` is accepted; no signer identity is allowed |
+| `test` | Disposable local/CI signing and integrity tests | Test-only; never promotable production evidence |
+| `production` | Optional future real-signer seam | Requires an external provider and approved thumbprint; not the project's current release policy |
 
-### Strict mode isolation
+The optional `production` branch remains available for a future, separately approved signer. It is
+not invoked by the canonical project release path and does not justify provider onboarding or paid
+service assumptions. In particular, the current release orchestrator sets
+`SKY_AUTHENTICODE_MODE=unsigned-zero-budget` and does not require provider inputs.
 
-1. **Fail-Closed by Default**: When `SKY_AUTHENTICODE_MODE` is unset, the signer defaults to `production`.
-2. **Rejection of Test Material**: In `production` mode, the presence of any test credentials
-   (`SKY_AUTHENTICODE_TEST_PFX_PATH`, `SKY_AUTHENTICODE_TEST_PFX_PASSWORD`, `SKY_AUTHENTICODE_TEST_THUMBPRINT`)
-   causes an immediate, non-recoverable error.
-3. **No Certificate Store Tampering**: Neither mode alters Windows system certificate stores or registers
-   ephemeral certificates as Trusted Publishers.
+## Verification contract
 
-## 3. Production Seam Contract
+`scripts/verify_v4_authenticode.ps1 -Mode unsigned-zero-budget` accepts only regular `.exe` and
+`.dll` project artifacts whose `Get-AuthenticodeSignature` result is exactly `NotSigned` and whose
+`SignerCertificate` is absent. It emits bounded evidence containing the file name and SHA-256,
+with null signer fields and the explicit `unsigned-zero-budget-policy` marker.
 
-### Required Environment Variables
+The bundle verifier binds the final NSIS evidence to the exact installer bytes. The installed-tree
+qualification repeats the same check for every project-owned PE; the generated `uninstall.exe` is
+not treated as a project-owned binary. These checks do not replace the Tauri updater signature,
+SBOM, provenance, digest, or install/launch/uninstall gates.
 
-When `SKY_AUTHENTICODE_MODE=production`, the release runner must supply:
+## Optional real-signer seam
 
-1. **`SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT`** (Required):
-   - A 40-character hexadecimal SHA-1 thumbprint identifying the authorized publisher certificate.
-   - Example: `A1B2C3D4E5F60718293A4B5C6D7E8F9012345678`
+When explicitly used outside the project production policy, `SKY_AUTHENTICODE_MODE=production`
+requires all of the following and fails closed otherwise:
 
-2. **`SKY_AUTHENTICODE_PROVIDER`** (Required):
-   - Identifies the provider mechanism for auditing and telemetry.
-   - Examples: `azure-trusted-signing`, `signtool-hsm`, `custom-script`.
+1. `SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT`, a 40-character SHA-1 thumbprint;
+2. `SKY_AUTHENTICODE_PROVIDER`; and
+3. exactly one of `SKY_AUTHENTICODE_PROVIDER_SCRIPT` or `SKY_AUTHENTICODE_PROVIDER_COMMAND`.
 
-3. **Signing Invocation** (Exactly one required, mutually exclusive):
-   - **`SKY_AUTHENTICODE_PROVIDER_SCRIPT`** (Preferred): Full path to a structured PowerShell script
-     accepting `-Path <file>`. Structured scripts are preferred over string commands to ensure clean
-     argument passing and error propagation.
-   - **`SKY_AUTHENTICODE_PROVIDER_COMMAND`**: Command line template where `%1` or `$Path` is replaced
-     by the target file path.
-   - **Mutual Exclusivity**: If both `SKY_AUTHENTICODE_PROVIDER_SCRIPT` and `SKY_AUTHENTICODE_PROVIDER_COMMAND`
-     are set (or if neither is set), signing fails closed immediately.
+The signer verifies the resulting certificate identity and independent Authenticode integrity. CI
+self-signed credentials are rejected in this mode. No provider credentials or certificate material
+belong in the repository, pull request, or ordinary CI configuration.
 
-### Provider Execution and Post-Signing Verification
+## Test contract
 
-When the provider completes signing the target file, `scripts/sign_v4_authenticode.ps1` executes
-an immediate post-condition verification:
-
-1. Target file must have an embedded Authenticode signature.
-2. Signer certificate thumbprint must match `SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT` byte-for-byte.
-3. Signer certificate Subject must not contain `CI V4 Test Code Signing`.
-4. Cryptographic integrity must pass independent verification via `scripts/v4_authenticode_crypto.ps1`:
-   - Valid PKCS#7 SignedCms envelope.
-   - Exact PE indirect-data hash match (`signed_digest == computed_digest`).
-
-If any check fails, the signer immediately exits with a non-zero code, aborting packaging.
-
-## 4. Supported Provider Integration Patterns
-
-### Pattern A: Azure Trusted Signing (dlib / cli)
-
-Set the following environment variables on the release runner:
-
-```powershell
-$env:SKY_AUTHENTICODE_MODE = "production"
-$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "<approved_thumbprint>"
-$env:SKY_AUTHENTICODE_PROVIDER = "azure-trusted-signing"
-$env:SKY_AUTHENTICODE_PROVIDER_COMMAND = 'trusted-signing-cli sign --endpoint https://wus.codesigning.azure.net --account <account> --profile <profile> --file %1'
-```
-
-### Pattern B: Hardware Token / HSM (via SignTool)
-
-```powershell
-$env:SKY_AUTHENTICODE_MODE = "production"
-$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "<approved_thumbprint>"
-$env:SKY_AUTHENTICODE_PROVIDER = "signtool-hsm"
-$env:SKY_AUTHENTICODE_PROVIDER_COMMAND = 'signtool.exe sign /sha1 <approved_thumbprint> /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 %1'
-```
-
-### Pattern C: Custom Provider Script
-
-```powershell
-$env:SKY_AUTHENTICODE_MODE = "production"
-$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = "<approved_thumbprint>"
-$env:SKY_AUTHENTICODE_PROVIDER = "custom-script"
-$env:SKY_AUTHENTICODE_PROVIDER_SCRIPT = "C:\ops\sign_artifact.ps1"
-```
-
-## 5. Contract Verification Tooling
-
-To run automated verification proving that ephemeral CI test certificates cannot satisfy
-production mode:
+The focused Windows contract suite uses throwaway material only:
 
 ```powershell
 pwsh scripts/test_v4_production_signing_contract.ps1
 ```
+
+It proves that the zero-budget no-op succeeds on an unsigned PE, a test-signed PE is rejected by
+the zero-budget verifier, and test evidence cannot satisfy production/promotion validation.

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -74,9 +74,10 @@ non-canonical artifact names.
 The packaged qualification path emits a bounded
 `tauri-nsis-qualified-release` evidence object containing the canonical
 version/name/size pair and SHA-256 digests for both the installer and `.sig`,
-plus production Authenticode evidence and SPDX SBOM references/digests.
+  plus `unsigned-zero-budget` Authenticode-state evidence and SPDX SBOM references/digests.
+  The installer is truthfully recorded as Authenticode-unsigned.
 `qualified=true` is not accepted by itself: the promotion gate rejects missing
-or extra fields, test-mode Authenticode evidence, malformed evidence, digest
+  or extra fields, `test` or other non-governed Authenticode modes, malformed evidence, digest
 mismatches, and same-name assets with different bytes. Metadata promotion is a separate operation after the
 immutable release has been published and the exact published assets have
 passed qualification. It compares GitHub's asset digest when present, or
@@ -106,9 +107,10 @@ change.
 
 The v4 Tauri updater public trust root is committed independently of this
 release-authority metadata contract. Its operational private key remains
-outside the repository, and Authenticode provider credentials are a separate
-Track B release input. The legacy `sky_updater` crate remains present for the
-v3 maintenance line.
+outside the repository. The project's production release policy does not
+require Authenticode provider credentials; an optional real-signer seam is
+separately governed and is not represented as current production evidence.
+The legacy `sky_updater` crate remains present for the v3 maintenance line.
 
 Updater rotation is qualified with real packaged clients: the bridge trusts
 `[old,new]` and verifies candidate bytes during `Update::download()`, while the

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -25,7 +25,7 @@ Every release candidate is subject to an immutable invariant:
      (1) BUILD ONCE  ---> Single NSIS Installer Candidate (.exe) + Updater Signature (.sig)
               |
               v
-     (2) QUALIFY     ---> Authenticode Production Verification + Ed25519 Minisign Verification
+     (2) QUALIFY     ---> Authenticode Unsigned-State Verification + Ed25519 Minisign Verification
               |           + SPDX SBOM Generation & Verification + Bundle Verification
               |           + Install/Launch/Uninstall Smoke Test
               v
@@ -43,7 +43,7 @@ Every release candidate is subject to an immutable invariant:
 - **Byte-Identity**: The SHA-256 hash recorded during qualification is identical to the hash
   in `V4_QUALIFICATION_EVIDENCE.json`, `latest.json`, `SBOM.spdx.json`, and the GitHub
   Release download asset.
-- **Fail-Closed Verification & Candidate Purge**: If any check (Authenticode, Ed25519 Minisign,
+- **Fail-Closed Verification & Candidate Purge**: If any check (Authenticode state, Ed25519 Minisign,
   SBOM, bundle, smoke test) fails, the candidate binary, signature, and unpromoted evidence are
   purged from the staging directory.
 
@@ -53,10 +53,10 @@ Every release candidate is subject to an immutable invariant:
 
 ### 2.1 The Custody vs. Cloud Attestation Boundary
 
-Tauri updater private keys and production Authenticode certificates must be protected
-with strict physical or cryptographic access controls (FIPS 140-2 Level 2+ HSM, smartcard,
-or isolated key vault). They **must never be stored as plaintext secrets in GitHub Actions
-cloud repository secrets**.
+The production v4 updater private key must remain outside the repository/workspace, encrypted at
+rest, with one independent readable encrypted backup. It **must never be stored as plaintext in
+GitHub Actions cloud repository secrets**. The current `unsigned-zero-budget` Authenticode policy
+does not require a production certificate or provider credential.
 
 Conversely, GitHub Artifact Attestations (`actions/attest@v4`) and GitHub-backed SLSA
 provenance rely on GitHub's OIDC minting service, which is accessible only from an active
@@ -73,14 +73,14 @@ GitHub Actions runner environment.
 |   GitHub Actions Workflow (Release Dispatch)                                   |
 |     |                                                                           |
 |     +---> Dedicated Single-Tenant Self-Hosted Windows Runner                    |
-|            |-- Isolated HSM / local key vault / KMS boundary (outside workspace)|
+|            |-- Encrypted updater-key custody outside workspace                     |
 |            |-- Clean worktree pre-flight check (fails closed on dirty source)   |
 |            |-- Runs `scripts/orchestrate_v4_production_release.ps1`             |
-|            |     |-- Validates commit, keys, providers                          |
+|            |     |-- Validates commit and updater key                         |
 |            |     |-- Builds candidate once with canonical public root           |
-|            |     |-- Signs PE via Authenticode Provider Seam                    |
+|            |     |-- Leaves project PEs unsigned under policy                  |
 |            |     |-- Signs updater package with private key (never logged)      |
-|            |     |-- Qualifies exact bytes (Authenticode + Minisign + SBOM)     |
+|            |     |-- Qualifies exact bytes (unsigned state + Minisign + SBOM)  |
 |            |     \-- Executes mandatory install/launch/uninstall smoke test     |
 |            |-- Runs `actions/attest` with GitHub OIDC token                     |
 |            |     \-- Generates authentic SLSA provenance & SBOM attestation     |
@@ -94,10 +94,10 @@ GitHub Actions runner environment.
 +---------------------------------------------------------------------------------+
 |                                                                                 |
 |   Maintainer Workstation (Offline or Private Network)                           |
-|     |-- Hardware Token / HSM / Offline Air-Gapped Key                           |
+|     |-- Encrypted updater key outside workspace                                |
 |     |-- Runs `scripts/orchestrate_v4_production_release.ps1`                    |
 |     |     |-- Builds candidate from verified clean git commit tag               |
-|     |     |-- Signs PE and updater payload                                      |
+|     |     |-- Leaves PE unsigned and signs updater payload                       |
 |     |     |-- Qualifies exact bytes & emits local evidence                      |
 |     |     \-- Executes install/launch/uninstall smoke test                      |
 |     |-- Cryptographic signatures authenticate bytes, BUT do NOT prove which    |
@@ -111,8 +111,9 @@ GitHub Actions runner environment.
 
 #### Topology A (Accepted Production Path):
 A dedicated, single-tenant Windows release runner registered as a GitHub Actions runner for the
-repository. The runner has access to the cloud signing provider (e.g., Azure Trusted
-Signing, DigiCert ONE) or attached hardware security key via external custody boundary.
+repository. The runner uses the governed `unsigned-zero-budget` Authenticode policy and needs no
+production certificate or provider. It still has access to the updater key only through the
+external encrypted custody boundary.
 Because it executes within GitHub Actions, `actions/attest@v4` runs directly on the exact
 candidate bytes produced by the orchestrator.
 **Under current ADR-0006 and WO-05 acceptance contracts, Topology A is the only release
@@ -120,7 +121,7 @@ path capable of satisfying the production GitHub provenance requirement.**
 
 #### Topology B (Documented Provenance Gap / Non-Qualifying Fallback):
 An operator runs `scripts/orchestrate_v4_production_release.ps1` directly on an air-gapped
-workstation. The script outputs candidate bytes, Authenticode signatures, updater signatures,
+workstation. The script outputs candidate bytes, Authenticode-state evidence, updater signatures,
 and local evidence. However, Authenticode and updater signatures authenticate the binary
 bytes; they do **not** cryptographically prove which source commit produced those bytes.
 Furthermore, `V4_PRODUCTION_RELEASE_EVIDENCE.json` is an unsigned local artifact.
@@ -152,10 +153,10 @@ The canonical release orchestrator is implemented in
 | `-Channel` | String | Yes | Release channel: `beta` or `stable`. Must conform to channel versioning rules. |
 | `-UpdaterPrivateKeyPath` | String | Yes | Path to private Minisign key. **Must be outside repository tree**. |
 | `-UpdaterPasswordEnv` | String | No | Name of environment variable holding key passphrase (default: `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`). |
-| `-AuthenticodeProvider` | String | Yes | Authenticode provider name matching provider seam (`trusted-signing`, `digicert-one`, `custom`, etc.). |
-| `-ApprovedSignerThumbprint` | String | Yes | Expected SHA-1 thumbprint of the production Authenticode certificate. |
-| `-AuthenticodeProviderScript` | String | Mutually Exclusive | Custom provider signing script path (for custom provider). |
-| `-AuthenticodeProviderCommand` | String | Mutually Exclusive | Custom provider command line (for command-based provider). |
+| `-AuthenticodeProvider` | String | No | Retained optional input for a future signer seam; unused by the current zero-budget policy. |
+| `-ApprovedSignerThumbprint` | String | No | Retained optional future-signer input; not required or recorded for current production. |
+| `-AuthenticodeProviderScript` | String | No | Retained optional future-signer input; not invoked by current production. |
+| `-AuthenticodeProviderCommand` | String | No | Retained optional future-signer input; not invoked by current production. |
 | `-BundleDir` | String | No | Target bundle directory. Defaults to `rust/target/dist/bundle/nsis`. |
 | `-EvidenceDir` | String | No | Target evidence directory. Defaults to `rust/target/dist`. |
 
@@ -181,10 +182,10 @@ Before initiating any build or invoking external tools, the orchestrator validat
    *before* building. Key ID is dynamically derived from canonical public root.
 8. **Zero Secret Output**: The orchestrator never prints or leaks the updater key passphrase or key material to
    stdout, stderr, or log streams under any execution or error path.
-9. **Provider Exclusivity**: Exactly one of `-AuthenticodeProviderScript` or `-AuthenticodeProviderCommand`.
-10. **Production Mode Enforcement**: Authenticode mode is locked to `production`. Test certificates
-    are rejected unconditionally.
-11. **Stale Output Purge**: Automatically purges any pre-existing installer candidate, `.sig` file,
+9. **Zero-Budget Authenticode Policy**: Production mode is locked to `unsigned-zero-budget`; the
+   signer seam performs no signing and qualification accepts only the actual unsigned state.
+   Test/self-signed and unexpected signed states are rejected.
+10. **Stale Output Purge**: Automatically purges any pre-existing installer candidate, `.sig` file,
     and qualification evidence from the resolved target bundle and evidence directories before packaging.
 
 ### 3.3 Execution Workflow
@@ -195,14 +196,15 @@ Step 1: Setup & Pre-Flight Checks
   - Validate parameters, commit SHA, clean worktree, version, channel rules.
   - Purge stale candidate and evidence files from resolved output directories.
   - Verify updater private key matches canonical public root via `cargo xtask updater-trust verify-private-key`.
-  - Configure production Authenticode environment variables for signCommand.
+  - Configure `SKY_AUTHENTICODE_MODE=unsigned-zero-budget` for signCommand; no provider inputs are required.
 
 Step 2: Build & Sign Candidate (Single Build)
   - Run `bun install --frozen-lockfile` and `bun run build` in desktop/.
   - Set `TAURI_SIGNING_PRIVATE_KEY` to the validated private key file path (never raw key bytes).
   - Run `bun run tauri build --ci -- --profile dist`.
   - Tauri NSIS bundler invokes `scripts/sign_v4_authenticode.ps1` via signCommand seam.
-  - Tauri bundler signs the installer with the private key, generating `.exe.sig`.
+  - The seam deliberately performs no Authenticode signing; Tauri signs the updater artifact with
+    the updater key, generating `.exe.sig`.
   - Assert working tree remains clean post-build (`git status --porcelain`); fail closed and purge
     candidate if any tracked file or manifest was mutated during packaging.
 
@@ -210,8 +212,9 @@ Step 3: Exact Candidate Verification
   - Check installer candidate and signature exist and are non-empty.
 
 Step 4: Authenticode Verification
-  - Run `scripts/verify_v4_authenticode.ps1 -Mode production`.
-  - Fail closed if thumbprint does not match `-ApprovedSignerThumbprint` or if CI test cert is detected.
+  - Run `scripts/verify_v4_authenticode.ps1 -Mode unsigned-zero-budget` for the final installer.
+  - Require `NotSigned` and no signer certificate for every project-owned shipped PE; fail closed
+    on test/self-signed, partially signed, or other unexpected state.
 
 Step 5: Tauri Updater Signature Verification against Canonical Root
   - Run `cargo xtask updater-trust verify-signature --installer <EXE> --signature <SIG>`.
@@ -223,7 +226,7 @@ Step 6: SPDX SBOM and Bundle Verification
 
 Step 7: Install Smoke Test
   - Install silently (`/S`) under `%TEMP%` test profile.
-  - Verify launcher executable exists and verify installed PE Authenticode signature.
+  - Verify launcher executable exists and verify every installed project PE is Authenticode-unsigned.
   - Launch application process, monitor execution, and stop.
   - Run uninstaller (`/S`) and verify clean removal.
 
@@ -260,7 +263,7 @@ constructs qualification evidence via the shared builder contract `scripts/v4_qu
   "signature_size": 512,
   "installer_sha256": "abcdef...",
   "updater_signature_sha256": "123456...",
-  "authenticode_mode": "production",
+  "authenticode_mode": "unsigned-zero-budget",
   "authenticode_evidence": "TAURI_AUTHENTICODE_EVIDENCE.json",
   "authenticode_evidence_sha256": "789abc...",
   "sbom": "SBOM.spdx.json",
@@ -289,10 +292,11 @@ Provides provenance and audit trails for release records:
   "updater_signature": "Sky Auto Player_4.0.0-beta.1_x64-setup.exe.sig",
   "signature_size": 512,
   "updater_signature_sha256": "123456...",
-  "authenticode_mode": "production",
-  "authenticode_provider": "trusted-signing",
-  "approved_signer_thumbprint": "0123456789ABCDEF0123456789ABCDEF01234567",
-  "observed_signer_thumbprint": "0123456789ABCDEF0123456789ABCDEF01234567",
+  "authenticode_mode": "unsigned-zero-budget",
+  "authenticode_state": "unsigned",
+  "authenticode_provider": "none",
+  "approved_signer_thumbprint": null,
+  "observed_signer_thumbprint": null,
   "updater_key_id": "F6355260A0C663D5",
   "updater_signature_status": "valid",
   "sbom": "SBOM.spdx.json",
@@ -316,7 +320,7 @@ Provides provenance and audit trails for release records:
    that a failed packaging run never leaves stale artifacts that could be erroneously reused.
 
 3. **Build or Signing Failure**:
-   If Tauri build fails or the Authenticode seam fails to sign:
+   If Tauri build fails or the Authenticode-state seam fails to qualify:
    - Any temporary signing environment overrides (`TAURI_SIGNING_PRIVATE_KEY*`, `SKY_AUTHENTICODE_*`)
      are removed and prior saved environment variables are restored in the `finally` block.
    - Canonical candidate installer (`.exe`), updater signature (`.exe.sig`), and unpromoted
@@ -329,7 +333,7 @@ Provides provenance and audit trails for release records:
      in isolated files outside the repository.
 
 4. **Qualification Failure & Candidate Purge**:
-   If the candidate binary fails Authenticode thumbprint verification, Ed25519 Minisign
+   If the candidate binary fails Authenticode unsigned-state verification, Ed25519 Minisign
    signature verification, SBOM validation, or smoke installation:
    - The candidate binary and signature file are purged from the bundle directory.
    - Unpromoted evidence files (`V4_QUALIFICATION_EVIDENCE.json`, `V4_PRODUCTION_RELEASE_EVIDENCE.json`)

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -7,9 +7,10 @@ dedicated v4 release authority described in `v4-release-authority.md`.
 Production metadata may be absent until a qualified promotion. The independent
 Tauri updater trust root is committed as public material in the Tauri config
 and Rust updater boundary; missing or invalid trust material fails closed.
-Authenticode provider credentials remain an external Track B release input
-and are never committed; Track B must also provide the approved signer
-thumbprint used by production verification.
+Production v4 uses the explicitly governed `unsigned-zero-budget` Authenticode
+policy. No production certificate, provider, or thumbprint is required. An
+optional real-signer seam remains available for a separately approved future
+policy, but it does not block this project's release.
 
 ## Canonical package contract
 
@@ -22,7 +23,7 @@ thumbprint used by production verification.
 - Legacy `sky_updater`: retained and buildable until the later retirement work order
 - Runtime updater: official `tauri-plugin-updater`, behind Rust `UpdateService`
 - Tauri updater trust: v4-only public root; no v3 `release-2026` key reuse
-- Authenticode: configured through a fail-closed `signCommand` seam
+- Authenticode: `unsigned-zero-budget`; the bounded `signCommand` deliberately performs no signing
 - React updater surface: bounded state, release notes, and progress only
 
 The legacy `cargo xtask dist` portable assembler remains available for the
@@ -80,9 +81,10 @@ cargo xtask verify-tauri-bundle `
   --sbom rust/target/dist/SBOM.spdx.json
 ```
 
-The build config invokes `scripts/sign_v4_authenticode.ps1`; it signs only in
-test mode with the ephemeral certificate. In production mode it fails closed
-until an approved Authenticode provider is configured. See
+The build config invokes `scripts/sign_v4_authenticode.ps1`. The canonical
+production path sets `SKY_AUTHENTICODE_MODE=unsigned-zero-budget`, so the seam
+deliberately performs no signing. The test fixture below uses an ephemeral
+self-signed certificate only for test-mode integrity coverage. See
 `v4-authenticode-provider-seam.md` for the formalized provider seam specification,
 `v4-updater-key-custody.md` for the private key custody and rotation runbook, and
 `v4-release-execution-topology.md` for the single-candidate release orchestrator
@@ -106,8 +108,11 @@ rust/target/dist/bundle/nsis/
   Sky Auto Player_<version>_<arch>-setup.exe.sig
 ```
 
-The Authenticode verifier requires an embedded signer certificate whose exact
-thumbprint matches the test PFX identity in test mode. It independently
+In `unsigned-zero-budget` mode the Authenticode verifier requires every
+project-owned PE and the final NSIS installer to have exactly Windows
+`NotSigned` status and no signer certificate. Any signed or unexpected state
+fails closed. In test mode it instead requires an embedded signer certificate
+whose exact thumbprint matches the test PFX identity. It independently
 decodes the embedded PKCS#7 `SignedCms`, verifies the CMS signature, extracts
 the signed `SpcIndirectDataContent` digest, and recomputes the PE
 Authenticode image hash while excluding only the documented checksum,
@@ -117,10 +122,9 @@ self-signed test certificate as `NotTrusted` or `UnknownError`; those platform
 diagnostics are recorded in `status`/`platform_status`, but never serve as
 integrity proof; `integrity_status` is the independent cryptographic result. A
 test result is accepted only when the independent cryptographic verifier passes;
-unsupported or invalid statuses remain rejected. Production verification requires `Valid`
-plus the separately approved
-`SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT`; it never accepts an arbitrary
-trusted signer or the test exception. A package-step tamper regression signs a
+unsupported or invalid statuses remain rejected. Production evidence records
+`authenticode_mode: "unsigned-zero-budget"`; promotion rejects test-mode
+evidence. A package-step tamper regression signs a
 disposable PE with the same PFX, verifies the clean bytes, mutates a hashed
 section byte, and requires verification to fail. It records signer status and
 SHA-256 for every project-owned PE in the installed tree (the generated NSIS
@@ -133,8 +137,8 @@ current commit. The SBOM covers the reachable Rust production graph from
 and binds both lockfile hashes to the same artifact set. After the
 install/launch/uninstall smoke, the packaged
 qualification path emits `V4_QUALIFICATION_EVIDENCE.json` with artifact,
-Authenticode evidence, SBOM, and digest references. Promotion requires
-production Authenticode mode and compares installer/.sig digests to the exact
+unsigned Authenticode evidence, SBOM, and digest references. Promotion requires
+the governed `unsigned-zero-budget` mode and compares installer/.sig digests to the exact
 published GitHub asset bytes. It rejects MSI, portable/updater ZIP, missing
 signatures, empty signatures, unexpected files, and version-naming drift.
 
@@ -172,10 +176,11 @@ The private halves are never read into repository files or logs.
 
 ## Operational key handling
 
-The release operator stores the private updater key and any approved
-Authenticode-provider credential in an offline encrypted vault, with a second
-offline backup under separate access control. Neither is copied into GitHub,
-build artifacts, frontend state, or logs. Loss of the updater key is fail-closed:
+The release operator stores the private updater key outside the repository/workspace,
+encrypted at rest, with at least one independent readable encrypted backup under
+separate access control. No Authenticode-provider credential is required by the
+current policy. Neither key nor credentials are copied into GitHub, build artifacts,
+frontend state, or logs. Loss of the updater key is fail-closed:
 create a new v4 root and release version, then use the normal reviewed
 qualification path. Suspected compromise requires revoking the old root through
 the bridge/cutover sequence, rotating the Authenticode provider if applicable,
@@ -200,4 +205,4 @@ path. A full non-PR run must be dispatched from the branch so provenance and
 SPDX attestations are generated and verified before acceptance. The production
 release/channel authority is configured by WO-04. The v4 updater public trust
 root and rotation policy are implemented here; an approved Authenticode
-provider and release credentials remain Track B work.
+provider is optional future work and is not a release prerequisite.

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -41,17 +41,17 @@ cargo xtask updater-trust inventory
    - The production private updater key must NEVER be committed to Git, stored in
      cloud storage, transmitted over email/chat, or configured in GitHub Actions
      repository secrets.
-   - The private key is held exclusively on offline, air-gapped, encrypted physical media
-     (e.g., hardware security module, encrypted FIPS 140-2 Level 2+ USB drive, or an
-     air-gapped workstation).
+   - The private key is held outside the repository and workspace, encrypted at rest. Offline
+     encrypted storage is sufficient; an HSM or paid key service is not required.
 
 2. **Access Control**:
    - Only authorized Release Operators have access to the physical media and its
      decryption passphrase.
-   - Access requires multi-person verification (dual custody) for production releases.
+   - Access is limited to the maintainer responsible for the release and protected by the
+     encryption passphrase.
 
 3. **Passphrase Standards**:
-   - The private key passphrase must be generated with high entropy (minimum 128 bits).
+   - The private key passphrase must be strong and managed separately from the key file.
    - The passphrase must be managed via a dedicated password manager and never stored in
      plaintext scripts or shell history.
 
@@ -109,16 +109,14 @@ sanitized error without leaking secret bytes.
 
 ## 4. Backup Procedures
 
-1. **Cold Encrypted Backups**:
-   - Two cold backup copies of the private updater key file must exist in separate physical
-     locations (e.g., Primary Safe, Offsite Safe).
-   - Each backup copy is stored on dedicated encrypted offline storage.
+1. **Independent Encrypted Backup**:
+   - At least one independent backup of the private updater key must be readable when needed and
+     encrypted at rest. It must be stored outside the repository/workspace under separate access
+     control from the working copy.
+   - The maintainer should periodically perform a local read/integrity check without copying the
+     key into repository files, CI, or logs.
 
-2. **Passphrase Recovery Split**:
-   - The passphrase for the encrypted backup media should be split using Shamir's Secret
-     Sharing (or equivalent dual-custody envelopes) among project maintainers.
-
-3. **Periodic Integrity Audit**:
+2. **Periodic Integrity Audit**:
    - Annually, operators must perform an air-gapped read test of backup media to ensure data
      retention and media integrity, using `cargo xtask updater-trust verify-private-key`.
 
@@ -148,8 +146,9 @@ without accessible backups):
      ```
    - Update `tauri.conf.json`, `native_update.rs`, and `tauri_bundle.rs` with the new public root.
    - Because existing clients cannot auto-update to a package signed with an unknown root,
-     the recovery release must be published as a standalone installer (NSIS setup executable)
-     signed with the approved Authenticode certificate.
+     the recovery release must be published as a standalone NSIS installer under the
+     `unsigned-zero-budget` Authenticode policy; the new Tauri updater signature is the update
+     authorization gate.
    - Publish a security notice on GitHub and project channels directing users to perform a
      manual update via the official installer.
 
@@ -188,11 +187,11 @@ If the private updater key is suspected or confirmed to be compromised:
      Pop-Location
      ```
 
-4. **Publish Authenticode-Signed Emergency Standalone Installer**:
-   - Build and sign a new release containing the new public trust root.
-   - Publish the recovery release as an official standalone installer signed with the approved
-     publisher Authenticode certificate. Windows Authenticode and SmartScreen provide publisher
-     provenance and integrity for users performing the manual installation.
+4. **Publish Emergency Standalone Installer**:
+   - Build a new release containing the new public trust root and qualify its exact unsigned
+     Authenticode state under `unsigned-zero-budget`.
+   - The installer may produce an Unknown Publisher or SmartScreen warning; this does not weaken
+     the Tauri updater signature check for the migrated trust root.
    - Direct all users to install the emergency update manually to migrate to the new trust root.
 
 ## 7. Scheduled Key Rotation
@@ -204,14 +203,16 @@ the two-phase Bridge/Cutover model:
 
 1. Generate new updater key pair `new.key` / `new.key.pub`.
 2. Update `native_update.rs` to carry dual trust roots: `[old_root, new_root]`.
-3. Sign the `v4.N` installer with the `old.key` so that existing `v4.N-1` clients (which only trust
-   `old_root`) successfully verify and download the update.
+3. Sign the updater artifact for the `v4.N` installer with the `old.key` so that existing `v4.N-1`
+   clients (which only trust `old_root`) successfully verify and download the update. The NSIS and
+   project-owned PE files remain Authenticode-unsigned under the project policy.
 4. Once installed, `v4.N` clients trust both `old_root` and `new_root`.
 
 ### Phase 2: Cutover Release (`v4.N+1`)
 
 1. Update `tauri.conf.json`, `native_update.rs`, and `tauri_bundle.rs` to carry only `[new_root]`.
-2. Sign `v4.N+1` exclusively with `new.key`.
+2. Sign the updater artifact for `v4.N+1` exclusively with `new.key`; keep the project-owned PE
+   files Authenticode-unsigned under the project policy.
 3. `v4.N` bridge clients verify the update against `new_root` and install successfully.
 4. Old root `old.key` is permanently retired.
 

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -546,6 +546,43 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
             .into());
         }
     }
+    let test_signing_setup_marker =
+        "      - name: Prepare bounded ephemeral Authenticode test certificate\n";
+    let tamper_regression_marker = "      - name: Run Authenticode tamper regression\n";
+    let test_signing_setup_position = packaged
+        .find(test_signing_setup_marker)
+        .ok_or("canonical v4 packaged CI is missing the isolated test-signing setup step")?;
+    let tamper_regression_position = packaged
+        .find(tamper_regression_marker)
+        .ok_or("canonical v4 packaged CI is missing the Authenticode tamper regression step")?;
+    if test_signing_setup_position >= tamper_regression_position {
+        return Err(
+            "canonical v4 packaged CI must prepare test signing credentials in a prior step".into(),
+        );
+    }
+    let test_signing_setup = &packaged[test_signing_setup_position..tamper_regression_position];
+    for marker in [
+        "timeout-minutes: 2",
+        "pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30",
+    ] {
+        if !test_signing_setup.contains(marker) {
+            return Err(format!(
+                "canonical v4 packaged CI test-signing setup is missing its required marker: {marker}"
+            )
+            .into());
+        }
+    }
+    let tamper_regression_end = packaged[tamper_regression_position..]
+        .find("\n      - name: Run V4 production signing contract test\n")
+        .map(|offset| tamper_regression_position + offset)
+        .ok_or("canonical v4 packaged CI tamper regression step has no bounded end")?;
+    let tamper_regression = &packaged[tamper_regression_position..tamper_regression_end];
+    if tamper_regression.contains("setup_v4_test_signing.ps1") {
+        return Err(
+            "canonical v4 packaged CI must not configure test signing in the tamper regression step"
+                .into(),
+        );
+    }
     let attestation_start = packaged
         .find("      - name: Verify exact GitHub artifact attestations\n")
         .ok_or("canonical v4 packaged CI is missing the attestation verification step")?;
@@ -2739,8 +2776,12 @@ read_only=true
         # Tauri updater signer generation failed with exit code
       - run: bun run tauri build --ci --config test.json
         # Tauri build failed with exit code
+      - name: Prepare bounded ephemeral Authenticode test certificate
+        timeout-minutes: 2
+        run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
       - name: Run Authenticode tamper regression
         run: pwsh scripts/test_v4_authenticode_integrity.ps1
+        # CI self-signed credentials remain test-only; canonical package evidence is unsigned.
       - name: Run V4 production signing contract test
         run: pwsh scripts/test_v4_production_signing_contract.ps1
         # V4 production signing contract test failed with exit code

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -2751,9 +2751,10 @@ read_only=true
         run: pwsh scripts/test_v4_updater_private_key.ps1
         # V4 updater private-key verifier regression failed with exit code
       - name: Verify Tauri Authenticode signature
-        run: pwsh scripts/verify_v4_authenticode.ps1
+        run: pwsh scripts/verify_v4_authenticode.ps1 -Mode unsigned-zero-budget
         # Authenticode verification failed with exit code
         # Installed Authenticode verification failed with exit code
+        # CI self-signed credentials remain test-only
       - name: Generate Tauri SPDX SBOM
         run: cargo xtask sbom generate
         # SBOM generation failed with exit code

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -374,6 +374,8 @@ fn release_authority_contract(root: &Path) -> Result<()> {
     let promotion_path = root.join("scripts/promote_v4_metadata.ps1");
     let promotion = fs::read_to_string(&promotion_path)?;
     for marker in [
+        "$productionAuthenticodeMode = \"unsigned-zero-budget\"",
+        "governed unsigned-zero-budget Authenticode evidence",
         "[ValidateSet(\"stable\", \"beta\")]",
         "$authorityRepository = \"pumni/Sky-Auto-Player-Releases\"",
         "$QualificationEvidence",
@@ -418,6 +420,7 @@ fn release_authority_contract(root: &Path) -> Result<()> {
         "scripts/ci_v4_release_authority_acceptance.ps1",
         "scripts/promote_v4_metadata.ps1 -SelfTest",
         "Emit exact Tauri qualification evidence",
+        "authenticode_mode = \"unsigned-zero-budget\"",
         "V4_QUALIFICATION_EVIDENCE.json",
         "RELEASE_AUTHORITY_RESULT",
         "needs: [changes, static, release_authority, supply_chain, validate, updater_e2e, packaged]",
@@ -505,6 +508,7 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
         "scripts/test_v4_updater_private_key.ps1",
         "V4 updater private-key verifier regression failed with exit code",
         "- name: Verify Tauri Authenticode signature",
+        "-Mode unsigned-zero-budget",
         "- name: Generate Tauri SPDX SBOM",
         "- name: Verify Tauri SPDX SBOM",
         "- name: Verify exact Tauri NSIS bundle",
@@ -513,6 +517,7 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
         "SBOM verification failed with exit code",
         "Tauri bundle verification failed with exit code",
         "Installed Authenticode verification failed with exit code",
+        "CI self-signed credentials remain test-only",
         "Tauri updater signer generation failed with exit code",
         "Tauri build failed with exit code",
         "Installer attestation verification failed with exit code",
@@ -710,6 +715,10 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
 
     let verifier = fs::read_to_string(root.join("scripts/verify_v4_authenticode.ps1"))?;
     for marker in [
+        "unsigned-zero-budget",
+        "NotSigned",
+        "authenticode-unsigned-zero-budget",
+        "unsigned-zero-budget-policy",
         "SKY_AUTHENTICODE_TEST_THUMBPRINT",
         "SKY_AUTHENTICODE_TEST_PFX_PATH",
         "SKY_AUTHENTICODE_TEST_PFX_PASSWORD",
@@ -820,6 +829,8 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
     }
     let signer = fs::read_to_string(root.join("scripts/sign_v4_authenticode.ps1"))?;
     for marker in [
+        "unsigned-zero-budget",
+        "no signing performed",
         "SKY_AUTHENTICODE_TEST_PFX_PATH",
         "SKY_AUTHENTICODE_TEST_PFX_PASSWORD",
         "/f $pfxPath",
@@ -855,11 +866,12 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
     let contract_test =
         fs::read_to_string(root.join("scripts/test_v4_production_signing_contract.ps1"))?;
     for marker in [
-        "Unconfigured production mode fails closed",
+        "unsigned-zero-budget mode succeeds without a provider",
         "Production signing rejects test credentials",
         "Production verification rejects CI test certificate",
+        "unsigned-zero-budget verification rejects signed binary",
         "Production verification rejects test thumbprint",
-        "CI test certificate cannot satisfy production mode",
+        "CI test certificate cannot satisfy production mode or zero-budget unsigned state",
     ] {
         if !contract_test.contains(marker) {
             return Err(format!(
@@ -913,6 +925,7 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "V4_PRODUCTION_RELEASE_EVIDENCE.json",
         "sign_v4_authenticode.ps1",
         "verify_v4_authenticode.ps1",
+        "unsigned-zero-budget",
         "Invoke-PrePackagingStaleOutputPurge",
         "[Pre-Packaging Purge] Stale candidate artifacts and evidence successfully purged: PASS",
     ] {

--- a/rust/xtask/src/tauri_bundle.rs
+++ b/rust/xtask/src/tauri_bundle.rs
@@ -10,6 +10,7 @@ const PRODUCT_NAME: &str = "Sky Auto Player";
 const NSIS_TARGET: &str = "nsis";
 const CURRENT_USER_INSTALL_MODE: &str = "currentUser";
 const WINDOWS_ARCH: &str = "x64";
+const UNSIGNED_ZERO_BUDGET_MODE: &str = "unsigned-zero-budget";
 // Public Tauri updater trust material. The matching private key is generated
 // and stored outside the repository by the release operator.
 pub const V4_TAURI_UPDATER_PUBLIC_KEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEY2MzU1MjYwQTBDNjYzRDUKUldUVlk4YWdZRkkxOWdWRnNkRTNVY0habzA0YlQ4OFkxZk42WEM3OGVnSW5WNlc5SHlSbGF3QWEK";
@@ -99,7 +100,7 @@ fn validate_config_value(config: &Value, project_version: &str) -> Result<()> {
         || sign_command.contains(['&', '|', ';', '`'])
     {
         return Err(
-            "Tauri Windows signing must use the fail-closed v4 Authenticode provider seam".into(),
+            "Tauri Windows Authenticode must use the bounded v4 signCommand policy seam".into(),
         );
     }
     let nsis = windows
@@ -301,7 +302,11 @@ fn validate_authenticode_evidence(path: &Path, summary: &ArtifactSummary) -> Res
         .get("mode")
         .and_then(Value::as_str)
         .ok_or("Authenticode evidence mode is missing")?;
-    let expected_thumbprint = expected_authenticode_signer_thumbprint(mode)?;
+    let expected_thumbprint = if mode == UNSIGNED_ZERO_BUDGET_MODE {
+        String::new()
+    } else {
+        expected_authenticode_signer_thumbprint(mode)?
+    };
     validate_authenticode_evidence_value(&payload, summary, mode, &expected_thumbprint)
 }
 
@@ -348,17 +353,31 @@ fn validate_authenticode_evidence_value(
     {
         return Err("Authenticode evidence schema is invalid".into());
     }
-    if !matches!(mode, "test" | "production") {
+    if !matches!(mode, "test" | "production" | UNSIGNED_ZERO_BUDGET_MODE) {
         return Err("Authenticode evidence mode is invalid".into());
     }
-    if payload
-        .get("expected_signer_thumbprint")
-        .and_then(Value::as_str)
-        .map(|value| value.eq_ignore_ascii_case(expected_thumbprint))
-        != Some(true)
+    if payload.get("mode").and_then(Value::as_str) != Some(mode) {
+        return Err("Authenticode evidence mode disagrees with its validation policy".into());
+    }
+    if mode != UNSIGNED_ZERO_BUDGET_MODE
+        && payload
+            .get("expected_signer_thumbprint")
+            .and_then(Value::as_str)
+            .map(|value| value.eq_ignore_ascii_case(expected_thumbprint))
+            != Some(true)
     {
         return Err(
             "Authenticode evidence approved signer identity is missing or mismatched".into(),
+        );
+    }
+    if mode == UNSIGNED_ZERO_BUDGET_MODE
+        && !payload
+            .get("expected_signer_thumbprint")
+            .map(Value::is_null)
+            .unwrap_or(false)
+    {
+        return Err(
+            "unsigned-zero-budget Authenticode evidence must not contain a signer identity".into(),
         );
     }
     let files = payload
@@ -387,6 +406,51 @@ fn validate_authenticode_evidence_value(
         return Err(
             "canonical installer Authenticode status disagrees with platform status".into(),
         );
+    }
+    if mode == UNSIGNED_ZERO_BUDGET_MODE {
+        if payload.get("verification_policy").and_then(Value::as_str)
+            != Some("unsigned-project-owned-pe-files-and-canonical-nsis")
+            || status != "NotSigned"
+            || file.get("verification").and_then(Value::as_str)
+                != Some("authenticode-unsigned-zero-budget")
+            || file.get("trust_exception").and_then(Value::as_str)
+                != Some("unsigned-zero-budget-policy")
+            || file.get("integrity_verifier").and_then(Value::as_str)
+                != Some("not-applicable-unsigned-zero-budget")
+            || file.get("integrity_status").and_then(Value::as_str) != Some("NotSigned")
+            || !file
+                .get("signed_digest")
+                .map(Value::is_null)
+                .unwrap_or(false)
+            || !file
+                .get("computed_digest")
+                .map(Value::is_null)
+                .unwrap_or(false)
+            || !file
+                .get("signer_thumbprint")
+                .map(Value::is_null)
+                .unwrap_or(false)
+            || !file
+                .get("signer_subject")
+                .map(Value::is_null)
+                .unwrap_or(false)
+        {
+            return Err(
+                "canonical installer Authenticode evidence is not the required unsigned-zero-budget state"
+                    .into(),
+            );
+        }
+        if file
+            .get("sha256")
+            .and_then(Value::as_str)
+            .map(|value| value.eq_ignore_ascii_case(&summary.installer_sha256))
+            != Some(true)
+        {
+            return Err(
+                "Authenticode evidence installer digest does not match the candidate".into(),
+            );
+        }
+        return Ok(());
     }
     let verification = file
         .get("verification")
@@ -710,6 +774,66 @@ mod tests {
         assert!(
             validate_authenticode_evidence_value(&payload, &summary, "test", &"A".repeat(40))
                 .is_err()
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn unsigned_zero_budget_requires_an_unsigned_installer_and_exact_digest() {
+        let root = std::env::temp_dir().join(format!(
+            "sky-xtask-tauri-authenticode-unsigned-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let installer = root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.exe");
+        let signature = root.join("Sky Auto Player_4.0.0-alpha.1_x64-setup.exe.sig");
+        fs::write(&installer, b"unsigned installer").unwrap();
+        fs::write(&signature, b"test-signature\n").unwrap();
+        let summary = artifact_summary(&root, "4.0.0-alpha.1").unwrap();
+        let payload = json!({
+            "schema_version": 1,
+            "evidence_type": "authenticode-verification",
+            "mode": UNSIGNED_ZERO_BUDGET_MODE,
+            "expected_signer_thumbprint": null,
+            "verification_policy": "unsigned-project-owned-pe-files-and-canonical-nsis",
+            "files": [{
+                "name": summary.installer.clone(),
+                "status": "NotSigned",
+                "platform_status": "NotSigned",
+                "verification": "authenticode-unsigned-zero-budget",
+                "trust_exception": "unsigned-zero-budget-policy",
+                "integrity_verifier": "not-applicable-unsigned-zero-budget",
+                "integrity_status": "NotSigned",
+                "signed_digest_algorithm": null,
+                "signed_digest": null,
+                "computed_digest": null,
+                "signer_thumbprint": null,
+                "signer_subject": null,
+                "sha256": summary.installer_sha256.clone(),
+            }]
+        });
+        validate_authenticode_evidence_value(&payload, &summary, UNSIGNED_ZERO_BUDGET_MODE, "")
+            .unwrap();
+
+        let mut signed = payload.clone();
+        signed["files"][0]["status"] = json!("Valid");
+        signed["files"][0]["platform_status"] = json!("Valid");
+        assert!(
+            validate_authenticode_evidence_value(&signed, &summary, UNSIGNED_ZERO_BUDGET_MODE, "")
+                .is_err()
+        );
+
+        let mut wrong_digest = payload;
+        wrong_digest["files"][0]["sha256"] = json!("0".repeat(64));
+        assert!(
+            validate_authenticode_evidence_value(
+                &wrong_digest,
+                &summary,
+                UNSIGNED_ZERO_BUDGET_MODE,
+                ""
+            )
+            .is_err()
         );
         fs::remove_dir_all(root).unwrap();
     }

--- a/scripts/orchestrate_v4_production_release.ps1
+++ b/scripts/orchestrate_v4_production_release.ps1
@@ -36,13 +36,6 @@ if ([string]::IsNullOrWhiteSpace($Channel) -or $Channel -notin @("stable", "beta
 if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) {
     throw "Missing mandatory parameter: UpdaterPrivateKeyPath"
 }
-if ([string]::IsNullOrWhiteSpace($AuthenticodeProvider)) {
-    throw "Missing mandatory parameter: AuthenticodeProvider"
-}
-if ([string]::IsNullOrWhiteSpace($ApprovedSignerThumbprint)) {
-    throw "Missing mandatory parameter: ApprovedSignerThumbprint"
-}
-
 # 2. Reject internal test parameters unless -InternalTestFixture is explicitly specified
 if (-not $InternalTestFixture) {
     if (-not [string]::IsNullOrWhiteSpace($InternalFixtureCandidatePath)) {
@@ -173,27 +166,13 @@ try {
         throw "Channel 'beta' requires a prerelease SemVer version (e.g. '$Version-beta.1')"
     }
 
-    # Validate ApprovedSignerThumbprint
-    if ($ApprovedSignerThumbprint -notmatch '^[0-9a-fA-F]{40}$') {
-        throw "ApprovedSignerThumbprint must be a 40-character hexadecimal SHA-1 thumbprint"
-    }
-    $approvedThumbprint = $ApprovedSignerThumbprint.ToUpperInvariant()
-
-    # Validate Authenticode provider invocation (mutual exclusivity)
+    # Provider inputs are optional under the project policy. Preserve the
+    # existing malformed-input guard for callers carrying both future-signer
+    # forms, but never require either form for current production.
     $hasScript = -not [string]::IsNullOrWhiteSpace($AuthenticodeProviderScript)
     $hasCommand = -not [string]::IsNullOrWhiteSpace($AuthenticodeProviderCommand)
-    if (-not $hasScript -and -not $hasCommand) {
-        throw "Authenticode provider requires exactly one of AuthenticodeProviderScript or AuthenticodeProviderCommand"
-    }
     if ($hasScript -and $hasCommand) {
         throw "Mutually exclusive Authenticode provider configuration: specify either AuthenticodeProviderScript or AuthenticodeProviderCommand, not both"
-    }
-    $resolvedProviderScript = $null
-    if ($hasScript) {
-        $resolvedProviderScript = (Resolve-Path -LiteralPath $AuthenticodeProviderScript -ErrorAction Stop).Path
-        if (-not (Test-Path -LiteralPath $resolvedProviderScript -PathType Leaf)) {
-            throw "AuthenticodeProviderScript does not exist: $AuthenticodeProviderScript"
-        }
     }
 
     # Validate UpdaterPrivateKeyPath (must exist and must NOT be inside repository workspace)
@@ -290,22 +269,18 @@ try {
         Write-Host "[Step 1/7] Internal test fixture mode: bypassing production root key pre-check..."
     }
 
-    # 5. Canonical Single Build with Production Signing Enabled
+    # 5. Canonical Single Build under the governed unsigned-zero-budget policy
     if (-not $InternalTestFixture) {
         Write-Host "[Step 2/7] Building canonical Tauri production artifact (build-once)..."
-        
-        # Set production Authenticode signing environment.
-        # Tauri NSIS bundler invokes scripts/sign_v4_authenticode.ps1 via bundle.windows.signCommand seam.
-        $env:SKY_AUTHENTICODE_MODE = "production"
-        $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = $approvedThumbprint
-        $env:SKY_AUTHENTICODE_PROVIDER = $AuthenticodeProvider.Trim().ToLowerInvariant()
-        if ($hasScript) {
-            $env:SKY_AUTHENTICODE_PROVIDER_SCRIPT = $resolvedProviderScript
-            Remove-Item Env:SKY_AUTHENTICODE_PROVIDER_COMMAND -ErrorAction SilentlyContinue
-        } else {
-            $env:SKY_AUTHENTICODE_PROVIDER_COMMAND = $AuthenticodeProviderCommand
-            Remove-Item Env:SKY_AUTHENTICODE_PROVIDER_SCRIPT -ErrorAction SilentlyContinue
-        }
+
+        # Tauri NSIS invokes scripts/sign_v4_authenticode.ps1 via the configured
+        # signCommand seam. The project release policy deliberately performs no
+        # Authenticode signing and requires no certificate/provider/thumbprint.
+        $env:SKY_AUTHENTICODE_MODE = "unsigned-zero-budget"
+        Remove-Item Env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT -ErrorAction SilentlyContinue
+        Remove-Item Env:SKY_AUTHENTICODE_PROVIDER -ErrorAction SilentlyContinue
+        Remove-Item Env:SKY_AUTHENTICODE_PROVIDER_SCRIPT -ErrorAction SilentlyContinue
+        Remove-Item Env:SKY_AUTHENTICODE_PROVIDER_COMMAND -ErrorAction SilentlyContinue
         # Tauri v2 bundler accepts a file path in TAURI_SIGNING_PRIVATE_KEY for signing.
         # Never place raw private key contents into environment variables.
         $env:TAURI_SIGNING_PRIVATE_KEY = $resolvedKeyPath
@@ -386,11 +361,10 @@ try {
 
     Write-Host "  Canonical candidate artifacts verified: $expectedInstallerName ($($installerBytes.Length) bytes)"
 
-    # 7. Production Authenticode Verification
-    $authenticodeMode = if ($InternalTestFixture) { "test" } else { "production" }
+    # 7. Production Authenticode-State Verification
+    $authenticodeMode = if ($InternalTestFixture) { "test" } else { "unsigned-zero-budget" }
     Write-Host "[Step 4/7] Verifying Authenticode $authenticodeMode signature..."
     $authenticodeEvidencePath = Join-Path $resolvedEvidenceDir "TAURI_AUTHENTICODE_EVIDENCE.json"
-    $env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT = $approvedThumbprint
     & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
         -File (Join-Path $PSScriptRoot "verify_v4_authenticode.ps1") `
         -Mode $authenticodeMode `
@@ -401,10 +375,11 @@ try {
     }
     $authEvidence = Get-Content -LiteralPath $authenticodeEvidencePath -Raw | ConvertFrom-Json
     $observedThumbprint = $authEvidence.files[0].signer_thumbprint
-    if ($authenticodeMode -eq "production" -and $observedThumbprint -ne $approvedThumbprint) {
-        throw "Observed thumbprint ($observedThumbprint) does not match approved thumbprint ($approvedThumbprint)"
+    if ($authenticodeMode -eq "unsigned-zero-budget" -and $null -ne $observedThumbprint) {
+        throw "unsigned-zero-budget Authenticode evidence unexpectedly contains a signer identity"
     }
-    Write-Host "  Authenticode verification: PASS (Thumbprint: $observedThumbprint, Mode: $authenticodeMode)"
+    $authenticodeState = if ($authenticodeMode -eq "unsigned-zero-budget") { "unsigned" } else { "test-signed" }
+    Write-Host "  Authenticode verification: PASS (State: $authenticodeState, Mode: $authenticodeMode)"
 
     # 8. Tauri Updater Signature Verification against Canonical Root
     if (-not $InternalTestFixture) {
@@ -557,9 +532,10 @@ try {
             updater_signature = $expectedSignatureName
             signature_size = (Get-Item -LiteralPath $signaturePath).Length
             updater_signature_sha256 = $signatureSha256
-            authenticode_mode = "production"
-            authenticode_provider = $AuthenticodeProvider
-            approved_signer_thumbprint = $approvedThumbprint
+            authenticode_mode = "unsigned-zero-budget"
+            authenticode_state = "unsigned"
+            authenticode_provider = "none"
+            approved_signer_thumbprint = $null
             observed_signer_thumbprint = $observedThumbprint
             updater_key_id = $canonicalKeyId
             updater_signature_status = "valid"

--- a/scripts/promote_v4_metadata.ps1
+++ b/scripts/promote_v4_metadata.ps1
@@ -30,6 +30,7 @@ $productIdentifier = "io.github.pumni.skyautoplayer"
 $installerNameSuffix = "_x64-setup.exe"
 $evidenceType = "tauri-nsis-qualified-release"
 $evidenceSchemaVersion = 1
+$productionAuthenticodeMode = "unsigned-zero-budget"
 
 function Get-GitHubJson([string]$Path) {
     $payload = & gh api $Path --header "Accept: application/vnd.github+json"
@@ -103,8 +104,8 @@ function Assert-QualificationEvidence(
         (Get-RequiredEvidenceString $Evidence "qualification") -ne "install-launch-uninstall") {
         throw "Qualification evidence type is not the canonical Tauri qualification path"
     }
-    if ((Get-RequiredEvidenceString $Evidence "authenticode_mode") -ne "production") {
-        throw "Qualification evidence is not production Authenticode evidence"
+    if ((Get-RequiredEvidenceString $Evidence "authenticode_mode") -ne $productionAuthenticodeMode) {
+        throw "Qualification evidence is not governed unsigned-zero-budget Authenticode evidence"
     }
     $qualified = $Evidence.PSObject.Properties["qualified"]
     if ($qualified.Value -isnot [bool] -or -not $qualified.Value) {
@@ -211,7 +212,7 @@ function Invoke-PromotionSelfTest {
         signature_size = [int64]10
         installer_sha256 = "a" * 64
         updater_signature_sha256 = "a" * 64
-        authenticode_mode = "production"
+        authenticode_mode = $productionAuthenticodeMode
         authenticode_evidence = "TAURI_AUTHENTICODE_EVIDENCE.json"
         authenticode_evidence_sha256 = "a" * 64
         sbom = "SBOM.spdx.json"

--- a/scripts/sign_v4_authenticode.ps1
+++ b/scripts/sign_v4_authenticode.ps1
@@ -11,9 +11,17 @@ if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
 Write-Host "V4 Authenticode signer invoked: target=$Path"
 
 $mode = if ([string]::IsNullOrWhiteSpace($env:SKY_AUTHENTICODE_MODE)) {
-    "production"
+    "unsigned-zero-budget"
 } else {
     $env:SKY_AUTHENTICODE_MODE.Trim().ToLowerInvariant()
+}
+
+if ($mode -eq "unsigned-zero-budget") {
+    # This is the permanent project release policy. The Tauri signCommand seam
+    # remains configured so the bundler has a deterministic, auditable hook,
+    # but the hook deliberately performs no Authenticode signing.
+    Write-Host "V4 Authenticode policy: unsigned-zero-budget; no signing performed: target=$Path"
+    exit 0
 }
 
 if ($mode -eq "production") {
@@ -91,7 +99,7 @@ if ($mode -eq "production") {
 }
 
 if ($mode -ne "test") {
-    throw "V4 Authenticode signing is fail-closed: unrecognized mode '$mode' (must be 'test' or 'production')"
+    throw "V4 Authenticode signing is fail-closed: unrecognized mode '$mode' (must be 'test', 'production', or 'unsigned-zero-budget')"
 }
 
 $thumbprint = [string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT

--- a/scripts/test_v4_production_orchestrator.ps1
+++ b/scripts/test_v4_production_orchestrator.ps1
@@ -585,7 +585,7 @@ try {
         -File (Join-Path $PSScriptRoot "promote_v4_metadata.ps1") `
         -ValidateEvidence $invalidFile 2>&1 | Out-String
     if ($LASTEXITCODE -eq 0) { throw "FAILED: Accepted authenticode_mode=test" }
-    if ($out16a -notmatch "Qualification evidence is not production Authenticode evidence") {
+    if ($out16a -notmatch "Qualification evidence is not governed unsigned-zero-budget Authenticode evidence") {
         throw "FAILED: Did not reject authenticode_mode=test"
     }
 

--- a/scripts/test_v4_production_signing_contract.ps1
+++ b/scripts/test_v4_production_signing_contract.ps1
@@ -77,10 +77,23 @@ try {
         [Environment]::SetEnvironmentVariable($varName, $null, "Process")
     }
 
-    # Contract Test 1: Unconfigured production mode fails closed
-    Write-Host "Contract Test 1: Unconfigured production mode fails closed..."
+    # Contract Test 1: The project production policy is an unconfigured no-op.
+    Write-Host "Contract Test 1: unsigned-zero-budget mode succeeds without a provider..."
+    $env:SKY_AUTHENTICODE_MODE = "unsigned-zero-budget"
+    $output1 = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
+        -Path $targetExe 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "FAILED: unsigned-zero-budget signing hook did not succeed without provider inputs: $output1"
+    }
+    $unsignedSignature = Get-AuthenticodeSignature -LiteralPath $targetExe
+    if ([string]$unsignedSignature.Status -ne "NotSigned" -or $null -ne $unsignedSignature.SignerCertificate) {
+        throw "FAILED: unsigned-zero-budget signing hook did not leave the throwaway target unsigned"
+    }
 
-    # 1a. Completely unconfigured (default mode = production, no thumbprint)
+    # 1a. The optional real-signer branch remains fail-closed when explicitly selected.
+    Write-Host "Contract Test 1a: Explicit future production mode fails closed when unconfigured..."
+    $env:SKY_AUTHENTICODE_MODE = "production"
     $output1a = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
         -File (Join-Path $PSScriptRoot 'sign_v4_authenticode.ps1') `
         -Path $targetExe 2>&1 | Out-String
@@ -157,6 +170,23 @@ try {
     if ($LASTEXITCODE -ne 0) {
         throw "Test-mode verification failed on signed target"
     }
+
+    # Verify the project production policy rejects the signed test target.
+    Write-Host "Contract Test 3a: unsigned-zero-budget verification rejects signed binary..."
+    $rejectedInZeroBudget = $false
+    try {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot 'verify_v4_authenticode.ps1') `
+            -Mode unsigned-zero-budget `
+            -Artifact $targetExe 2>$null
+        if ($LASTEXITCODE -ne 0) { $rejectedInZeroBudget = $true }
+    } catch {
+        $rejectedInZeroBudget = $true
+    }
+    if (-not $rejectedInZeroBudget) {
+        throw "FAILED: unsigned-zero-budget verification accepted signed binary"
+    }
+    Write-Host "Contract Test 3a: PASS"
 
     # Verify production mode rejects test certificate
     $rejectedInProduction = $false
@@ -252,5 +282,5 @@ try {
     Restore-SavedEnvironment
 }
 
-Write-Host "[PASS] V4 Authenticode contract tests: CI test certificate cannot satisfy production mode"
+Write-Host "[PASS] V4 Authenticode contract tests: CI test certificate cannot satisfy production mode or zero-budget unsigned state"
 exit 0

--- a/scripts/v4_qualification_evidence.ps1
+++ b/scripts/v4_qualification_evidence.ps1
@@ -41,7 +41,9 @@ function New-V4CanonicalQualificationEvidence {
         signature_size = $SignatureSize
         installer_sha256 = $InstallerSha256.ToLowerInvariant()
         updater_signature_sha256 = $SignatureSha256.ToLowerInvariant()
-        authenticode_mode = "production"
+        # The project production policy is intentionally Authenticode-unsigned.
+        # The linked Authenticode evidence proves this exact state.
+        authenticode_mode = "unsigned-zero-budget"
         authenticode_evidence = "TAURI_AUTHENTICODE_EVIDENCE.json"
         authenticode_evidence_sha256 = $AuthenticodeEvidenceSha256.ToLowerInvariant()
         sbom = "SBOM.spdx.json"

--- a/scripts/verify_v4_authenticode.ps1
+++ b/scripts/verify_v4_authenticode.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("test", "production")]
+    [ValidateSet("test", "production", "unsigned-zero-budget")]
     [string]$Mode,
 
     [Parameter(Mandatory = $true)]
@@ -13,21 +13,24 @@ $ErrorActionPreference = "Stop"
 . (Join-Path $PSScriptRoot "v4_authenticode_crypto.ps1")
 if ($Artifact.Count -eq 0) { throw "At least one Authenticode artifact is required" }
 $mode = $Mode.ToLowerInvariant()
-$expectedThumbprint = if ($mode -eq "test") {
-    [string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT
-} else {
-    [string]$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT
-}
-$expectedThumbprint = $expectedThumbprint.Trim()
-if ($expectedThumbprint -notmatch '^[0-9a-fA-F]{40}$') {
-    $identityVariable = if ($mode -eq "test") {
-        "SKY_AUTHENTICODE_TEST_THUMBPRINT"
+$expectedThumbprint = $null
+if ($mode -ne "unsigned-zero-budget") {
+    $expectedThumbprint = if ($mode -eq "test") {
+        [string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT
     } else {
-        "SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT"
+        [string]$env:SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT
     }
-    throw "V4 Authenticode verification requires the exact approved signer thumbprint in $identityVariable"
+    $expectedThumbprint = $expectedThumbprint.Trim()
+    if ($expectedThumbprint -notmatch '^[0-9a-fA-F]{40}$') {
+        $identityVariable = if ($mode -eq "test") {
+            "SKY_AUTHENTICODE_TEST_THUMBPRINT"
+        } else {
+            "SKY_AUTHENTICODE_APPROVED_SIGNER_THUMBPRINT"
+        }
+        throw "V4 Authenticode verification requires the exact approved signer thumbprint in $identityVariable"
+    }
+    $expectedThumbprint = $expectedThumbprint.ToUpperInvariant()
 }
-$expectedThumbprint = $expectedThumbprint.ToUpperInvariant()
 if ($mode -eq "production") {
     $testThumbprint = ([string]$env:SKY_AUTHENTICODE_TEST_THUMBPRINT).Trim().ToUpperInvariant()
     if (-not [string]::IsNullOrWhiteSpace($testThumbprint) -and $expectedThumbprint -eq $testThumbprint) {
@@ -99,6 +102,32 @@ $records = foreach ($file in $files) {
     $seen[$file.Name] = $true
     $signature = Get-AuthenticodeSignature -LiteralPath $file.FullName
     $platformStatus = [string]$signature.Status
+
+    if ($mode -eq "unsigned-zero-budget") {
+        # The governed production state accepts exactly an unsigned PE. Any
+        # signature, including a self-signed CI certificate, is unexpected and
+        # fails closed. Only NotSigned is evidence of the required state.
+        if ($platformStatus -ne "NotSigned" -or $null -ne $signature.SignerCertificate) {
+            throw "unsigned-zero-budget Authenticode verification requires an unsigned target: $($file.Name) ($platformStatus)"
+        }
+        [ordered]@{
+            name = $file.Name
+            status = $platformStatus
+            platform_status = $platformStatus
+            verification = "authenticode-unsigned-zero-budget"
+            trust_exception = "unsigned-zero-budget-policy"
+            integrity_verifier = "not-applicable-unsigned-zero-budget"
+            integrity_status = "NotSigned"
+            signed_digest_algorithm = $null
+            signed_digest = $null
+            computed_digest = $null
+            sha256 = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+            signer_thumbprint = $null
+            signer_subject = $null
+        }
+        continue
+    }
+
     if ($null -eq $signature.SignerCertificate) {
         throw "Authenticode signature has no embedded signer certificate for $($file.Name): $platformStatus"
     }
@@ -162,7 +191,9 @@ $payload = [ordered]@{
     evidence_type = "authenticode-verification"
     mode = $mode
     expected_signer_thumbprint = $expectedThumbprint
-    verification_policy = if ($mode -eq "test") {
+    verification_policy = if ($mode -eq "unsigned-zero-budget") {
+        "unsigned-project-owned-pe-files-and-canonical-nsis"
+    } elseif ($mode -eq "test") {
         "exact-signer-independent-authenticode-integrity-with-platform-trust-diagnostic"
     } else {
         "windows-valid-platform-and-exact-approved-signer-independent-authenticode-integrity"


### PR DESCRIPTION
Related to #117

## Scope

This Draft PR adopts the maintainer-approved permanent `unsigned-zero-budget` policy for production v4 Authenticode. WO-06 and WO-07 are explicitly out of scope.

- Exact baseline: `91a5d1d33d496377da14e859d3b745cb70be313b`
- Exact head: `99b310e2d22a985ae4619286edbec4b5066f366e`
- No provider credential, PFX, production updater private key, or passphrase is present in this PR or CI configuration.
- No real-key readiness check was run.

## Implementation

- `scripts/sign_v4_authenticode.ps1` defaults to `unsigned-zero-budget` and deliberately performs no signing; the optional explicit real-signer branch remains fail-closed and non-authoritative.
- `scripts/verify_v4_authenticode.ps1` proves exact Windows `NotSigned` state with no signer certificate for every checked project PE and final NSIS installer.
- `rust/xtask/src/tauri_bundle.rs` binds unsigned evidence to the exact installer SHA-256 and preserves mandatory updater signature, SBOM, and artifact checks.
- Promotion accepts only governed `unsigned-zero-budget` evidence and rejects `test`/other Authenticode modes.
- CI canonical packaging is unsigned; ephemeral self-signed credentials remain confined to test-only integrity fixtures.
- ADR-0006 and current v4 release/security/custody documentation record the Unknown Publisher/SmartScreen publisher-identity trade-off and that updater cryptographic trust is unchanged.

## Files and crates

20 files changed across CI, release scripts, Authenticode verification/policy, `xtask`, and current normative documentation. No production crate was removed or added. Historical v3 documentation, release/evidence/performance records, and the optional future signer seam remain intentionally retained.

## Validation

- `cargo fmt --all -- --check`: PASS (from `rust/`)
- `cargo xtask check static --skip-supply-chain`: PASS
- `cargo xtask check rust`: PASS
- `cargo xtask check all`: PASS, including cargo-vet supply-chain gate
- `cargo xtask check desktop`: PASS
- `git diff --check`: PASS
- `scripts/test_v4_production_signing_contract.ps1`: PASS with throwaway test material
- `scripts/test_v4_production_orchestrator.ps1`: PASS with throwaway fixtures
- `promote_v4_metadata.ps1 -SelfTest`: PASS
- Local isolated Tauri NSIS qualification: PASS; exact unsigned Authenticode evidence, exact bundle/SBOM verification, and zero `Sky-Auto-Player-Updater.exe` files.
- Local packaged official Tauri updater fixture: bridge/cutover install, update, shutdown-safety, and old-root rejection assertions emitted PASS; its outer wrapper returned a cleanup-status nonzero after the success marker, with the worktree restored clean.

## CI

- Exact GitHub Actions run: [33969305550](https://github.com/pumni/Sky-Auto-Player/actions/runs/33969305550), head `99b310e2d22a985ae4619286edbec4b5066f366e`.
- Attempt 1 failed in Windows restricted repository verification; static, release-authority, and supply-chain jobs passed.
- Unchanged rerun (attempt 2) reproduced the same failure in Windows restricted repository verification while running the full Rust test command; no source diagnostic or test failure was emitted. The packaged NSIS and updater fixture jobs were skipped downstream.
- The PR remains Draft pending release-policy acceptance and maintainer review.

No merge is requested.