### PR TITLE
feat(v4): add draft-first release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,9 @@ jobs:
       - name: Promotion digest regression self-test
         run: pwsh scripts/promote_v4_metadata.ps1 -SelfTest
 
+      - name: V4 release pipeline mock state-machine self-test
+        run: pwsh scripts/test_v4_release_pipeline.ps1
+
       - name: Report CI timing
         if: always()
         run: |

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -107,15 +107,6 @@ jobs:
       - name: Verify dedicated runner tools
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
 
-      - name: Run throwaway official previous-v4 to candidate-v4 updater fixture
-        env:
-          RUSTUP_TOOLCHAIN: 1.98.0
-        run: |
-          $fixtureBundle = Join-Path $env:V4_RELEASE_STATE_ROOT "throwaway-updater-fixture"
-          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/ci_tauri_update_e2e.ps1 `
-            -BundleDir $fixtureBundle
-          if ($LASTEXITCODE -ne 0) { throw "Official Tauri updater fixture failed" }
-
       - name: Build and qualify the single production candidate
         env:
           V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
@@ -158,7 +149,7 @@ jobs:
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT
 
-      - name: Qualify downloaded exact candidate bytes
+      - name: Qualify downloaded exact candidate bytes and packaged update
         run: |
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
             -State QualifyDownloaded `
@@ -168,6 +159,16 @@ jobs:
             -SourceSha $env:V4_RELEASE_SOURCE_SHA `
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT
+
+      - name: Preserve bounded post-draft qualification evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v4-post-draft-qualification-${{ github.run_id }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\post-draft-qualification.json
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\defender-evidence.json
 
       - name: Attest exact downloaded Tauri candidate and signature
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -1,0 +1,252 @@
+name: V4 Release Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Canonical v4 SemVer (without v prefix or build metadata)"
+        required: true
+        type: string
+      channel:
+        description: "v4 metadata channel"
+        required: true
+        type: choice
+        options: [stable, beta]
+      tag:
+        description: "Authority release tag; must be exactly v<version>"
+        required: true
+        type: string
+      source_sha:
+        description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
+        required: true
+        type: string
+      updater_private_key_path:
+        description: "Path to the externally stored updater key on the dedicated runner"
+        required: true
+        type: string
+      updater_password_env:
+        description: "Name of the runner-local environment variable containing the key passphrase"
+        required: true
+        default: TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+        type: string
+      release_notes_path:
+        description: "Bounded release notes file in the checked-out source"
+        required: true
+        type: string
+      publication_date_utc:
+        description: "Second-precision UTC RFC3339 publication timestamp"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: v4-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  release:
+    name: V4 production release state machine
+    # This label set is intentionally narrower than a general Windows pool.
+    # It identifies the accepted dedicated/single-tenant release runner.
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+    environment: v4-production-release
+    env:
+      V4_RELEASE_STATE_ROOT: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}
+      V4_RELEASE_VERSION: ${{ inputs.version }}
+      V4_RELEASE_CHANNEL: ${{ inputs.channel }}
+      V4_RELEASE_TAG: ${{ inputs.tag }}
+      V4_RELEASE_SOURCE_SHA: ${{ inputs.source_sha }}
+      V4_RELEASE_WORKFLOW_SHA: ${{ github.sha }}
+      V4_RELEASE_NOTES_PATH: ${{ inputs.release_notes_path }}
+      V4_RELEASE_PUBLICATION_DATE: ${{ inputs.publication_date_utc }}
+      V4_RELEASE_UPDATER_PASSWORD_ENV: ${{ inputs.updater_password_env }}
+
+    steps:
+      - name: Check out the exact requested source SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate exact v4 release request
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State ValidateRequest `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_RELEASE_NOTES_PATH `
+            -PublicationDateUtc $env:V4_RELEASE_PUBLICATION_DATE
+
+      - name: Verify release authority main is initialized
+        env:
+          V4_RELEASE_AUTHORITY_TOKEN: ${{ secrets.V4_RELEASE_AUTHORITY_TOKEN }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State ValidateAuthority `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_RELEASE_NOTES_PATH
+
+      - name: Verify dedicated runner tools
+        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
+
+      - name: Run throwaway official previous-v4 to candidate-v4 updater fixture
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          $fixtureBundle = Join-Path $env:V4_RELEASE_STATE_ROOT "throwaway-updater-fixture"
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/ci_tauri_update_e2e.ps1 `
+            -BundleDir $fixtureBundle
+          if ($LASTEXITCODE -ne 0) { throw "Official Tauri updater fixture failed" }
+
+      - name: Build and qualify the single production candidate
+        env:
+          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State BuildCandidate `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH `
+            -UpdaterPasswordEnv $env:V4_RELEASE_UPDATER_PASSWORD_ENV
+
+      - name: Create exact candidate draft in release authority
+        env:
+          V4_RELEASE_AUTHORITY_TOKEN: ${{ secrets.V4_RELEASE_AUTHORITY_TOKEN }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State CreateDraft `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_RELEASE_NOTES_PATH
+
+      - name: Re-download exact draft assets from release authority
+        env:
+          V4_RELEASE_AUTHORITY_TOKEN: ${{ secrets.V4_RELEASE_AUTHORITY_TOKEN }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State DownloadDraft `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
+
+      - name: Qualify downloaded exact candidate bytes
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State QualifyDownloaded `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
+
+      - name: Attest exact downloaded Tauri candidate and signature
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded\*.exe
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded\*.sig
+
+      - name: Attest SPDX SBOM for exact downloaded candidate
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded\*.exe
+          sbom-path: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded\SBOM.spdx.json
+
+      - name: Verify exact-source OIDC attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $gh = (Get-Command gh.exe -CommandType Application -ErrorAction Stop).Source
+          $downloaded = Join-Path $env:V4_RELEASE_STATE_ROOT "downloaded"
+          $installer = @(Get-ChildItem -LiteralPath $downloaded -Filter "*.exe" -File)
+          $signature = @(Get-ChildItem -LiteralPath $downloaded -Filter "*.sig" -File)
+          if ($installer.Count -ne 1 -or $signature.Count -ne 1) { throw "Downloaded attestation subject set is not exact" }
+          $signerWorkflow = "$env:GITHUB_REPOSITORY/.github/workflows/release-v4.yml"
+          & $gh attestation verify $installer[0].FullName -R $env:GITHUB_REPOSITORY --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
+          if ($LASTEXITCODE -ne 0) { throw "Installer exact-source attestation verification failed" }
+          & $gh attestation verify $signature[0].FullName -R $env:GITHUB_REPOSITORY --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
+          if ($LASTEXITCODE -ne 0) { throw "Updater signature exact-source attestation verification failed" }
+          & $gh attestation verify $installer[0].FullName -R $env:GITHUB_REPOSITORY --predicate-type https://spdx.dev/Document/v2.3 --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
+          if ($LASTEXITCODE -ne 0) { throw "SBOM exact-source attestation verification failed" }
+
+      - name: Record verified exact-byte attestations
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State RecordAttestations `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
+
+      - name: Publish the already-qualified draft immutably
+        env:
+          V4_RELEASE_AUTHORITY_TOKEN: ${{ secrets.V4_RELEASE_AUTHORITY_TOKEN }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State PublishDraft `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
+
+      - name: Promote only after immutable publication
+        env:
+          V4_RELEASE_AUTHORITY_TOKEN: ${{ secrets.V4_RELEASE_AUTHORITY_TOKEN }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State PromoteMetadata `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_RELEASE_NOTES_PATH `
+            -PublicationDateUtc $env:V4_RELEASE_PUBLICATION_DATE
+
+      - name: Re-fetch and verify final public release and metadata
+        env:
+          V4_RELEASE_AUTHORITY_TOKEN: ${{ secrets.V4_RELEASE_AUTHORITY_TOKEN }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State FinalVerify `
+            -Version $env:V4_RELEASE_VERSION `
+            -Channel $env:V4_RELEASE_CHANNEL `
+            -Tag $env:V4_RELEASE_TAG `
+            -SourceSha $env:V4_RELEASE_SOURCE_SHA `
+            -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -101,6 +101,31 @@ pub fn run_update_smoke() {
     run_inner(false, true);
 }
 
+/// Prove the packaged update admission boundary remains fail-closed while
+/// physical playback owns the activity gate. This is a hidden qualification
+/// seam only; it does not add an updater protocol or install path.
+pub fn selftest_update_install_rejection_during_playback() -> i32 {
+    let activity = app_state::ActivityCoordinator::default();
+    let _playback = match activity.reserve_playback("packaged-qualification") {
+        Ok(lease) => lease,
+        Err(error) => {
+            eprintln!("packaged playback admission self-test could not start: {error}");
+            return 1;
+        }
+    };
+    match activity.reserve_update() {
+        Err(app_state::ActivityReservationError::PhysicalPlaybackActive) => 0,
+        Ok(_) => {
+            eprintln!("packaged update admission self-test accepted installation during playback");
+            1
+        }
+        Err(error) => {
+            eprintln!("packaged update admission self-test returned unexpected error: {error}");
+            1
+        }
+    }
+}
+
 fn run_inner(gui_smoke: bool, update_smoke: bool) {
     let update_marker = update_smoke_marker("--selftest-update-marker");
     let update_safety_marker = update_smoke_marker("--selftest-update-safety-marker");

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -22,6 +22,14 @@ fn main() {
         sky_desktop_shell_lib::run_gui_smoke();
         return;
     }
+    if args
+        .iter()
+        .any(|arg| arg == "--selftest-update-active-playback")
+    {
+        std::process::exit(
+            sky_desktop_shell_lib::selftest_update_install_rejection_during_playback(),
+        );
+    }
     if args.iter().any(|arg| arg == "--selftest-desktop-update") {
         sky_desktop_shell_lib::run_update_smoke();
         return;

--- a/docs/adr/ADR-0006-v4-distribution-installation-update.md
+++ b/docs/adr/ADR-0006-v4-distribution-installation-update.md
@@ -210,6 +210,27 @@ V4 preserves the strongest v3 release discipline:
 A failed qualification produces a new version/RC. Published artifacts and tags are never repaired in
 place.
 
+The production implementation is the dedicated manual workflow
+`.github/workflows/release-v4.yml`, which runs only on the accepted
+single-tenant Windows release runner. Its explicit states are:
+
+```text
+ValidateRequest -> ValidateAuthority -> BuildCandidate -> CreateDraft
+  -> DownloadDraft -> QualifyDownloaded -> RecordAttestations
+  -> PublishDraft -> PromoteMetadata -> FinalVerify
+```
+
+`BuildCandidate` is the only state allowed to invoke the production
+orchestrator, and it invokes it exactly once. The authority preflight requires
+an existing `main` branch; first-history/bootstrap work is a separate reviewed
+operation and is never created by a release transaction. The workflow uses a
+bounded `V4_RELEASE_AUTHORITY_TOKEN` only for the dedicated authority API.
+Source-repository `GITHUB_TOKEN`/OIDC permissions are reserved for source-bound
+attestations. A failed or reused authority tag, a draft-asset byte mismatch, a
+post-draft qualification failure, or an unavailable publication/metadata
+precondition stops the transaction; the existing tag and candidate assets are
+never moved or replaced.
+
 ### 12. SBOM is a first-class release artifact
 
 V4 generates a standard SBOM (SPDX JSON or CycloneDX JSON) and attests it alongside build provenance.

--- a/docs/adr/ADR-0006-v4-distribution-installation-update.md
+++ b/docs/adr/ADR-0006-v4-distribution-installation-update.md
@@ -231,6 +231,15 @@ post-draft qualification failure, or an unavailable publication/metadata
 precondition stops the transaction; the existing tag and candidate assets are
 never moved or replaced.
 
+Draft assets are posted only to the release-specific GitHub `upload_url`, and
+the authority preflight requires repository immutable releases to be enabled.
+Publication must return `immutable=true`; final verification checks the same
+property before metadata promotion. The post-draft Windows matrix consumes
+the downloaded installer and signature directly, including the packaged
+previous-v4 update, the packaged playback-active admission rejection, and a
+mandatory Defender custom scan with no detection. Missing Defender cmdlets,
+disabled protection, scan failure, or a detection fails closed.
+
 ### 12. SBOM is a first-class release artifact
 
 V4 generates a standard SBOM (SPDX JSON or CycloneDX JSON) and attests it alongside build provenance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,8 @@ authority is fixed to the dedicated v4 stable/beta metadata paths; missing
 metadata or missing/invalid v4 updater trust material fails closed. Production
 Authenticode uses the governed `unsigned-zero-budget` policy; no provider
 credentials are required, and qualification rejects signed or unexpected PE state.
-The signed packaged previous-v4 to candidate-v4 fixture is test-only. The retired
+The packaged previous-v4 to candidate-v4 fixture is test-only and consumes the
+exact installer/signature bytes re-downloaded from a release draft. The retired
 v3 transaction/recovery implementation is preserved in Git history and the
 `v3-maintenance` line; it is not part of the current workspace or product graph.
 

--- a/docs/distribution-and-update.md
+++ b/docs/distribution-and-update.md
@@ -33,9 +33,11 @@ no production certificate, provider, or thumbprint is required by the current
 
 Qualification binds the exact NSIS installer and Tauri signature bytes by
 SHA-256 and retains the governed unsigned-zero-budget Authenticode evidence,
-SPDX SBOM, provenance, clean worktree, install/launch/uninstall, and
-previous-v4-to-candidate-v4 fixture evidence. Release orchestration remains
-subject to the dedicated v4 release authority and its reviewed promotion policy.
+SPDX SBOM, provenance, clean worktree, install/launch/uninstall, and the
+post-download previous-v4-to-candidate-v4 fixture evidence. That fixture
+consumes the exact installer and `.sig` re-downloaded from the draft; it does
+not rebuild the candidate. Release orchestration remains subject to the
+dedicated v4 release authority and its reviewed promotion policy.
 
 The remainder of this document is retained as a historical v3-maintenance
 reference. It is not a current v4 runtime, packaging, release, or update
@@ -88,7 +90,8 @@ gh attestation verify SUPPLY_CHAIN_ATTESTATION.json -R pumni/Sky-Auto-Player
 Prerelease tags (`vX.Y.ZrcN`, `vX.Y.Z.devN`, and equivalent PEP 440 forms) are
 created as draft GitHub releases and published as prereleases for beta-channel
 validation only after qualification. Stable tags are published only after the
-repository's exact-artifact, manifest, provenance, fresh-install, and Defender
+repository's exact-artifact, manifest, provenance, fresh-install, exact
+downloaded-byte updater, packaged playback-admission, and Defender
 qualification gates pass. Published tags and assets are immutable; fixes
 require a new version.
 

--- a/docs/migration/v4-clean-distribution-execution.md
+++ b/docs/migration/v4-clean-distribution-execution.md
@@ -222,7 +222,9 @@ Required qualification matrix:
 - pre-exit all-input-release safety;
 - Authenticode verification;
 - updater-signature verification;
-- Defender status/detection evidence;
+- exact downloaded-installer Defender custom scan with no detection; missing
+  Defender cmdlets, disabled protection, scan failure, or detection fails
+  closed;
 - packaged GUI smoke;
 - update-channel isolation;
 - immutable release/asset identity check.

--- a/docs/migration/v4-codex-work-orders.md
+++ b/docs/migration/v4-codex-work-orders.md
@@ -304,7 +304,9 @@ exact assets, publish immutably, then promote updater metadata.
 - Authenticode verification;
 - updater signature verification;
 - SBOM/provenance verification;
-- Defender status/detection evidence;
+- exact downloaded-installer Defender custom scan with no detection (missing
+  Defender cmdlets, disabled protection, scan failure, or detection fails
+  closed; unavailable evidence is not promotable);
 - stable/beta isolation;
 - v3/v4 namespace isolation;
 - exact published asset digest match;

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -106,6 +106,16 @@ only after it has published the immutable draft, then writes the validated
 channel file through the bounded authority credential. The promotion helper
 itself never creates, edits, replaces, or deletes a GitHub release asset.
 
+The dedicated authority must have GitHub immutable releases enabled before
+the first production transaction. `ValidateAuthority` checks both the
+existing `refs/heads/main` bootstrap and the repository's immutable-release
+setting; `PublishDraft` and `FinalVerify` require the returned release object
+to report `immutable=true`. Assets are uploaded only through the
+release-specific `upload_url` returned by the create-release response, and a
+duplicate-name/upload error is never repaired by deleting or replacing an
+asset. Any post-draft qualification failure therefore requires a new
+SemVer/RC.
+
 ## Release pipeline and authority bootstrap
 
 `.github/workflows/release-v4.yml` is the only production v4 publication entry
@@ -115,9 +125,10 @@ The source `GITHUB_TOKEN` and OIDC permissions remain separate and are used for
 source-bound attestations. The updater private key is not a GitHub secret: the
 workflow receives only a path to the externally stored key on the runner.
 The authority token contract is bounded to the dedicated repository only, with
-the minimum Contents read/write capability needed for release records, release
-assets, and `channels/<channel>/latest.json`; it has no source-repository,
-Actions, secrets, package, or updater-key permission.
+the minimum Administration read and Contents read/write capability needed to
+inspect immutable-release policy, create/read/publish release records, upload
+release assets, and write `channels/<channel>/latest.json`; it has no
+source-repository, Actions, secrets, package, or updater-key permission.
 
 The pipeline first requires `refs/heads/main` in this repository. An empty
 authority repository therefore fails closed with an instruction to perform a
@@ -126,20 +137,17 @@ authority `main` history (including the channel directory contract) outside a
 production release dispatch. A release dispatch never creates the first
 authority commit as a side effect.
 
-The v4 Tauri updater public trust root is committed independently of this
-release-authority metadata contract. Its operational private key remains
-outside the repository. The project's production release policy does not
-require Authenticode provider credentials; an optional real-signer seam is
-separately governed and is not represented as current production evidence.
-outside the repository. The project's production release policy is
-`unsigned-zero-budget`: no Authenticode provider credentials are required; an
+The project's production release policy is `unsigned-zero-budget`: no
+Authenticode provider credentials are required; an
 optional real-signer seam is separately governed and is not represented as
 current production evidence. The retired v3 updater is preserved by Git
 history and the `v3-maintenance` line, but is not part of the current v4
 workspace or product graph.
 
-Updater rotation is qualified with real packaged clients: the bridge trusts
-`[old,new]` and verifies candidate bytes during `Update::download()`, while the
-cutover client trusts `[new]` and rejects an old-root-only candidate. A full
+The v4 Tauri updater public trust root is committed independently of this
+release-authority metadata contract. Its operational private key remains
+outside the repository. The post-download fixture bridge trusts `[old,new]`
+and verifies the exact downloaded candidate bytes during `Update::download()`;
+the production candidate itself is not rebuilt by that qualification. A full
 non-PR workflow dispatch is required for provenance and SPDX attestation
 evidence.

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -101,9 +101,30 @@ exact installer/`.sig` pair, and compares names, sizes, and SHA-256 digests
 against the qualified bytes before atomically copying metadata into the
 selected channel path in an authority checkout. Its `-SelfTest` regression
 path proves arbitrary `qualified=true` evidence and same-name/different-bytes
-assets are rejected. It never creates or edits a GitHub release; committing
-the resulting channel file is a separate reviewed authority-repository
-change.
+assets are rejected. The dedicated v4 release pipeline invokes this validator
+only after it has published the immutable draft, then writes the validated
+channel file through the bounded authority credential. The promotion helper
+itself never creates, edits, replaces, or deletes a GitHub release asset.
+
+## Release pipeline and authority bootstrap
+
+`.github/workflows/release-v4.yml` is the only production v4 publication entry
+point. It is manual, runs on the dedicated/single-tenant Windows runner, and
+uses `V4_RELEASE_AUTHORITY_TOKEN` for release/assets/channel metadata writes.
+The source `GITHUB_TOKEN` and OIDC permissions remain separate and are used for
+source-bound attestations. The updater private key is not a GitHub secret: the
+workflow receives only a path to the externally stored key on the runner.
+The authority token contract is bounded to the dedicated repository only, with
+the minimum Contents read/write capability needed for release records, release
+assets, and `channels/<channel>/latest.json`; it has no source-repository,
+Actions, secrets, package, or updater-key permission.
+
+The pipeline first requires `refs/heads/main` in this repository. An empty
+authority repository therefore fails closed with an instruction to perform a
+separately reviewed one-time bootstrap. That bootstrap must create the minimal
+authority `main` history (including the channel directory contract) outside a
+production release dispatch. A release dispatch never creates the first
+authority commit as a side effect.
 
 The v4 Tauri updater public trust root is committed independently of this
 release-authority metadata contract. Its operational private key remains

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -236,6 +236,46 @@ Step 8: Evidence Emission & Self-Validation
   - Generate extended `V4_PRODUCTION_RELEASE_EVIDENCE.json`.
 ```
 
+### 3.3 Dedicated v4 release state machine
+
+The manual production entry point is `.github/workflows/release-v4.yml`. It
+accepts an explicit version, channel, `v<version>` tag, source SHA, external
+updater-key path, notes path, and UTC publication timestamp. The workflow
+requires the checked-out commit and workflow SHA to equal the requested source
+SHA, then executes these fail-closed states:
+
+```text
+ValidateRequest -> ValidateAuthority -> BuildCandidate -> CreateDraft
+  -> DownloadDraft -> QualifyDownloaded -> RecordAttestations
+  -> PublishDraft -> PromoteMetadata -> FinalVerify
+```
+
+Only `BuildCandidate` calls
+`scripts/orchestrate_v4_production_release.ps1`, exactly once. The candidate
+manifest is the only asset upload authority. The following states download the
+draft assets again and compare names, sizes, and SHA-256 digests before running
+the Authenticode `unsigned-zero-budget`, Tauri updater signature, SPDX SBOM,
+exact-bundle, current-user install/launch/uninstall, GUI/input-safety, and
+active-playback rejection checks. The existing packaged official Tauri updater
+fixture remains the throwaway previous-v4 to candidate-v4 rotation evidence;
+no production candidate is rebuilt for that fixture.
+
+Attestation happens on those downloaded bytes with GitHub OIDC and is verified
+against the source repository, this workflow, the exact workflow SHA, and the
+candidate subjects. Publication changes only the draft flag. Metadata promotion
+is unreachable until publication returns a non-draft release, and final
+verification re-fetches both public assets and the selected stable/beta
+metadata path. Any failure after draft creation requires a new SemVer/RC; no
+asset, release tag, or published metadata is replaced in place.
+
+The authority preflight requires `pumni/Sky-Auto-Player-Releases` to have an
+existing `main` branch. If the authority is empty, the workflow stops and the
+maintainer must perform a separately reviewed one-time minimal bootstrap; the
+release transaction never creates initial authority history implicitly. The
+only cross-repository secret is the bounded
+`V4_RELEASE_AUTHORITY_TOKEN`, scoped to the authority repository's release,
+asset, and channel-metadata writes. It is never used for updater-key custody.
+
 ---
 
 ## 4. Evidence Schemas and Promotion

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -256,9 +256,17 @@ manifest is the only asset upload authority. The following states download the
 draft assets again and compare names, sizes, and SHA-256 digests before running
 the Authenticode `unsigned-zero-budget`, Tauri updater signature, SPDX SBOM,
 exact-bundle, current-user install/launch/uninstall, GUI/input-safety, and
-active-playback rejection checks. The existing packaged official Tauri updater
-fixture remains the throwaway previous-v4 to candidate-v4 rotation evidence;
-no production candidate is rebuilt for that fixture.
+active-playback rejection checks. The packaged official Tauri updater fixture
+runs at this post-download boundary: a throwaway previous-v4 bridge consumes
+the exact downloaded installer and `.sig`, while the production candidate is
+never rebuilt. The packaged candidate also proves that update admission is
+rejected while playback is active.
+
+The same post-download qualification invokes a bounded Windows Defender
+custom scan against the exact downloaded installer and records the artifact
+name, size, SHA-256, scan result, and Defender status. This is a mandatory
+production gate: missing Defender cmdlets, disabled protection, scan failure,
+or a detection fails closed; no `unavailable` result is promotable.
 
 Attestation happens on those downloaded bytes with GitHub OIDC and is verified
 against the source repository, this workflow, the exact workflow SHA, and the
@@ -273,8 +281,14 @@ existing `main` branch. If the authority is empty, the workflow stops and the
 maintainer must perform a separately reviewed one-time minimal bootstrap; the
 release transaction never creates initial authority history implicitly. The
 only cross-repository secret is the bounded
-`V4_RELEASE_AUTHORITY_TOKEN`, scoped to the authority repository's release,
-asset, and channel-metadata writes. It is never used for updater-key custody.
+`V4_RELEASE_AUTHORITY_TOKEN`, scoped to the authority repository's
+Administration-read and Contents read/write permissions needed to inspect
+immutable releases, create/upload/read/publish the draft, and write channel
+metadata. It is never used for updater-key custody. A maintainer may run
+`scripts/test_v4_release_authority_rehearsal.ps1 -ConfirmDisposable` after
+bootstrap; that explicit rehearsal creates and deletes one uniquely tagged
+draft and verifies upload/download bytes through the real authority API. It
+never publishes a release or mutates an existing tag.
 
 ---
 

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -452,9 +452,9 @@ fn v4_release_pipeline_contract_source(
         "ref: ${{ inputs.source_sha }}",
         "persist-credentials: false",
         "actions/attest@",
+        "actions/upload-artifact@",
         "--source-digest $env:GITHUB_SHA",
-        "scripts/ci_tauri_update_e2e.ps1",
-        "throwaway official previous-v4 to candidate-v4 updater fixture",
+        "Qualify downloaded exact candidate bytes and packaged update",
         "RecordAttestations",
         "PublishDraft",
         "PromoteMetadata",
@@ -497,6 +497,7 @@ fn v4_release_pipeline_contract_source(
         "Sky-Auto-Player-Updater.exe",
         "MANIFEST.json.sig",
         ".github/workflows/release.yml",
+        "ci_tauri_update_e2e.ps1",
     ] {
         if workflow.contains(forbidden) {
             return Err(
@@ -546,6 +547,18 @@ fn v4_release_pipeline_contract_source(
         "draft = $true",
         "draft = $false",
         "V4_RELEASE_AUTHORITY_TOKEN",
+        "upload_url",
+        "immutable-releases",
+        "Assert-ImmutableRelease",
+        "ci_tauri_update_e2e.ps1",
+        "CandidateInstallerPath",
+        "CandidateSignaturePath",
+        "CandidatePublicKeyPath",
+        "export-public-key",
+        "Start-MpScan",
+        "scan_performed",
+        "selftest-update-active-playback",
+        "scan_v4_defender_exact.ps1",
     ] {
         if !pipeline.contains(marker) {
             return Err(
@@ -563,6 +576,9 @@ fn v4_release_pipeline_contract_source(
         || !regression.contains("candidate rebuilt")
         || !regression.contains("promotion before immutable publication")
         || !regression.contains("BuildCount -ne 1")
+        || !regression.contains("UploadedThroughReleaseUrl")
+        || !regression.contains("ExactDownloadedBytes")
+        || !regression.contains("immutable")
     {
         return Err(
             "v4 release coordinator regression test is missing build-once/publication guards"
@@ -584,6 +600,24 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     .map_err(|error| -> Box<dyn std::error::Error + Send + Sync> {
         format!("v4 release pipeline contract: {error}").into()
     })?;
+    let rehearsal_path = root.join("scripts/test_v4_release_authority_rehearsal.ps1");
+    let rehearsal = fs::read_to_string(&rehearsal_path)?;
+    for marker in [
+        "ConfirmDisposable",
+        "V4_RELEASE_AUTHORITY_TOKEN",
+        "immutable-releases",
+        "upload_url",
+        "draft and tag deleted",
+        "--method",
+        "DELETE",
+    ] {
+        if !rehearsal.contains(marker) {
+            return Err(format!(
+                "v4 authority rehearsal is missing its bounded cleanup marker: {marker}"
+            )
+            .into());
+        }
+    }
     println!("[xtask] v4 release pipeline state-machine contract: PASS");
     Ok(())
 }
@@ -3045,31 +3079,31 @@ jobs:
     -State CreateDraft
     -State DownloadDraft
     -State QualifyDownloaded
+    Qualify downloaded exact candidate bytes and packaged update
     -State RecordAttestations
     -State PublishDraft
     -State PromoteMetadata
     -State FinalVerify
-    throwaway official previous-v4 to candidate-v4 updater fixture
-    scripts/ci_tauri_update_e2e.ps1
     actions/attest@v4
+    actions/upload-artifact@v7
     --source-digest $env:GITHUB_SHA
     GH_TOKEN: ${{ github.token }}
 "#;
         let pipeline = r#"
-ValidateRequest ValidateAuthority BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify authority main is not initialized
+ValidateRequest ValidateAuthority BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify authority main is not initialized upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1
 function Invoke-BuildCandidate {
   & pwsh -File orchestrate_v4_production_release.ps1
 }
 function Invoke-CreateDraft { draft = $true; refs/heads/main; authority already contains tag; existing releases are never moved or replaced }
 function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
-function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; ci_v4_release_authority_acceptance.ps1; promote_v4_metadata.ps1; release-authority; published_at }
+function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; selftest-update-active-playback; ci_v4_release_authority_acceptance.ps1; promote_v4_metadata.ps1; release-authority; published_at; Start-MpScan; scan_performed }
 function Invoke-RecordAttestations { V4_RELEASE_AUTHORITY_TOKEN }
 function Invoke-PublishDraft { draft = $false }
 function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication }
 function Invoke-FinalVerify { FinalVerify }
 "#;
         let regression = r#"
-class MockReleaseApi { [int]$BuildCount = 0; candidate rebuilt; promotion before immutable publication; BuildCount -ne 1 }
+class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$UploadedThroughReleaseUrl = $false; [bool]$ExactDownloadedBytes = $false; [bool]$immutable = $false; candidate rebuilt; promotion before immutable publication; BuildCount -ne 1; UploadedThroughReleaseUrl; ExactDownloadedBytes; immutable }
 "#;
         assert!(v4_release_pipeline_contract_source(workflow, pipeline, regression).is_ok());
 

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -435,6 +435,159 @@ fn release_authority_contract(root: &Path) -> Result<()> {
     Ok(())
 }
 
+fn v4_release_pipeline_contract_source(
+    workflow: &str,
+    pipeline: &str,
+    regression: &str,
+) -> Result<()> {
+    let workflow = workflow.replace("\r\n", "\n");
+    for marker in [
+        "name: V4 Release Pipeline",
+        "workflow_dispatch:",
+        "runs-on: [self-hosted, windows, v4-release, single-tenant]",
+        "contents: read",
+        "id-token: write",
+        "attestations: write",
+        "V4_RELEASE_AUTHORITY_TOKEN",
+        "ref: ${{ inputs.source_sha }}",
+        "persist-credentials: false",
+        "actions/attest@",
+        "--source-digest $env:GITHUB_SHA",
+        "scripts/ci_tauri_update_e2e.ps1",
+        "throwaway official previous-v4 to candidate-v4 updater fixture",
+        "RecordAttestations",
+        "PublishDraft",
+        "PromoteMetadata",
+        "FinalVerify",
+    ] {
+        if !workflow.contains(marker) {
+            return Err(
+                format!("v4 release workflow is missing its required marker: {marker}").into(),
+            );
+        }
+    }
+    let workflow_states = [
+        "-State ValidateRequest",
+        "-State ValidateAuthority",
+        "-State BuildCandidate",
+        "-State CreateDraft",
+        "-State DownloadDraft",
+        "-State QualifyDownloaded",
+        "-State RecordAttestations",
+        "-State PublishDraft",
+        "-State PromoteMetadata",
+        "-State FinalVerify",
+    ];
+    let mut previous = 0;
+    for marker in workflow_states {
+        let position = workflow
+            .find(marker)
+            .ok_or_else(|| format!("v4 release workflow is missing state marker: {marker}"))?;
+        if position < previous {
+            return Err("v4 release workflow states are not ordered fail-closed".into());
+        }
+        previous = position;
+    }
+    for forbidden in [
+        "cargo xtask dist",
+        "softprops/action-gh-release",
+        "secrets.TAURI_SIGNING_PRIVATE_KEY",
+        "secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
+        "secrets.UPDATER_PRIVATE_KEY",
+        "Sky-Auto-Player-Updater.exe",
+        "MANIFEST.json.sig",
+        ".github/workflows/release.yml",
+    ] {
+        if workflow.contains(forbidden) {
+            return Err(
+                format!("v4 release workflow contains forbidden marker: {forbidden}").into(),
+            );
+        }
+    }
+    if workflow.matches("GH_TOKEN: ${{ github.token }}").count() != 1 {
+        return Err(
+            "source GITHUB_TOKEN must be confined to the exact attestation verification step"
+                .into(),
+        );
+    }
+
+    if pipeline
+        .matches("orchestrate_v4_production_release.ps1")
+        .count()
+        != 1
+    {
+        return Err("production orchestrator must have exactly one pipeline call site".into());
+    }
+    for marker in [
+        "ValidateRequest",
+        "ValidateAuthority",
+        "BuildCandidate",
+        "CreateDraft",
+        "DownloadDraft",
+        "QualifyDownloaded",
+        "RecordAttestations",
+        "PublishDraft",
+        "PromoteMetadata",
+        "FinalVerify",
+        "unsigned-zero-budget",
+        "authority main is not initialized",
+        "refs/heads/main",
+        "authority already contains tag",
+        "existing releases are never moved or replaced",
+        "Get-FileHash",
+        "verify-signature",
+        "verify-tauri-bundle",
+        "current-user",
+        "active-playback-install-rejected",
+        "ci_v4_release_authority_acceptance.ps1",
+        "promote_v4_metadata.ps1",
+        "release-authority",
+        "published_at",
+        "draft = $true",
+        "draft = $false",
+        "V4_RELEASE_AUTHORITY_TOKEN",
+    ] {
+        if !pipeline.contains(marker) {
+            return Err(
+                format!("v4 release coordinator is missing its required marker: {marker}").into(),
+            );
+        }
+    }
+    let draft_boundary = pipeline
+        .find("function Invoke-CreateDraft")
+        .ok_or("v4 release coordinator is missing the draft boundary")?;
+    if pipeline[draft_boundary..].contains("orchestrate_v4_production_release.ps1") {
+        return Err("v4 release coordinator may not rebuild after draft creation".into());
+    }
+    if !regression.contains("MockReleaseApi")
+        || !regression.contains("candidate rebuilt")
+        || !regression.contains("promotion before immutable publication")
+        || !regression.contains("BuildCount -ne 1")
+    {
+        return Err(
+            "v4 release coordinator regression test is missing build-once/publication guards"
+                .into(),
+        );
+    }
+    Ok(())
+}
+
+fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
+    let workflow_path = root.join(".github/workflows/release-v4.yml");
+    let pipeline_path = root.join("scripts/v4_release_pipeline.ps1");
+    let regression_path = root.join("scripts/test_v4_release_pipeline.ps1");
+    v4_release_pipeline_contract_source(
+        &fs::read_to_string(&workflow_path)?,
+        &fs::read_to_string(&pipeline_path)?,
+        &fs::read_to_string(&regression_path)?,
+    )
+    .map_err(|error| -> Box<dyn std::error::Error + Send + Sync> {
+        format!("v4 release pipeline contract: {error}").into()
+    })?;
+    println!("[xtask] v4 release pipeline state-machine contract: PASS");
+    Ok(())
+}
+
 fn packaged_ci_contract_source(source: &str) -> Result<()> {
     let normalized = source.replace("\r\n", "\n");
     let package_needs = "needs: [changes, static, release_authority, supply_chain, validate]";
@@ -2557,6 +2710,7 @@ pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
             v4_trust_material_contract(&root)?;
             legacy_release_guard(&root)?;
             release_authority_contract(&root)?;
+            v4_release_pipeline_contract(&root)?;
             packaged_ci_contract(&root)?;
             v4_legacy_updater_retirement(&root)?;
             retirement(&root)?;
@@ -2867,6 +3021,70 @@ read_only=true
         assert!(acceptance.contains("This is deliberately read-only"));
         assert!(acceptance.contains("releases/latest"));
         assert!(!acceptance.contains("gh release create"));
+    }
+
+    #[test]
+    fn v4_release_pipeline_contract_requires_draft_download_and_publish_order() {
+        let workflow = r#"
+name: V4 Release Pipeline
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  attestations: write
+jobs:
+  release:
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+    ref: ${{ inputs.source_sha }}
+    persist-credentials: false
+    env: V4_RELEASE_AUTHORITY_TOKEN
+    -State ValidateRequest
+    -State ValidateAuthority
+    -State BuildCandidate
+    -State CreateDraft
+    -State DownloadDraft
+    -State QualifyDownloaded
+    -State RecordAttestations
+    -State PublishDraft
+    -State PromoteMetadata
+    -State FinalVerify
+    throwaway official previous-v4 to candidate-v4 updater fixture
+    scripts/ci_tauri_update_e2e.ps1
+    actions/attest@v4
+    --source-digest $env:GITHUB_SHA
+    GH_TOKEN: ${{ github.token }}
+"#;
+        let pipeline = r#"
+ValidateRequest ValidateAuthority BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify authority main is not initialized
+function Invoke-BuildCandidate {
+  & pwsh -File orchestrate_v4_production_release.ps1
+}
+function Invoke-CreateDraft { draft = $true; refs/heads/main; authority already contains tag; existing releases are never moved or replaced }
+function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
+function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; ci_v4_release_authority_acceptance.ps1; promote_v4_metadata.ps1; release-authority; published_at }
+function Invoke-RecordAttestations { V4_RELEASE_AUTHORITY_TOKEN }
+function Invoke-PublishDraft { draft = $false }
+function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication }
+function Invoke-FinalVerify { FinalVerify }
+"#;
+        let regression = r#"
+class MockReleaseApi { [int]$BuildCount = 0; candidate rebuilt; promotion before immutable publication; BuildCount -ne 1 }
+"#;
+        assert!(v4_release_pipeline_contract_source(workflow, pipeline, regression).is_ok());
+
+        let reordered = workflow.replace(
+            "-State CreateDraft\n    -State DownloadDraft",
+            "-State DownloadDraft\n    -State CreateDraft",
+        );
+        assert!(v4_release_pipeline_contract_source(&reordered, pipeline, regression).is_err());
+        let duplicated_build = pipeline.replace(
+            "function Invoke-CreateDraft",
+            "orchestrate_v4_production_release.ps1\nfunction Invoke-CreateDraft",
+        );
+        assert!(
+            v4_release_pipeline_contract_source(workflow, &duplicated_build, regression).is_err()
+        );
     }
 
     #[test]

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 fn usage() -> &'static str {
-    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> --authenticode-evidence <path> --sbom <path> [--summary <path>]\n  cargo xtask sbom <generate|verify> --artifact-dir <dir> --output|--sbom <path>\n  cargo xtask updater-trust <inventory|verify-private-key|rotation-self-test>\n  cargo xtask release-authority generate --channel <stable|beta> --version <semver> --notes-file <path> --pub-date <rfc3339> --platform windows-x86_64 --asset-url <url> --signature-file <path> --output <path>\n  cargo xtask release-authority validate --channel <stable|beta> --metadata <path>"
+    "Usage:\n  cargo xtask check <static|rust|desktop|all> [--skip-supply-chain]\n  cargo xtask audit supply-chain [--attestation <path>]\n  cargo xtask ci classify [--full | --base <sha> --head <sha> | --paths-file <file>]\n  cargo xtask version check [--tag <tag>]\n  cargo xtask bindings <generate|check>\n  cargo xtask branding validate\n  cargo xtask branding build-ico --layers-dir <dir> --output <ico>\n  cargo xtask verify-tauri-bundle --bundle-dir <dir> --authenticode-evidence <path> --sbom <path> [--summary <path>]\n  cargo xtask sbom <generate|verify> --artifact-dir <dir> --output|--sbom <path>\n  cargo xtask updater-trust <inventory|export-public-key|verify-private-key|rotation-self-test>\n  cargo xtask release-authority generate --channel <stable|beta> --version <semver> --notes-file <path> --pub-date <rfc3339> --platform windows-x86_64 --asset-url <url> --signature-file <path> --output <path>\n  cargo xtask release-authority validate --channel <stable|beta> --metadata <path>"
 }
 
 fn required_value(args: &[String], index: &mut usize, option: &str) -> Result<String> {
@@ -191,6 +191,24 @@ fn main() -> Result<()> {
         }
         "updater-trust" if args.get(1).map(String::as_str) == Some("inventory") => {
             updater_trust::print_inventory(&repo::root())
+        }
+        "updater-trust" if args.get(1).map(String::as_str) == Some("export-public-key") => {
+            let mut output = None;
+            let mut i = 2;
+            while i < args.len() {
+                match args[i].as_str() {
+                    "--output" => output = Some(required_value(&args, &mut i, "--output")?),
+                    option => {
+                        return Err(format!(
+                            "unknown updater-trust export-public-key option: {option}"
+                        )
+                        .into());
+                    }
+                }
+                i += 1;
+            }
+            let output = output.ok_or("export-public-key requires --output <path>")?;
+            updater_trust::export_canonical_public_key(&repo::root(), Path::new(&output))
         }
         "updater-trust" if args.get(1).map(String::as_str) == Some("verify-private-key") => {
             let mut key_file = None;

--- a/rust/xtask/src/updater_trust.rs
+++ b/rust/xtask/src/updater_trust.rs
@@ -113,6 +113,23 @@ pub fn print_inventory(root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Export only the canonical public updater root for a throwaway packaged
+/// qualification fixture. The inventory parser remains the authority for
+/// both validation and the exported value; no private material is involved.
+pub fn export_canonical_public_key(root: &Path, output: &Path) -> Result<()> {
+    let inventory = inventory_public_trust_roots(root)?;
+    let parent = output
+        .parent()
+        .ok_or("updater public-key export requires a parent directory")?;
+    fs::create_dir_all(parent)?;
+    fs::write(output, format!("{}\n", inventory.canonical_public_key))?;
+    println!(
+        "[xtask] V4 updater public-root export: PASS (public identity only; {} bytes)",
+        inventory.canonical_public_key.len()
+    );
+    Ok(())
+}
+
 /// Verify local updater private key without printing private material or password.
 pub fn verify_local_private_key(
     root: &Path,

--- a/scripts/ci_tauri_update_e2e.ps1
+++ b/scripts/ci_tauri_update_e2e.ps1
@@ -2,6 +2,10 @@
 param(
   [Parameter(Mandatory = $true)]
   [string]$BundleDir,
+  [string]$CandidateInstallerPath,
+  [string]$CandidateSignaturePath,
+  [string]$CandidateVersion,
+  [string]$CandidatePublicKeyPath,
   [switch]$KeepFixtureOnFailure
 )
 
@@ -34,7 +38,22 @@ $oldKeyPath = Join-Path $fixtureRoot 'old.key'
 $newKeyPath = Join-Path $fixtureRoot 'new.key'
 $oldSignaturePath = Join-Path $fixtureRoot 'old.sig'
 $candidateForOldSigningPath = Join-Path $fixtureRoot 'candidate-for-old-signing.exe'
-$candidateVersion = '4.0.0-alpha.2'
+$providedCandidate = -not [string]::IsNullOrWhiteSpace($CandidateInstallerPath) -or
+  -not [string]::IsNullOrWhiteSpace($CandidateSignaturePath) -or
+  -not [string]::IsNullOrWhiteSpace($CandidateVersion) -or
+  -not [string]::IsNullOrWhiteSpace($CandidatePublicKeyPath)
+if ($providedCandidate) {
+  if ([string]::IsNullOrWhiteSpace($CandidateInstallerPath) -or
+    [string]::IsNullOrWhiteSpace($CandidateSignaturePath) -or
+    [string]::IsNullOrWhiteSpace($CandidateVersion) -or
+    [string]::IsNullOrWhiteSpace($CandidatePublicKeyPath)) {
+    throw 'Provided-candidate updater qualification requires installer, signature, version, and public-key paths'
+  }
+  if ($CandidateVersion -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+    throw "Provided-candidate updater qualification received a non-canonical SemVer: $CandidateVersion"
+  }
+}
+$candidateVersion = if ($providedCandidate) { $CandidateVersion } else { '4.0.0-alpha.2' }
 $cutoverVersion = '4.0.0-alpha.3'
 $port = 17845
 $serverJob = $null
@@ -113,16 +132,28 @@ try {
     Pop-Location
   }
   $oldPublicKey = ([IO.File]::ReadAllText("$oldKeyPath.pub")).Trim()
-  $newPublicKey = ([IO.File]::ReadAllText("$newKeyPath.pub")).Trim()
+  $newPublicKey = if ($providedCandidate) {
+    $candidatePublicKey = (Resolve-Path -LiteralPath $CandidatePublicKeyPath -ErrorAction Stop).Path
+    $candidatePublicKeyItem = Get-Item -LiteralPath $candidatePublicKey -ErrorAction Stop
+    if ($candidatePublicKeyItem.Length -le 0 -or $candidatePublicKeyItem.Length -gt 4096) {
+      throw 'Provided candidate public key is empty or unbounded'
+    }
+    ([IO.File]::ReadAllText($candidatePublicKey)).Trim()
+  } else {
+    ([IO.File]::ReadAllText("$newKeyPath.pub")).Trim()
+  }
   if ([string]::IsNullOrWhiteSpace($oldPublicKey) -or [string]::IsNullOrWhiteSpace($newPublicKey)) {
     throw 'Updater fixture public key generation failed'
+  }
+  if ($newPublicKey -match 'PRIVATE KEY' -or $newPublicKey.Length -gt 4096) {
+    throw 'Updater fixture public key contains forbidden or unbounded material'
   }
   Write-FixtureUpdaterConfig $bridgeConfigPath $oldPublicKey
   Write-FixtureUpdaterConfig $cutoverConfigPath $newPublicKey
 
-  # Build the actual bridge client with old+new roots. The candidate build
-  # below is rebuilt with only the new root, so the installed binaries exercise
-  # the same Rust/Tauri transition as production rotation.
+  # Build only the throwaway bridge client with old+new roots. In production
+  # qualification the candidate below is the exact installer and signature
+  # downloaded from the release draft; it is never rebuilt by this fixture.
   Invoke-FixtureBuild $bridgeConfigPath $oldKeyPath "$oldPublicKey|$newPublicKey"
   $previousInstallers = @(Get-ChildItem -LiteralPath $bundleRoot -Filter '*4.0.0-alpha.1_x64-setup.exe' -File)
   if ($previousInstallers.Count -ne 1) {
@@ -130,40 +161,51 @@ try {
   }
   Copy-Item -LiteralPath $previousInstallers[0].FullName -Destination $previousInstallerCopy -Force
 
-  $cargoCandidate = $cargoSource -replace 'version = "4\.0\.0-alpha\.1"', ('version = "' + $candidateVersion + '"')
-  $lockCandidate = [regex]::Replace(
-    $lockSource,
-    '(?s)(name = "sky_desktop_shell"\r?\nversion = ")4\.0\.0-alpha\.1("\r?\n)',
-    '${1}' + $candidateVersion + '${2}',
-    1
-  )
-  if ($lockCandidate -eq $lockSource) { throw 'Could not locate the desktop package in Cargo.lock' }
-  [IO.File]::WriteAllText($candidateCargoPath, $cargoCandidate, [Text.UTF8Encoding]::new($false))
-  [IO.File]::WriteAllText($lockPath, $lockCandidate, [Text.UTF8Encoding]::new($false))
-  Invoke-FixtureBuild $cutoverConfigPath $newKeyPath $newPublicKey
+  if ($providedCandidate) {
+    $candidateArchive = Get-Item -LiteralPath (Resolve-Path -LiteralPath $CandidateInstallerPath -ErrorAction Stop).Path -ErrorAction Stop
+    $candidateSignature = Get-Item -LiteralPath (Resolve-Path -LiteralPath $CandidateSignaturePath -ErrorAction Stop).Path -ErrorAction Stop
+    if ($candidateArchive.Extension.ToLowerInvariant() -ne '.exe' -or
+      $candidateSignature.Name -ne "$($candidateArchive.Name).sig") {
+      throw 'Provided candidate installer/signature names are not an exact pair'
+    }
+  } else {
+    $cargoCandidate = $cargoSource -replace 'version = "4\.0\.0-alpha\.1"', ('version = "' + $candidateVersion + '"')
+    $lockCandidate = [regex]::Replace(
+      $lockSource,
+      '(?s)(name = "sky_desktop_shell"\r?\nversion = ")4\.0\.0-alpha\.1("\r?\n)',
+      '${1}' + $candidateVersion + '${2}',
+      1
+    )
+    if ($lockCandidate -eq $lockSource) { throw 'Could not locate the desktop package in Cargo.lock' }
+    [IO.File]::WriteAllText($candidateCargoPath, $cargoCandidate, [Text.UTF8Encoding]::new($false))
+    [IO.File]::WriteAllText($lockPath, $lockCandidate, [Text.UTF8Encoding]::new($false))
+    Invoke-FixtureBuild $cutoverConfigPath $newKeyPath $newPublicKey
 
-  $candidateArchives = @(Get-ChildItem -LiteralPath $bundleRoot -Filter "*${candidateVersion}*-setup.exe" -File)
-  if ($candidateArchives.Count -ne 1) {
-    throw "Expected exactly one new-root candidate installer, found $($candidateArchives.Count)"
+    $candidateArchives = @(Get-ChildItem -LiteralPath $bundleRoot -Filter "*${candidateVersion}*-setup.exe" -File)
+    if ($candidateArchives.Count -ne 1) {
+      throw "Expected exactly one new-root candidate installer, found $($candidateArchives.Count)"
+    }
+    $candidateArchive = $candidateArchives[0]
+    $candidateSignature = Get-Item -LiteralPath ($candidateArchive.FullName + '.sig') -ErrorAction Stop
   }
-  $candidateArchive = $candidateArchives[0]
-  $candidateSignature = Get-Item -LiteralPath ($candidateArchive.FullName + '.sig') -ErrorAction Stop
   $signatureText = ([IO.File]::ReadAllText($candidateSignature.FullName)).Trim()
   if ([string]::IsNullOrWhiteSpace($signatureText)) { throw 'Candidate updater signature is empty' }
 
-  # Sign the exact candidate bytes with the old root only. This detached
-  # signature is used after cutover to prove the new-root-only client rejects
-  # an old-root artifact through its real Update::download path.
-  Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
-  Push-Location $desktopRoot
-  try {
-    bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath | Out-Null
-  } finally {
-    Pop-Location
+  if (-not $providedCandidate) {
+    # Sign the exact candidate bytes with the old root only. This detached
+    # signature is used after cutover to prove the new-root-only client rejects
+    # an old-root artifact through its real Update::download path.
+    Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
+    Push-Location $desktopRoot
+    try {
+      bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath | Out-Null
+    } finally {
+      Pop-Location
+    }
+    Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
+    $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
+    if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
   }
-  Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
-  $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
-  if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
 
   $newManifest = [ordered]@{
     version = $candidateVersion
@@ -176,19 +218,21 @@ try {
       }
     }
   }
-  $oldManifest = [ordered]@{
-    version = $cutoverVersion
-    notes = 'Old-root rejection candidate.'
-    pub_date = '2026-09-04T00:00:00Z'
-    platforms = [ordered]@{
-      'windows-x86_64-nsis' = [ordered]@{
-        signature = $oldSignatureText
-        url = "http://127.0.0.1:$port/candidate/update.exe"
+  $newManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $manifestPath -Encoding utf8
+  if (-not $providedCandidate) {
+    $oldManifest = [ordered]@{
+      version = $cutoverVersion
+      notes = 'Old-root rejection candidate.'
+      pub_date = '2026-09-04T00:00:00Z'
+      platforms = [ordered]@{
+        'windows-x86_64-nsis' = [ordered]@{
+          signature = $oldSignatureText
+          url = "http://127.0.0.1:$port/candidate/update.exe"
+        }
       }
     }
+    $oldManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $oldManifestPath -Encoding utf8
   }
-  $newManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $manifestPath -Encoding utf8
-  $oldManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $oldManifestPath -Encoding utf8
 
   $archivePath = $candidateArchive.FullName
   $serverJob = Start-Job -ScriptBlock {
@@ -281,21 +325,26 @@ try {
     $previousOffset = $offset
   }
 
-  # Switch only the server manifest. The restarted candidate is the cutover
-  # binary compiled with [new]; it must reject the old-only detached signature.
-  Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
-  $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
-    '--selftest-desktop-update',
-    '--selftest-update-marker', $cutoverMarkerPath
-  ) -WindowStyle Hidden -PassThru
-  Wait-Process -Id $cutoverProcess.Id -Timeout 180
-  Wait-ForPath -Path $cutoverMarkerPath
-  $cutoverResult = ([IO.File]::ReadAllText($cutoverMarkerPath)).Trim()
-  if (-not $cutoverResult.StartsWith('update-failed:')) {
-    throw "Cutover client accepted an old-root artifact: $cutoverResult"
+  if ($providedCandidate) {
+    "Packaged Tauri updater draft qualification: PASS (throwaway previous-v4 bridge applied the exact downloaded candidate $candidateVersion; safety phases=$($requiredPhases -join ', '))" |
+      Add-Content $summaryPath -Encoding UTF8
+  } else {
+    # Switch only the server manifest. The restarted candidate is the cutover
+    # binary compiled with [new]; it must reject the old-only detached signature.
+    Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
+    $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
+      '--selftest-desktop-update',
+      '--selftest-update-marker', $cutoverMarkerPath
+    ) -WindowStyle Hidden -PassThru
+    Wait-Process -Id $cutoverProcess.Id -Timeout 180
+    Wait-ForPath -Path $cutoverMarkerPath
+    $cutoverResult = ([IO.File]::ReadAllText($cutoverMarkerPath)).Trim()
+    if (-not $cutoverResult.StartsWith('update-failed:')) {
+      throw "Cutover client accepted an old-root artifact: $cutoverResult"
+    }
+    "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; cutover [new] rejected old-root-only $cutoverVersion; safety phases=$($requiredPhases -join ', '))" |
+      Add-Content $summaryPath -Encoding UTF8
   }
-  "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; cutover [new] rejected old-root-only $cutoverVersion; safety phases=$($requiredPhases -join ', '))" |
-    Add-Content $summaryPath -Encoding UTF8
 } finally {
   if ($null -ne $serverJob) {
     New-Item -ItemType File -Path $stopPath -Force | Out-Null

--- a/scripts/scan_v4_defender_exact.ps1
+++ b/scripts/scan_v4_defender_exact.ps1
@@ -1,0 +1,95 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Artifact,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Evidence
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    throw "V4 exact Defender scan failed closed: $Message"
+}
+
+$resolvedArtifact = (Resolve-Path -LiteralPath $Artifact -ErrorAction Stop).Path
+$artifactItem = Get-Item -LiteralPath $resolvedArtifact -ErrorAction Stop
+if ($artifactItem.PSIsContainer -or $artifactItem.Extension.ToLowerInvariant() -ne ".exe") {
+    Fail "the exact downloaded artifact must be one regular installer PE"
+}
+
+$statusCommand = Get-Command Get-MpComputerStatus -ErrorAction SilentlyContinue
+$scanCommand = Get-Command Start-MpScan -ErrorAction SilentlyContinue
+$detectionsCommand = Get-Command Get-MpThreatDetection -ErrorAction SilentlyContinue
+if ($null -eq $statusCommand -or $null -eq $scanCommand -or $null -eq $detectionsCommand) {
+    Fail "Windows Defender status, custom-scan, and detection cmdlets are required"
+}
+
+try {
+    $status = & $statusCommand.Name -ErrorAction Stop
+    if (-not [bool]$status.AntivirusEnabled -or -not [bool]$status.RealTimeProtectionEnabled) {
+        Fail "Windows Defender antivirus and real-time protection must be enabled"
+    }
+
+    $beforeHash = (Get-FileHash -LiteralPath $resolvedArtifact -Algorithm SHA256).Hash.ToLowerInvariant()
+    $scanStarted = [DateTime]::UtcNow
+    & $scanCommand.Name -ScanType CustomScan -ScanPath $resolvedArtifact -ErrorAction Stop | Out-Null
+    $scanCompleted = [DateTime]::UtcNow
+    if (-not (Test-Path -LiteralPath $resolvedArtifact -PathType Leaf)) {
+        Fail "Defender removed or quarantined the exact downloaded installer"
+    }
+    $afterHash = (Get-FileHash -LiteralPath $resolvedArtifact -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($afterHash -ne $beforeHash) {
+        Fail "the exact downloaded installer changed during Defender scanning"
+    }
+
+    $artifactFullPath = [IO.Path]::GetFullPath($resolvedArtifact)
+    $detections = @(
+        & $detectionsCommand.Name -ErrorAction Stop |
+            Where-Object {
+                $_.InitialDetectionTime -and
+                $_.InitialDetectionTime.ToUniversalTime() -ge $scanStarted.AddSeconds(-2) -and
+                (@($_.Resources | ForEach-Object { [string]$_ }) -join "`n") -match [regex]::Escape($artifactFullPath)
+            } |
+            ForEach-Object {
+                [ordered]@{
+                    initial_detection_time = $_.InitialDetectionTime.ToUniversalTime().ToString("o")
+                    threat_id = $_.ThreatID
+                    threat_name = $_.ThreatName
+                    action_success = $_.ActionSuccess
+                    resource_count = @($_.Resources).Count
+                }
+            }
+    )
+    if ($detections.Count -ne 0) {
+        Fail "Defender detected a threat in the exact downloaded installer"
+    }
+
+    $parent = Split-Path -Parent $Evidence
+    if ([string]::IsNullOrWhiteSpace($parent)) { Fail "Defender evidence requires a parent directory" }
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    [ordered]@{
+        schema_version = 1
+        evidence_type = "v4-defender-exact-artifact-scan"
+        artifact = $artifactItem.Name
+        artifact_size = [int64]$artifactItem.Length
+        artifact_sha256 = $beforeHash
+        scan_performed = $true
+        scan_type = "CustomScan"
+        scan_started_utc = $scanStarted.ToString("o")
+        scan_completed_utc = $scanCompleted.ToString("o")
+        detection_result = "none"
+        detection_count = 0
+        detections = @()
+        antivirus_enabled = [bool]$status.AntivirusEnabled
+        realtime_protection_enabled = [bool]$status.RealTimeProtectionEnabled
+        unavailable = $false
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Evidence -Encoding utf8
+    Write-Host "V4 exact Defender scan: PASS (artifact=$($artifactItem.Name); detection_result=none)"
+}
+catch {
+    if ($_.Exception.Message -like "V4 exact Defender scan failed closed:*") { throw }
+    Fail "status, custom scan, or detection query was unavailable"
+}

--- a/scripts/test_v4_release_authority_rehearsal.ps1
+++ b/scripts/test_v4_release_authority_rehearsal.ps1
@@ -1,0 +1,153 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [switch]$ConfirmDisposable,
+
+    [string]$AuthorityTokenEnv = "V4_RELEASE_AUTHORITY_TOKEN"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if (-not $ConfirmDisposable) {
+    throw "Authority rehearsal requires -ConfirmDisposable and creates only a uniquely tagged draft that is deleted before exit"
+}
+
+$authorityRepository = "pumni/Sky-Auto-Player-Releases"
+$token = [Environment]::GetEnvironmentVariable($AuthorityTokenEnv, "Process")
+if ([string]::IsNullOrWhiteSpace($token)) {
+    throw "Authority rehearsal requires the bounded authority token environment variable"
+}
+
+$rehearsalRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-authority-rehearsal-" + [guid]::NewGuid().ToString("N"))
+$artifactName = "v4-authority-upload-rehearsal-" + [guid]::NewGuid().ToString("N") + ".txt"
+$artifactPath = Join-Path $rehearsalRoot $artifactName
+$downloadPath = Join-Path $rehearsalRoot "downloaded.txt"
+$errorPath = Join-Path $rehearsalRoot "gh-error.log"
+$tag = "v4-authority-rehearsal-" + [guid]::NewGuid().ToString("N")
+$releaseId = $null
+$oldGhToken = [Environment]::GetEnvironmentVariable("GH_TOKEN", "Process")
+$failure = $null
+
+function Invoke-AuthorityApi {
+    param(
+        [Parameter(Mandatory = $true)] [string[]]$Arguments,
+        [switch]$BinaryOutput,
+        [switch]$AllowNotFound,
+        [switch]$NoJson,
+        [string]$OutputPath
+    )
+    try {
+        [Environment]::SetEnvironmentVariable("GH_TOKEN", $token, "Process")
+        if ($BinaryOutput) {
+            & gh @Arguments --output $OutputPath 2>$errorPath | Out-Null
+        } else {
+            $result = & gh @Arguments 2>$errorPath
+        }
+        $exitCode = $LASTEXITCODE
+    } finally {
+        if ($null -eq $oldGhToken) {
+            [Environment]::SetEnvironmentVariable("GH_TOKEN", $null, "Process")
+        } else {
+            [Environment]::SetEnvironmentVariable("GH_TOKEN", $oldGhToken, "Process")
+        }
+    }
+    if ($exitCode -ne 0) {
+        $errorText = if (Test-Path -LiteralPath $errorPath) { Get-Content -LiteralPath $errorPath -Raw } else { "" }
+        if ($AllowNotFound -and $errorText -match '(?i)(404|not found)') { return $null }
+        throw "release authority rehearsal API request failed"
+    }
+    if ($BinaryOutput) { return $null }
+    if ($NoJson) { return ($result -join "`n") }
+    return (($result -join "`n") | ConvertFrom-Json)
+}
+
+try {
+    New-Item -ItemType Directory -Path $rehearsalRoot -Force | Out-Null
+    [IO.File]::WriteAllText(
+        $artifactPath,
+        "throwaway v4 authority upload rehearsal $([guid]::NewGuid().ToString('N'))`n",
+        [Text.UTF8Encoding]::new($false)
+    )
+    $expectedHash = (Get-FileHash -LiteralPath $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $expectedSize = (Get-Item -LiteralPath $artifactPath).Length
+
+    $policy = Invoke-AuthorityApi -Arguments @(
+        "api", "repos/$authorityRepository/immutable-releases"
+    )
+    if (-not [bool]$policy.enabled) {
+        throw "release authority immutable-releases policy is not enabled"
+    }
+
+    $releasePayload = Join-Path $rehearsalRoot "release.json"
+    [ordered]@{
+        tag_name = $tag
+        target_commitish = "main"
+        name = "V4 authority upload rehearsal $tag"
+        body = "Disposable API rehearsal only; this draft is deleted before the script exits."
+        draft = $true
+        prerelease = $true
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $releasePayload -Encoding utf8
+    $release = Invoke-AuthorityApi -Arguments @(
+        "api", "--method", "POST", "repos/$authorityRepository/releases", "--input", $releasePayload
+    )
+            $releaseId = [int64]$release.id
+    if (-not $release.draft -or [string]$release.tag_name -ne $tag) {
+        throw "authority rehearsal did not create the expected draft"
+    }
+    $uploadUrl = ([string]$release.upload_url) -replace '\{\?name,label\}$', ''
+    if ($uploadUrl -notmatch '^https://uploads\.github\.com/repos/[^/]+/[^/]+/releases/\d+/assets$') {
+        throw "authority rehearsal did not receive the release-specific upload_url"
+    }
+    $uploaded = Invoke-AuthorityApi -Arguments @(
+        "api", "--method", "POST", "$uploadUrl?name=$([Uri]::EscapeDataString($artifactName))",
+        "--header", "Content-Type: text/plain", "--input", $artifactPath
+    )
+    if ([string]$uploaded.name -ne $artifactName -or [int64]$uploaded.size -ne [int64]$expectedSize) {
+        throw "authority rehearsal upload response did not preserve the exact asset identity"
+    }
+
+    $rehearsed = Invoke-AuthorityApi -Arguments @(
+        "api", "repos/$authorityRepository/releases/$releaseId"
+    )
+    $asset = @($rehearsed.assets | Where-Object { [string]$_.name -eq $artifactName })
+    if ($asset.Count -ne 1) { throw "authority rehearsal draft asset was not found" }
+    Invoke-AuthorityApi -Arguments @(
+        "api", [string]$asset[0].url, "--header", "Accept: application/octet-stream"
+    ) -BinaryOutput -OutputPath $downloadPath
+    if ((Get-Item -LiteralPath $downloadPath).Length -ne $expectedSize -or
+        (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant() -ne $expectedHash) {
+        throw "authority rehearsal downloaded bytes did not match the throwaway upload"
+    }
+}
+catch {
+    $failure = $_
+}
+finally {
+    try {
+        if ($null -ne $releaseId) {
+            Invoke-AuthorityApi -Arguments @(
+                "api", "--method", "DELETE", "repos/$authorityRepository/releases/$releaseId"
+            ) -NoJson | Out-Null
+        }
+        Invoke-AuthorityApi -Arguments @(
+            "api", "--method", "DELETE", "repos/$authorityRepository/git/refs/tags/$tag"
+        ) -AllowNotFound -NoJson | Out-Null
+    }
+    catch {
+        if ($null -eq $failure) { $failure = $_ }
+    }
+    if ($null -eq $oldGhToken) {
+        [Environment]::SetEnvironmentVariable("GH_TOKEN", $null, "Process")
+    } else {
+        [Environment]::SetEnvironmentVariable("GH_TOKEN", $oldGhToken, "Process")
+    }
+    if (Test-Path -LiteralPath $rehearsalRoot) {
+        Remove-Item -LiteralPath $rehearsalRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($null -ne $failure) {
+    throw "V4 release authority rehearsal failed closed; disposable cleanup was attempted"
+}
+Write-Host "V4 release authority upload rehearsal: PASS (draft upload/download exact bytes; draft and tag deleted)"

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -22,7 +22,10 @@ foreach ($marker in @(
     'metadata promotion is forbidden before immutable publication',
     'authority already contains tag', 'existing releases are never moved or replaced',
     'Get-FileHash', 'verify-signature', 'sbom', 'verify-tauri-bundle',
-    'current-user', 'active-playback-install-rejected'
+    'current-user', 'active-playback-install-rejected', 'upload_url',
+    'immutable-releases', 'Assert-ImmutableRelease', 'Start-MpScan',
+    'previous-v4-to-exact-downloaded-candidate-update',
+    'selftest-update-active-playback', 'scan_performed'
 )) {
     if (-not $pipeline.Contains($marker)) { Fail "pipeline marker is missing: $marker" }
 }
@@ -31,6 +34,7 @@ foreach ($marker in @(
     'workflow_dispatch:',
     'runs-on: [self-hosted, windows, v4-release, single-tenant]',
     'contents: read', 'id-token: write', 'attestations: write',
+    'actions/upload-artifact@',
     'V4_RELEASE_AUTHORITY_TOKEN',
     'ref: ${{ inputs.source_sha }}',
     'persist-credentials: false',
@@ -55,7 +59,11 @@ class MockReleaseApi {
     [bool]$Qualified = $false
     [bool]$Attested = $false
     [bool]$Published = $false
+    [bool]$immutable = $false
     [bool]$Promoted = $false
+    [bool]$UploadedThroughReleaseUrl = $false
+    [string]$UploadUrl = ""
+    [bool]$ExactDownloadedBytes = $false
 
     [void] BuildCandidate() {
         if ($this.BuildCount -ne 0) { throw "candidate rebuilt" }
@@ -64,19 +72,29 @@ class MockReleaseApi {
     [void] CreateDraft() {
         if ($this.BuildCount -ne 1 -or $this.Draft) { throw "draft ordering violation" }
         $this.Draft = $true
+        $this.UploadedThroughReleaseUrl = $true
+        $this.UploadUrl = "https://uploads.github.com/repos/pumni/Sky-Auto-Player-Releases/releases/42/assets"
+    }
+    [void] AssertExactDraftUpload() {
+        if (-not $this.Draft -or -not $this.UploadedThroughReleaseUrl -or
+            $this.UploadUrl -notmatch '^https://uploads\.github\.com/.+/assets$') {
+            throw "release-specific upload_url was not used"
+        }
     }
     [void] DownloadDraft() {
         if (-not $this.Draft -or $this.Published) { throw "download ordering violation" }
         $this.Downloaded = $true
+        $this.ExactDownloadedBytes = $true
     }
     [void] QualifyDownloaded() {
-        if (-not $this.Downloaded) { throw "qualification did not use downloaded bytes" }
+        if (-not $this.Downloaded -or -not $this.ExactDownloadedBytes) { throw "qualification did not use downloaded bytes" }
         $this.Qualified = $true
     }
     [void] PublishDraft() {
         if (-not $this.Qualified -or -not $this.Attested -or $this.Published) { throw "publication ordering violation" }
         $this.Draft = $false
         $this.Published = $true
+        $this.immutable = $true
     }
     [void] PromoteMetadata() {
         if (-not $this.Published) { throw "promotion before immutable publication" }
@@ -87,6 +105,7 @@ class MockReleaseApi {
 $mock = [MockReleaseApi]::new()
 $mock.BuildCandidate()
 $mock.CreateDraft()
+$mock.AssertExactDraftUpload()
 $mock.DownloadDraft()
 $mock.QualifyDownloaded()
 try {
@@ -98,7 +117,7 @@ try {
 $mock.Attested = $true
 $mock.PublishDraft()
 $mock.PromoteMetadata()
-if ($mock.BuildCount -ne 1 -or -not $mock.Promoted -or $mock.Draft -or -not $mock.Published) {
+if ($mock.BuildCount -ne 1 -or -not $mock.Promoted -or $mock.Draft -or -not $mock.Published -or -not $mock.immutable -or -not $mock.UploadedThroughReleaseUrl -or -not $mock.ExactDownloadedBytes) {
     Fail "mock state machine did not preserve build-once/publication ordering"
 }
 

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -1,0 +1,105 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$pipelinePath = Join-Path $PSScriptRoot "v4_release_pipeline.ps1"
+$workflowPath = Join-Path $repoRoot ".github/workflows/release-v4.yml"
+$pipeline = Get-Content -LiteralPath $pipelinePath -Raw
+$workflow = Get-Content -LiteralPath $workflowPath -Raw
+
+function Fail([string]$Message) { throw "FAILED: $Message" }
+
+if (([regex]::Matches($pipeline, "orchestrate_v4_production_release\.ps1")).Count -ne 1) {
+    Fail "production orchestrator must have exactly one call site"
+}
+foreach ($marker in @(
+    'ValidateRequest', 'ValidateAuthority', 'BuildCandidate', 'CreateDraft',
+    'DownloadDraft', 'QualifyDownloaded', 'RecordAttestations', 'PublishDraft',
+    'PromoteMetadata', 'FinalVerify', 'unsigned-zero-budget',
+    'metadata promotion is forbidden before immutable publication',
+    'authority already contains tag', 'existing releases are never moved or replaced',
+    'Get-FileHash', 'verify-signature', 'sbom', 'verify-tauri-bundle',
+    'current-user', 'active-playback-install-rejected'
+)) {
+    if (-not $pipeline.Contains($marker)) { Fail "pipeline marker is missing: $marker" }
+}
+
+foreach ($marker in @(
+    'workflow_dispatch:',
+    'runs-on: [self-hosted, windows, v4-release, single-tenant]',
+    'contents: read', 'id-token: write', 'attestations: write',
+    'V4_RELEASE_AUTHORITY_TOKEN',
+    'ref: ${{ inputs.source_sha }}',
+    'persist-credentials: false',
+    'actions/attest@',
+    '--source-digest $env:GITHUB_SHA',
+    'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
+)) {
+    if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }
+}
+foreach ($forbidden in @(
+    'cargo xtask dist', 'Sky-Auto-Player-Updater.exe', 'MANIFEST.json.sig',
+    'softprops/action-gh-release', 'secrets.TAURI_SIGNING_PRIVATE_KEY',
+    'secrets.UPDATER_PRIVATE_KEY', 'secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD'
+)) {
+    if ($workflow.Contains($forbidden)) { Fail "forbidden production workflow marker remains: $forbidden" }
+}
+
+class MockReleaseApi {
+    [int]$BuildCount = 0
+    [bool]$Draft = $false
+    [bool]$Downloaded = $false
+    [bool]$Qualified = $false
+    [bool]$Attested = $false
+    [bool]$Published = $false
+    [bool]$Promoted = $false
+
+    [void] BuildCandidate() {
+        if ($this.BuildCount -ne 0) { throw "candidate rebuilt" }
+        $this.BuildCount++
+    }
+    [void] CreateDraft() {
+        if ($this.BuildCount -ne 1 -or $this.Draft) { throw "draft ordering violation" }
+        $this.Draft = $true
+    }
+    [void] DownloadDraft() {
+        if (-not $this.Draft -or $this.Published) { throw "download ordering violation" }
+        $this.Downloaded = $true
+    }
+    [void] QualifyDownloaded() {
+        if (-not $this.Downloaded) { throw "qualification did not use downloaded bytes" }
+        $this.Qualified = $true
+    }
+    [void] PublishDraft() {
+        if (-not $this.Qualified -or -not $this.Attested -or $this.Published) { throw "publication ordering violation" }
+        $this.Draft = $false
+        $this.Published = $true
+    }
+    [void] PromoteMetadata() {
+        if (-not $this.Published) { throw "promotion before immutable publication" }
+        $this.Promoted = $true
+    }
+}
+
+$mock = [MockReleaseApi]::new()
+$mock.BuildCandidate()
+$mock.CreateDraft()
+$mock.DownloadDraft()
+$mock.QualifyDownloaded()
+try {
+    $mock.PromoteMetadata()
+    Fail "mock promotion before publication was accepted"
+} catch {
+    if ($_.Exception.Message -notmatch "promotion before immutable publication") { throw }
+}
+$mock.Attested = $true
+$mock.PublishDraft()
+$mock.PromoteMetadata()
+if ($mock.BuildCount -ne 1 -or -not $mock.Promoted -or $mock.Draft -or -not $mock.Published) {
+    Fail "mock state machine did not preserve build-once/publication ordering"
+}
+
+Write-Host "V4 release pipeline contract/self-test: PASS (mock draft/download/qualify/attest/publish/promote; build count=1)"

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -203,7 +203,11 @@ function Assert-AuthorityMain {
         Fail "release authority main is not initialized; run a separately reviewed authority bootstrap before production release"
     }
     if ([string]$main.ref -ne "refs/heads/main") { Fail "release authority main ref is not canonical" }
-    Write-Host "V4 release authority bootstrap precondition: PASS (main exists)"
+    $immutable = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/immutable-releases") -AllowNotFound
+    if ($null -eq $immutable -or -not [bool]$immutable.enabled) {
+        Fail "release authority immutable-releases policy is not enabled; enable it before any production transaction"
+    }
+    Write-Host "V4 release authority preconditions: PASS (main exists; immutable releases enabled)"
 }
 
 function Get-ExpectedInstallerName {
@@ -362,15 +366,29 @@ function Invoke-CreateDraft {
     })
     $release = Invoke-AuthorityApi -Arguments @("api", "--method", "POST", "repos/$authorityRepository/releases", "--input", $payloadPath)
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "authority did not create the requested draft release" }
+    $uploadUrl = [string]$release.upload_url
+    if ([string]::IsNullOrWhiteSpace($uploadUrl)) { Fail "authority draft did not return its release-specific upload_url" }
+    $uploadUrl = $uploadUrl -replace '\{\?name,label\}$', ''
+    if ($uploadUrl -notmatch '^https://uploads\.github\.com/repos/[^/]+/[^/]+/releases/\d+/assets$') {
+        Fail "authority draft returned an unexpected release asset upload_url"
+    }
 
     foreach ($record in $manifest.assets) {
         $candidate = (Get-CandidateRecords | Where-Object { $_.name -eq [string]$record.name })
         if ($null -eq $candidate) { Fail "candidate manifest contains an unknown asset" }
-        Invoke-AuthorityApi -Arguments @(
-            "api", "--method", "POST",
-            "repos/$authorityRepository/releases/$($release.id)/assets?name=$([Uri]::EscapeDataString([string]$record.name))",
+        $assetUrl = "$uploadUrl?name=$([Uri]::EscapeDataString([string]$record.name))"
+        # GitHub's release-specific upload_url is deliberately used here. The
+        # endpoint rejects duplicate names; this path never deletes or
+        # replaces an asset after a failed upload.
+        $uploaded = Invoke-AuthorityApi -Arguments @(
+            "api", "--method", "POST", $assetUrl,
             "--header", "Content-Type: application/octet-stream", "--input", $candidate.path
-        ) | Out-Null
+        )
+        if ([string]$uploaded.name -ne [string]$record.name -or
+            [int64]$uploaded.size -ne [int64]$record.size -or
+            [string]$uploaded.state -ne "uploaded") {
+            Fail "authority upload did not return the exact uploaded asset: $($record.name)"
+        }
     }
     $state = [ordered]@{
         schema_version = 1
@@ -381,6 +399,7 @@ function Invoke-CreateDraft {
         release_id = [int64]$release.id
         draft = $true
         published = $false
+        immutable = $false
         attested = $false
         qualified_after_download = $false
         assets = $manifest.assets
@@ -393,6 +412,12 @@ function Assert-ExactAssetSet([object]$Release, [object[]]$Expected) {
     $actual = @($Release.assets | ForEach-Object { [string]$_.name } | Sort-Object)
     $expectedNames = @($Expected | ForEach-Object { [string]$_.name } | Sort-Object)
     if (($actual -join "`n") -ne ($expectedNames -join "`n")) { Fail "authority release asset set differs from the qualified candidate set" }
+}
+
+function Assert-ImmutableRelease([object]$Release) {
+    if ($null -eq $Release.immutable -or -not [bool]$Release.immutable) {
+        Fail "authority release is not marked immutable"
+    }
 }
 
 function Invoke-DownloadDraft {
@@ -473,27 +498,44 @@ function Invoke-QualifyDownloaded {
         "-ValidateEvidence", (Join-Path $downloaded $qualificationEvidenceName)
     ) "downloaded candidate qualification evidence schema validation failed"
 
-    $defenderEvidence = [ordered]@{
-        schema_version = 1
-        evidence_type = "v4-defender-status"
-        status = "unavailable"
-        deterministic = $false
+    # Export the canonical public root through the existing updater-trust
+    # authority, then run the real previous-v4 bridge against the exact
+    # installer and signature downloaded from the draft. The fixture builds
+    # only its throwaway previous client; it never rebuilds the candidate.
+    $canonicalPublicKey = Join-Path $root "canonical-updater-public-key.txt"
+    Invoke-Checked "cargo" @(
+        "xtask", "updater-trust", "export-public-key", "--output", $canonicalPublicKey
+    ) "canonical updater public-root export failed"
+    $fixtureBundle = Join-Path $root "previous-v4-fixture"
+    Invoke-Checked "pwsh" @(
+        "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+        "-File", (Join-Path $PSScriptRoot "ci_tauri_update_e2e.ps1"),
+        "-BundleDir", $fixtureBundle,
+        "-CandidateInstallerPath", (Join-Path $downloaded $installer),
+        "-CandidateSignaturePath", (Join-Path $downloaded "$installer.sig"),
+        "-CandidateVersion", $Version,
+        "-CandidatePublicKeyPath", $canonicalPublicKey
+    ) "exact downloaded previous-v4 to candidate-v4 updater qualification failed"
+
+    # Production policy requires a deterministic exact-artifact Defender
+    # custom scan on the downloaded installer. scan_v4_defender_exact.ps1
+    # invokes Start-MpScan and records scan_performed; missing Defender or a
+    # scan failure is a release failure, not an accepted unavailable result.
+    $defenderEvidencePath = Join-Path $root "defender-evidence.json"
+    Invoke-Checked "pwsh" @(
+        "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+        "-File", (Join-Path $PSScriptRoot "scan_v4_defender_exact.ps1"),
+        "-Artifact", (Join-Path $downloaded $installer),
+        "-Evidence", $defenderEvidencePath
+    ) "exact downloaded installer Defender scan failed"
+    $defenderEvidence = Read-JsonFile $defenderEvidencePath
+    $installerRecord = @($state.assets | Where-Object { [string]$_.name -eq $installer })
+    if (-not [bool]$defenderEvidence.scan_performed -or
+        [string]$defenderEvidence.detection_result -ne "none" -or
+        $installerRecord.Count -ne 1 -or
+        [string]$defenderEvidence.artifact_sha256 -ne [string]$installerRecord[0].sha256) {
+        Fail "Defender evidence did not bind a clean scan to the exact downloaded installer"
     }
-    $defenderCommand = Get-Command Get-MpComputerStatus -ErrorAction SilentlyContinue
-    if ($null -ne $defenderCommand) {
-        try {
-            $defenderStatus = & $defenderCommand.Source
-            $defenderEvidence.status = "observed"
-            $defenderEvidence.deterministic = $true
-            $defenderEvidence.real_time_protection_enabled = [bool]$defenderStatus.RealTimeProtectionEnabled
-            $defenderEvidence.antivirus_enabled = [bool]$defenderStatus.AntivirusEnabled
-        } catch {
-            # Defender availability is recorded explicitly; it never changes
-            # the mandatory byte, updater-signature, SBOM, or provenance gates.
-            $defenderEvidence.status = "unavailable"
-        }
-    }
-    Write-JsonFile (Join-Path $root "defender-evidence.json") $defenderEvidence
 
     # Reuse the production current-user smoke shape against the downloaded
     # installer. The packaged shell self-test exercises GUI/native command
@@ -521,6 +563,8 @@ function Invoke-QualifyDownloaded {
             "-File", (Join-Path $PSScriptRoot "verify_v4_authenticode.ps1"),
             "-Mode", "unsigned-zero-budget", "-Artifact" , $installedPe.FullName
         ) "downloaded candidate installed PE state is not unsigned-zero-budget"
+        $activity = Start-Process -FilePath $app -ArgumentList @("--selftest-update-active-playback") -WindowStyle Hidden -Wait -PassThru
+        if ($activity.ExitCode -ne 0) { Fail "downloaded candidate packaged playback-active update rejection self-test failed" }
         $shell = Start-Process -FilePath $app -ArgumentList @("--selftest-desktop-shell") -WindowStyle Hidden -Wait -PassThru
         if ($shell.ExitCode -ne 0) { Fail "downloaded candidate packaged shell self-test failed" }
         $gui = Start-Process -FilePath $app -ArgumentList @("--selftest-desktop-gui") -WindowStyle Hidden -Wait -PassThru
@@ -550,11 +594,12 @@ function Invoke-QualifyDownloaded {
         qualification = @(
             "fresh-current-user-no-admin-install",
             "gui-input-safety",
+            "previous-v4-to-exact-downloaded-candidate-update",
             "official-tauri-updater-signature",
-            "active-playback-install-rejected",
+            "active-playback-install-rejected-packaged",
             "uninstall",
             "reinstall-preserves-external-app-data",
-            "defender-status-observed-or-explicitly-unavailable",
+            "defender-exact-download-scan-no-detection",
             "spdx-sbom",
             "exact-asset-digest"
         )
@@ -583,8 +628,10 @@ function Invoke-PublishDraft {
     Write-JsonFile $patchPath ([ordered]@{ draft = $false })
     $published = Invoke-AuthorityApi -Arguments @("api", "--method", "PATCH", "repos/$authorityRepository/releases/$($state.release_id)", "--input", $patchPath)
     if ($published.draft -or [string]::IsNullOrWhiteSpace([string]$published.published_at)) { Fail "authority did not publish the already-qualified draft" }
+    Assert-ImmutableRelease $published
     $state.draft = $false
     $state.published = $true
+    $state.immutable = $true
     Write-JsonFile (Get-StatePath) $state
     Write-Host "V4 immutable publication: PASS (assets were not replaced or rebuilt)"
 }
@@ -652,6 +699,7 @@ function Invoke-FinalVerify {
     if (-not $state.published) { Fail "final verification requires a published release" }
     $release = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/releases/tags/$Tag")
     if ($release.draft -or [string]::IsNullOrWhiteSpace([string]$release.published_at)) { Fail "final release is still draft or unpublished" }
+    Assert-ImmutableRelease $release
     Assert-ExactAssetSet $release $state.assets
     foreach ($expected in $state.assets) {
         $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -1,0 +1,732 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet(
+        "ValidateRequest",
+        "ValidateAuthority",
+        "BuildCandidate",
+        "CreateDraft",
+        "DownloadDraft",
+        "QualifyDownloaded",
+        "RecordAttestations",
+        "PublishDraft",
+        "PromoteMetadata",
+        "FinalVerify",
+        "SelfTest"
+    )]
+    [string]$State,
+
+    [string]$Version,
+    [ValidateSet("stable", "beta")]
+    [string]$Channel,
+    [string]$Tag,
+    [string]$SourceSha,
+    [string]$WorkflowSha,
+    [string]$StateRoot,
+    [string]$UpdaterPrivateKeyPath,
+    [string]$UpdaterPasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
+    [string]$ReleaseNotesPath,
+    [string]$PublicationDateUtc,
+    [string]$AuthorityTokenEnv = "V4_RELEASE_AUTHORITY_TOKEN"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$authorityRepository = "pumni/Sky-Auto-Player-Releases"
+$sourceRepository = "pumni/Sky-Auto-Player"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$installerSuffix = "_x64-setup.exe"
+$productionEvidenceName = "V4_PRODUCTION_RELEASE_EVIDENCE.json"
+$qualificationEvidenceName = "V4_QUALIFICATION_EVIDENCE.json"
+$authenticodeEvidenceName = "TAURI_AUTHENTICODE_EVIDENCE.json"
+$installedAuthenticodeEvidenceName = "INSTALLED_AUTHENTICODE_EVIDENCE.json"
+$summaryName = "TAURI_ARTIFACT_SUMMARY.json"
+$sbomName = "SBOM.spdx.json"
+
+function Fail([string]$Message) {
+    throw "V4 release pipeline failed closed: $Message"
+}
+
+function Get-EffectiveStateRoot {
+    if ([string]::IsNullOrWhiteSpace($StateRoot)) { Fail "StateRoot is required" }
+    $full = [IO.Path]::GetFullPath($StateRoot)
+    $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if ($full.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "StateRoot must be outside the repository workspace"
+    }
+    New-Item -ItemType Directory -Path $full -Force | Out-Null
+    return $full
+}
+
+function Get-StatePath {
+    return Join-Path (Get-EffectiveStateRoot) "release-state.json"
+}
+
+function Write-JsonFile([string]$Path, [object]$Value) {
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $json = $Value | ConvertTo-Json -Depth 20
+    [IO.File]::WriteAllText($Path, $json + "`n", [Text.UTF8Encoding]::new($false))
+}
+
+function Read-JsonFile([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { Fail "Required state file is missing: $Path" }
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Assert-RequestIdentity {
+    if ([string]::IsNullOrWhiteSpace($Version)) { Fail "version is required" }
+    if ([string]::IsNullOrWhiteSpace($Channel) -or $Channel -notin @("stable", "beta")) {
+        Fail "channel must be stable or beta"
+    }
+    if ([string]::IsNullOrWhiteSpace($Tag) -or $Tag -ne "v$Version") {
+        Fail "tag must exactly equal v<version>"
+    }
+    if ($Version -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+        Fail "version is not canonical SemVer without build metadata"
+    }
+    $isPrerelease = $Version.Contains("-")
+    if ($Channel -eq "stable" -and $isPrerelease) { Fail "stable releases must use final SemVer" }
+    if ($Channel -eq "beta" -and -not $isPrerelease) { Fail "beta releases must use a SemVer prerelease" }
+    if (-not [string]::IsNullOrWhiteSpace($PublicationDateUtc)) {
+        if ($PublicationDateUtc -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$') {
+            Fail "publication date must be second-precision UTC RFC3339"
+        }
+        try {
+            [DateTimeOffset]::ParseExact(
+                $PublicationDateUtc,
+                "yyyy-MM-dd'T'HH:mm:ss'Z'",
+                [Globalization.CultureInfo]::InvariantCulture,
+                [Globalization.DateTimeStyles]::AssumeUniversal
+            ) | Out-Null
+        } catch {
+            Fail "publication date is not a valid UTC timestamp"
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($SourceSha) -or $SourceSha -notmatch '^[0-9a-fA-F]{40}$') {
+        Fail "source_sha must be an exact 40-character commit SHA"
+    }
+
+    $currentHead = (& git rev-parse HEAD 2>$null).Trim().ToLowerInvariant()
+    if ($LASTEXITCODE -ne 0 -or $currentHead -ne $SourceSha.ToLowerInvariant()) {
+        Fail "checked-out HEAD does not equal the requested source SHA"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($WorkflowSha) -and
+        $WorkflowSha -notmatch '^[0-9a-fA-F]{40}$') {
+        Fail "workflow SHA must be an exact commit SHA"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($WorkflowSha) -and
+        $WorkflowSha.ToLowerInvariant() -ne $SourceSha.ToLowerInvariant()) {
+        Fail "source SHA differs from the workflow SHA used for OIDC provenance"
+    }
+
+    $cargoPath = Join-Path $repoRoot "desktop/src-tauri/Cargo.toml"
+    $cargo = Get-Content -LiteralPath $cargoPath -Raw
+    if ($cargo -notmatch '(?m)^version\s*=\s*"([^"]+)"') { Fail "Cargo package version is missing" }
+    if ($Matches[1] -ne $Version) { Fail "Cargo/Tauri package version does not equal requested version" }
+
+    & cargo xtask version check --tag $Tag *> (Join-Path (Get-EffectiveStateRoot) "version-check.log")
+    if ($LASTEXITCODE -ne 0) { Fail "canonical cargo xtask version/tag validation failed" }
+    Write-Host "V4 release identity: PASS (version=$Version, channel=$Channel, source=$($SourceSha.ToLowerInvariant()))"
+}
+
+function Assert-ReleaseNotes {
+    if ([string]::IsNullOrWhiteSpace($ReleaseNotesPath)) { Fail "release notes path is required" }
+    $resolved = (Resolve-Path -LiteralPath $ReleaseNotesPath -ErrorAction Stop).Path
+    $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if (-not $resolved.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "release notes must be inside the checked-out source workspace"
+    }
+    if ((Get-Item -LiteralPath $resolved).Length -gt 16384) { Fail "release notes exceed the bounded limit" }
+    return $resolved
+}
+
+function Get-AuthorityToken {
+    $token = [Environment]::GetEnvironmentVariable($AuthorityTokenEnv, "Process")
+    if ([string]::IsNullOrWhiteSpace($token)) { Fail "authority token environment variable is unavailable" }
+    return $token
+}
+
+function Invoke-WithAuthorityToken([scriptblock]$Action) {
+    $token = Get-AuthorityToken
+    $oldGhToken = [Environment]::GetEnvironmentVariable("GH_TOKEN", "Process")
+    try {
+        [Environment]::SetEnvironmentVariable("GH_TOKEN", $token, "Process")
+        & $Action
+    } finally {
+        if ($null -eq $oldGhToken) {
+            [Environment]::SetEnvironmentVariable("GH_TOKEN", $null, "Process")
+        } else {
+            [Environment]::SetEnvironmentVariable("GH_TOKEN", $oldGhToken, "Process")
+        }
+    }
+}
+
+function Invoke-AuthorityApi {
+    param(
+        [Parameter(Mandatory = $true)] [string[]]$Arguments,
+        [switch]$AllowNotFound,
+        [switch]$BinaryOutput,
+        [switch]$Raw,
+        [string]$OutputPath
+    )
+    $errorPath = Join-Path (Get-EffectiveStateRoot) ("gh-error-" + [guid]::NewGuid().ToString("N") + ".log")
+    try {
+        Invoke-WithAuthorityToken {
+            if ($BinaryOutput) {
+                & gh @Arguments --output $OutputPath 2>$errorPath | Out-Null
+            } else {
+                $script:authorityApiResult = & gh @Arguments 2>$errorPath
+            }
+            $script:authorityApiExitCode = $LASTEXITCODE
+        }
+        if ($authorityApiExitCode -ne 0) {
+            $errorText = if (Test-Path -LiteralPath $errorPath) { Get-Content -LiteralPath $errorPath -Raw } else { "" }
+            if ($AllowNotFound -and $errorText -match '(?i)(404|not found)') { return $null }
+            # Do not include the provider response: it is not needed for diagnosis and
+            # keeps credentials and server diagnostics out of the release log.
+            Fail "authority API request failed"
+        }
+        if ($BinaryOutput) { return $null }
+        if ($Raw) { return ($authorityApiResult -join "`n") }
+        return (($authorityApiResult -join "`n") | ConvertFrom-Json)
+    } finally {
+        Remove-Item -LiteralPath $errorPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-AuthorityMain {
+    $main = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/git/ref/heads/main") -AllowNotFound
+    if ($null -eq $main) {
+        Fail "release authority main is not initialized; run a separately reviewed authority bootstrap before production release"
+    }
+    if ([string]$main.ref -ne "refs/heads/main") { Fail "release authority main ref is not canonical" }
+    Write-Host "V4 release authority bootstrap precondition: PASS (main exists)"
+}
+
+function Get-ExpectedInstallerName {
+    return "Sky Auto Player_${Version}$installerSuffix"
+}
+
+function Get-CandidateRecords {
+    $installer = Get-ExpectedInstallerName
+    $bundle = Join-Path $repoRoot "rust/target/dist/bundle/nsis"
+    $evidence = Join-Path $repoRoot "rust/target/dist"
+    return @(
+        [pscustomobject]@{ name = $installer; path = Join-Path $bundle $installer; role = "installer" },
+        [pscustomobject]@{ name = "$installer.sig"; path = Join-Path $bundle "$installer.sig"; role = "updater-signature" },
+        [pscustomobject]@{ name = $qualificationEvidenceName; path = Join-Path $evidence $qualificationEvidenceName; role = "qualification-evidence" },
+        [pscustomobject]@{ name = $productionEvidenceName; path = Join-Path $evidence $productionEvidenceName; role = "production-evidence" },
+        [pscustomobject]@{ name = $authenticodeEvidenceName; path = Join-Path $evidence $authenticodeEvidenceName; role = "authenticode-evidence" },
+        [pscustomobject]@{ name = $installedAuthenticodeEvidenceName; path = Join-Path $evidence $installedAuthenticodeEvidenceName; role = "installed-authenticode-evidence" },
+        [pscustomobject]@{ name = $summaryName; path = Join-Path $evidence $summaryName; role = "artifact-summary" },
+        [pscustomobject]@{ name = $sbomName; path = Join-Path $evidence $sbomName; role = "sbom" }
+    )
+}
+
+function Get-FileRecord([object]$Candidate) {
+    if (-not (Test-Path -LiteralPath $Candidate.path -PathType Leaf)) { Fail "qualified candidate file is missing: $($Candidate.name)" }
+    $item = Get-Item -LiteralPath $Candidate.path
+    if ($item.Length -le 0) { Fail "qualified candidate file is empty: $($Candidate.name)" }
+    return [pscustomobject]@{
+        name = $Candidate.name
+        role = $Candidate.role
+        size = [int64]$item.Length
+        sha256 = (Get-FileHash -LiteralPath $Candidate.path -Algorithm SHA256).Hash.ToLowerInvariant()
+    }
+}
+
+function Assert-EvidenceIdentity([string]$ProductionPath, [string]$QualificationPath, [object[]]$Records) {
+    $recordsByName = @{}
+    foreach ($record in @($Records)) { $recordsByName[[string]$record.name] = $record }
+    foreach ($requiredName in @($productionEvidenceName, $qualificationEvidenceName, $authenticodeEvidenceName, $sbomName)) {
+        if (-not $recordsByName.ContainsKey($requiredName)) { Fail "candidate manifest is missing required identity record: $requiredName" }
+    }
+    $evidence = Get-Content -LiteralPath $ProductionPath -Raw | ConvertFrom-Json
+    $qualification = Get-Content -LiteralPath $QualificationPath -Raw | ConvertFrom-Json
+    if ([string]$evidence.source_sha -ne $SourceSha.ToLowerInvariant()) { Fail "production evidence source SHA mismatch" }
+    if ([string]$evidence.version -ne $Version -or [string]$evidence.channel -ne $Channel) { Fail "production evidence release identity mismatch" }
+    if ([string]$evidence.authenticode_mode -ne "unsigned-zero-budget" -or
+        [string]$evidence.authenticode_state -ne "unsigned" -or
+        [string]$evidence.authenticode_provider -ne "none" -or
+        $null -ne $evidence.approved_signer_thumbprint -or
+        $null -ne $evidence.observed_signer_thumbprint) {
+        Fail "production evidence is not the governed unsigned-zero-budget state"
+    }
+    if ([string]$evidence.updater_signature_status -ne "valid" -or [string]$evidence.qualification_status -ne "PASS") {
+        Fail "production evidence omitted a mandatory updater or qualification result"
+    }
+    if ([string]$evidence.installer -ne (Get-ExpectedInstallerName) -or
+        [string]$evidence.updater_signature -ne "$(Get-ExpectedInstallerName).sig" -or
+        [string]$evidence.authenticode_evidence -ne $authenticodeEvidenceName -or
+        [string]$evidence.sbom -ne $sbomName -or
+        [string]$evidence.installer -ne [string]$recordsByName[(Get-ExpectedInstallerName)].name -or
+        [int64]$evidence.installer_size -ne [int64]$recordsByName[(Get-ExpectedInstallerName)].size -or
+        [string]$evidence.installer_sha256 -ne [string]$recordsByName[(Get-ExpectedInstallerName)].sha256 -or
+        [int64]$evidence.signature_size -ne [int64]$recordsByName["$((Get-ExpectedInstallerName)).sig"].size -or
+        [string]$evidence.updater_signature_sha256 -ne [string]$recordsByName["$((Get-ExpectedInstallerName)).sig"].sha256 -or
+        [string]$evidence.authenticode_evidence_sha256 -ne [string]$recordsByName[$authenticodeEvidenceName].sha256 -or
+        [string]$evidence.sbom_sha256 -ne [string]$recordsByName[$sbomName].sha256) {
+        Fail "production evidence digests or sizes do not match the candidate manifest"
+    }
+    if ([string]$qualification.installer -ne (Get-ExpectedInstallerName) -or
+        [string]$qualification.updater_signature -ne "$(Get-ExpectedInstallerName).sig" -or
+        [string]$qualification.installer_sha256 -ne [string]$recordsByName[(Get-ExpectedInstallerName)].sha256 -or
+        [string]$qualification.updater_signature_sha256 -ne [string]$recordsByName["$((Get-ExpectedInstallerName)).sig"].sha256 -or
+        [string]$qualification.authenticode_mode -ne "unsigned-zero-budget" -or
+        [string]$qualification.sbom_sha256 -ne [string]$recordsByName[$sbomName].sha256) {
+        Fail "qualification evidence does not bind the exact candidate manifest"
+    }
+}
+
+function Assert-CandidateEvidence([object[]]$Records) {
+    Assert-EvidenceIdentity `
+        (Join-Path $repoRoot "rust/target/dist/$productionEvidenceName") `
+        (Join-Path $repoRoot "rust/target/dist/$qualificationEvidenceName") `
+        $Records
+}
+
+function Invoke-BuildCandidate {
+    Assert-RequestIdentity
+    if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) { Fail "updater private key path is required" }
+    if ([string]::IsNullOrWhiteSpace($UpdaterPasswordEnv)) { Fail "updater password environment variable name is required" }
+    $keyPath = (Resolve-Path -LiteralPath $UpdaterPrivateKeyPath -ErrorAction Stop).Path
+    $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if ($keyPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) { Fail "updater private key must remain outside workspace" }
+    if (-not (Test-Path -LiteralPath $keyPath -PathType Leaf)) { Fail "updater private key path is not a file" }
+    if (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY) -or
+        -not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
+        Fail "ambient updater key environment is forbidden"
+    }
+
+    # This is the only production candidate build boundary. The orchestrator
+    # owns key verification, stale purge, clean-worktree, NSIS, updater sig,
+    # unsigned-zero-budget, SBOM, and install smoke semantics.
+    & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
+        -ExpectedSourceSha $SourceSha `
+        -Version $Version `
+        -Channel $Channel `
+        -UpdaterPrivateKeyPath $keyPath `
+        -UpdaterPasswordEnv $UpdaterPasswordEnv
+    if ($LASTEXITCODE -ne 0) { Fail "production orchestrator failed" }
+
+    $records = @(Get-CandidateRecords | ForEach-Object { Get-FileRecord $_ })
+    Assert-CandidateEvidence $records
+    $manifest = [ordered]@{
+        schema_version = 1
+        source_sha = $SourceSha.ToLowerInvariant()
+        version = $Version
+        channel = $Channel
+        authenticode_mode = "unsigned-zero-budget"
+        assets = $records
+    }
+    Write-JsonFile (Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json") $manifest
+    Write-Host "V4 candidate build: PASS (one orchestrator invocation; exact candidate manifest recorded)"
+}
+
+function Get-State {
+    $state = Read-JsonFile (Get-StatePath)
+    if ([string]$state.source_sha -ne $SourceSha.ToLowerInvariant() -or
+        [string]$state.version -ne $Version -or [string]$state.channel -ne $Channel) {
+        Fail "state file release identity does not match this invocation"
+    }
+    return $state
+}
+
+function Assert-NoExistingAuthorityTag {
+    $release = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/releases/tags/$Tag") -AllowNotFound
+    if ($null -ne $release) { Fail "authority already contains release tag $Tag; existing releases are never moved or replaced" }
+    $ref = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/git/ref/tags/$Tag") -AllowNotFound
+    if ($null -ne $ref) { Fail "authority already contains tag $Tag; a new SemVer/RC is required" }
+}
+
+function Invoke-CreateDraft {
+    Assert-RequestIdentity
+    Assert-AuthorityMain
+    $manifestPath = Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json"
+    $manifest = Read-JsonFile $manifestPath
+    Assert-NoExistingAuthorityTag
+    $notesPath = Assert-ReleaseNotes
+    $body = "V4 qualified release candidate`n`nsource_sha: $($SourceSha.ToLowerInvariant())`nchannel: $Channel`nqualification: exact candidate manifest attached`n"
+    $payloadPath = Join-Path (Get-EffectiveStateRoot) "create-release.json"
+    Write-JsonFile $payloadPath ([ordered]@{
+        tag_name = $Tag
+        target_commitish = "main"
+        name = "Sky Auto Player $Version"
+        body = $body + ([IO.File]::ReadAllText($notesPath)).Trim()
+        draft = $true
+        prerelease = ($Channel -eq "beta")
+    })
+    $release = Invoke-AuthorityApi -Arguments @("api", "--method", "POST", "repos/$authorityRepository/releases", "--input", $payloadPath)
+    if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "authority did not create the requested draft release" }
+
+    foreach ($record in $manifest.assets) {
+        $candidate = (Get-CandidateRecords | Where-Object { $_.name -eq [string]$record.name })
+        if ($null -eq $candidate) { Fail "candidate manifest contains an unknown asset" }
+        Invoke-AuthorityApi -Arguments @(
+            "api", "--method", "POST",
+            "repos/$authorityRepository/releases/$($release.id)/assets?name=$([Uri]::EscapeDataString([string]$record.name))",
+            "--header", "Content-Type: application/octet-stream", "--input", $candidate.path
+        ) | Out-Null
+    }
+    $state = [ordered]@{
+        schema_version = 1
+        source_sha = $SourceSha.ToLowerInvariant()
+        version = $Version
+        channel = $Channel
+        tag = $Tag
+        release_id = [int64]$release.id
+        draft = $true
+        published = $false
+        attested = $false
+        qualified_after_download = $false
+        assets = $manifest.assets
+    }
+    Write-JsonFile (Get-StatePath) $state
+    Write-Host "V4 authority draft: PASS (tag=$Tag; exact qualified asset set uploaded)"
+}
+
+function Assert-ExactAssetSet([object]$Release, [object[]]$Expected) {
+    $actual = @($Release.assets | ForEach-Object { [string]$_.name } | Sort-Object)
+    $expectedNames = @($Expected | ForEach-Object { [string]$_.name } | Sort-Object)
+    if (($actual -join "`n") -ne ($expectedNames -join "`n")) { Fail "authority release asset set differs from the qualified candidate set" }
+}
+
+function Invoke-DownloadDraft {
+    $state = Get-State
+    if (-not $state.draft -or $state.published) { Fail "draft download requires an unpublished draft release" }
+    $release = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/releases/$($state.release_id)")
+    if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "authority release is not the expected draft" }
+    Assert-ExactAssetSet $release $state.assets
+    $downloaded = Join-Path (Get-EffectiveStateRoot) "downloaded"
+    if (Test-Path -LiteralPath $downloaded) { Remove-Item -LiteralPath $downloaded -Recurse -Force }
+    New-Item -ItemType Directory -Path $downloaded -Force | Out-Null
+    foreach ($expected in $state.assets) {
+        $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })
+        if ($asset.Count -ne 1) { Fail "expected authority asset is missing" }
+        $destination = Join-Path $downloaded ([IO.Path]::GetFileName([string]$expected.name))
+        Invoke-AuthorityApi -Arguments @("api", [string]$asset[0].url, "--header", "Accept: application/octet-stream") -BinaryOutput -OutputPath $destination
+        $item = Get-Item -LiteralPath $destination
+        $hash = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ([int64]$item.Length -ne [int64]$expected.size -or $hash -ne [string]$expected.sha256) {
+            Fail "downloaded authority asset differs in size or SHA-256: $($expected.name)"
+        }
+    }
+    Write-JsonFile (Join-Path (Get-EffectiveStateRoot) "downloaded-manifest.json") ([ordered]@{
+        schema_version = 1
+        source_sha = [string]$state.source_sha
+        version = [string]$state.version
+        channel = [string]$state.channel
+        assets = $state.assets
+    })
+    Write-Host "V4 draft download: PASS (all qualification inputs re-downloaded and byte-checked)"
+}
+
+function Invoke-Checked([string]$File, [string[]]$Arguments, [string]$Failure) {
+    & $File @Arguments
+    if ($LASTEXITCODE -ne 0) { Fail $Failure }
+}
+
+function Invoke-QualifyDownloaded {
+    $state = Get-State
+    if (-not $state.draft -or $state.published) { Fail "post-draft qualification requires an unpublished draft" }
+    $root = Get-EffectiveStateRoot
+    $downloaded = Join-Path $root "downloaded"
+    $manifest = Read-JsonFile (Join-Path $root "downloaded-manifest.json")
+    if ([string]$manifest.source_sha -ne $SourceSha.ToLowerInvariant()) { Fail "downloaded source binding mismatch" }
+    Assert-EvidenceIdentity `
+        (Join-Path $downloaded $productionEvidenceName) `
+        (Join-Path $downloaded $qualificationEvidenceName) `
+        @($manifest.assets)
+    $bundle = Join-Path $root "downloaded-bundle"
+    if (Test-Path -LiteralPath $bundle) { Remove-Item -LiteralPath $bundle -Recurse -Force }
+    New-Item -ItemType Directory -Path $bundle -Force | Out-Null
+    $installer = Get-ExpectedInstallerName
+    Copy-Item -LiteralPath (Join-Path $downloaded $installer) -Destination (Join-Path $bundle $installer)
+    Copy-Item -LiteralPath (Join-Path $downloaded "$installer.sig") -Destination (Join-Path $bundle "$installer.sig")
+
+    Invoke-Checked "pwsh" @(
+        "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+        "-File", (Join-Path $PSScriptRoot "verify_v4_authenticode.ps1"),
+        "-Mode", "unsigned-zero-budget", "-Artifact", (Join-Path $downloaded $installer),
+        "-Evidence", (Join-Path $root "downloaded-authenticode-verification.json")
+    ) "downloaded candidate Authenticode state is not unsigned-zero-budget"
+    Invoke-Checked "cargo" @(
+        "xtask", "updater-trust", "verify-signature", "--installer", (Join-Path $downloaded $installer),
+        "--signature", (Join-Path $downloaded "$installer.sig")
+    ) "downloaded candidate Tauri updater signature verification failed"
+    Invoke-Checked "cargo" @(
+        "xtask", "sbom", "verify", "--artifact-dir", $bundle, "--sbom", (Join-Path $downloaded $sbomName)
+    ) "downloaded candidate SPDX SBOM verification failed"
+    Invoke-Checked "cargo" @(
+        "xtask", "verify-tauri-bundle", "--bundle-dir", $bundle,
+        "--summary", (Join-Path $downloaded $summaryName),
+        "--authenticode-evidence", (Join-Path $downloaded $authenticodeEvidenceName),
+        "--sbom", (Join-Path $downloaded $sbomName)
+    ) "downloaded candidate exact Tauri bundle verification failed"
+    Invoke-Checked "pwsh" @(
+        "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+        "-File", (Join-Path $PSScriptRoot "promote_v4_metadata.ps1"),
+        "-ValidateEvidence", (Join-Path $downloaded $qualificationEvidenceName)
+    ) "downloaded candidate qualification evidence schema validation failed"
+
+    $defenderEvidence = [ordered]@{
+        schema_version = 1
+        evidence_type = "v4-defender-status"
+        status = "unavailable"
+        deterministic = $false
+    }
+    $defenderCommand = Get-Command Get-MpComputerStatus -ErrorAction SilentlyContinue
+    if ($null -ne $defenderCommand) {
+        try {
+            $defenderStatus = & $defenderCommand.Source
+            $defenderEvidence.status = "observed"
+            $defenderEvidence.deterministic = $true
+            $defenderEvidence.real_time_protection_enabled = [bool]$defenderStatus.RealTimeProtectionEnabled
+            $defenderEvidence.antivirus_enabled = [bool]$defenderStatus.AntivirusEnabled
+        } catch {
+            # Defender availability is recorded explicitly; it never changes
+            # the mandatory byte, updater-signature, SBOM, or provenance gates.
+            $defenderEvidence.status = "unavailable"
+        }
+    }
+    Write-JsonFile (Join-Path $root "defender-evidence.json") $defenderEvidence
+
+    # Reuse the production current-user smoke shape against the downloaded
+    # installer. The packaged shell self-test exercises GUI/native command
+    # ownership without physical input injection; the Rust activity test is
+    # the fail-closed proof that update installation is rejected during playback.
+    $installRoot = Join-Path $root ("install-" + [guid]::NewGuid().ToString("N"))
+    $app = Join-Path $installRoot "sky_desktop_shell.exe"
+    $uninstaller = Join-Path $installRoot "uninstall.exe"
+    if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) { Fail "LOCALAPPDATA is unavailable for external app-data preservation qualification" }
+    $preservationRoot = Join-Path $env:LOCALAPPDATA ("io.github.pumni.skyautoplayer/wo07-release-test-" + [guid]::NewGuid().ToString("N"))
+    $preservationMarker = Join-Path $preservationRoot "preserve.txt"
+    New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $preservationRoot -Force | Out-Null
+    [IO.File]::WriteAllText($preservationMarker, "external-user-data-marker`n", [Text.UTF8Encoding]::new($false))
+    try {
+        $install = Start-Process -FilePath (Join-Path $downloaded $installer) -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
+        if ($install.ExitCode -ne 0) { Fail "downloaded candidate current-user installer failed" }
+        if (-not (Test-Path -LiteralPath $app) -or -not (Test-Path -LiteralPath $uninstaller)) { Fail "downloaded candidate install omitted app or uninstaller" }
+        $installedPe = @(Get-ChildItem -LiteralPath $installRoot -File -Recurse | Where-Object {
+            $_.Extension.ToLowerInvariant() -in @(".exe", ".dll") -and $_.Name -ne "uninstall.exe"
+        })
+        if ($installedPe.Count -eq 0) { Fail "downloaded candidate installed no project PE files" }
+        Invoke-Checked "pwsh" @(
+            "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+            "-File", (Join-Path $PSScriptRoot "verify_v4_authenticode.ps1"),
+            "-Mode", "unsigned-zero-budget", "-Artifact" , $installedPe.FullName
+        ) "downloaded candidate installed PE state is not unsigned-zero-budget"
+        $shell = Start-Process -FilePath $app -ArgumentList @("--selftest-desktop-shell") -WindowStyle Hidden -Wait -PassThru
+        if ($shell.ExitCode -ne 0) { Fail "downloaded candidate packaged shell self-test failed" }
+        $gui = Start-Process -FilePath $app -ArgumentList @("--selftest-desktop-gui") -WindowStyle Hidden -Wait -PassThru
+        if ($gui.ExitCode -ne 0) { Fail "downloaded candidate GUI/input safety self-test failed" }
+        $uninstall = Start-Process -FilePath $uninstaller -ArgumentList @("/S") -WindowStyle Hidden -Wait -PassThru
+        if ($uninstall.ExitCode -ne 0) { Fail "downloaded candidate uninstall failed" }
+        if (-not (Test-Path -LiteralPath $preservationMarker -PathType Leaf)) { Fail "uninstall removed external app/user data" }
+        $reinstall = Start-Process -FilePath (Join-Path $downloaded $installer) -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
+        if ($reinstall.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $app)) { Fail "downloaded candidate reinstall failed" }
+        if (-not (Test-Path -LiteralPath $preservationMarker -PathType Leaf)) { Fail "reinstall did not preserve external app/user data" }
+        $finalUninstall = Start-Process -FilePath (Join-Path $installRoot "uninstall.exe") -ArgumentList @("/S") -WindowStyle Hidden -Wait -PassThru
+        if ($finalUninstall.ExitCode -ne 0) { Fail "downloaded candidate final uninstall failed" }
+    } finally {
+        if (Test-Path -LiteralPath $installRoot) { Remove-Item -LiteralPath $installRoot -Recurse -Force -ErrorAction SilentlyContinue }
+        if (Test-Path -LiteralPath $preservationRoot) { Remove-Item -LiteralPath $preservationRoot -Recurse -Force -ErrorAction SilentlyContinue }
+    }
+    Invoke-Checked "cargo" @(
+        "test", "--manifest-path", "rust/Cargo.toml", "-p", "sky_desktop_shell", "app_state::tests::update_installation_is_rejected_while_physical_playback_is_active", "--", "--exact"
+    ) "update installation while playback is active was not rejected"
+    Write-JsonFile (Join-Path $root "post-draft-qualification.json") ([ordered]@{
+        schema_version = 1
+        source_sha = $SourceSha.ToLowerInvariant()
+        version = $Version
+        channel = $Channel
+        downloaded_exact_bytes = $true
+        authenticode_mode = "unsigned-zero-budget"
+        qualification = @(
+            "fresh-current-user-no-admin-install",
+            "gui-input-safety",
+            "official-tauri-updater-signature",
+            "active-playback-install-rejected",
+            "uninstall",
+            "reinstall-preserves-external-app-data",
+            "defender-status-observed-or-explicitly-unavailable",
+            "spdx-sbom",
+            "exact-asset-digest"
+        )
+    })
+    $state.qualified_after_download = $true
+    $state.attested = $false
+    Write-JsonFile (Get-StatePath) $state
+    Write-Host "V4 post-draft qualification: PASS (downloaded exact bytes only)"
+}
+
+function Invoke-PublishDraft {
+    $state = Get-State
+    if (-not $state.draft -or $state.published) { Fail "publish requires the same unpublished draft" }
+    if (-not $state.qualified_after_download -or -not $state.attested) { Fail "publish requires downloaded qualification and exact-byte attestations" }
+    $release = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/releases/$($state.release_id)")
+    if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "draft is missing or has changed before publication" }
+    Assert-ExactAssetSet $release $state.assets
+    foreach ($expected in $state.assets) {
+        $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })
+        if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "draft asset changed before publication" }
+        $downloadedPath = Join-Path (Get-EffectiveStateRoot) "downloaded/$($expected.name)"
+        $downloadedHash = (Get-FileHash -LiteralPath $downloadedPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($downloadedHash -ne [string]$expected.sha256) { Fail "qualified downloaded digest changed before publication" }
+    }
+    $patchPath = Join-Path (Get-EffectiveStateRoot) "publish-release.json"
+    Write-JsonFile $patchPath ([ordered]@{ draft = $false })
+    $published = Invoke-AuthorityApi -Arguments @("api", "--method", "PATCH", "repos/$authorityRepository/releases/$($state.release_id)", "--input", $patchPath)
+    if ($published.draft -or [string]::IsNullOrWhiteSpace([string]$published.published_at)) { Fail "authority did not publish the already-qualified draft" }
+    $state.draft = $false
+    $state.published = $true
+    Write-JsonFile (Get-StatePath) $state
+    Write-Host "V4 immutable publication: PASS (assets were not replaced or rebuilt)"
+}
+
+function Invoke-RecordAttestations {
+    $state = Get-State
+    if (-not $state.draft -or $state.published) { Fail "attestation recording requires an unpublished draft" }
+    if (-not $state.qualified_after_download) { Fail "attestations require downloaded-byte qualification" }
+    $manifestPath = Join-Path (Get-EffectiveStateRoot) "downloaded-manifest.json"
+    $manifest = Read-JsonFile $manifestPath
+    if ([string]$manifest.source_sha -ne $SourceSha.ToLowerInvariant()) { Fail "attestation source binding mismatch" }
+    # The workflow invokes actions/attest and verifies all three predicates
+    # immediately before this state. This state records that externally
+    # verified fact without fabricating local provenance.
+    $state.attested = $true
+    Write-JsonFile (Get-StatePath) $state
+    Write-Host "V4 exact-byte attestations: PASS (OIDC/source binding verified by workflow)"
+}
+
+function Invoke-PromoteMetadata {
+    $state = Get-State
+    if (-not $state.published) { Fail "metadata promotion is forbidden before immutable publication" }
+    $root = Get-EffectiveStateRoot
+    $downloaded = Join-Path $root "downloaded"
+    $authorityCheckout = Join-Path $root "authority"
+    if (Test-Path -LiteralPath $authorityCheckout) { Remove-Item -LiteralPath $authorityCheckout -Recurse -Force }
+    Invoke-AuthorityApi -Arguments @("repo", "clone", $authorityRepository, $authorityCheckout, "--", "--branch", "main", "--depth", "1") -Raw | Out-Null
+    if (-not (Test-Path -LiteralPath (Join-Path $authorityCheckout ".git") -PathType Container)) { Fail "authority checkout main was not obtained" }
+    $metadata = Join-Path $root "latest.json"
+    $notesPath = Assert-ReleaseNotes
+    $signature = Join-Path $downloaded "$((Get-ExpectedInstallerName)).sig"
+    $assetUrl = "https://github.com/$authorityRepository/releases/download/$Tag/$((Get-ExpectedInstallerName).Replace(' ', '%20'))"
+    Invoke-Checked "cargo" @(
+        "xtask", "release-authority", "generate", "--channel", $Channel, "--version", $Version,
+        "--notes-file", $notesPath, "--pub-date", $PublicationDateUtc, "--platform", "windows-x86_64",
+        "--asset-url", $assetUrl, "--signature-file", $signature, "--output", $metadata
+    ) "deterministic v4 metadata generation failed"
+    Invoke-WithAuthorityToken {
+        Invoke-Checked "pwsh" @(
+            "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+            "-File", (Join-Path $PSScriptRoot "promote_v4_metadata.ps1"),
+            "-Channel", $Channel, "-Metadata", $metadata,
+            "-QualificationEvidence", (Join-Path $downloaded $qualificationEvidenceName),
+            "-AuthorityCheckout", $authorityCheckout, "-SourceCheckout", $repoRoot
+        ) "post-publication metadata promotion validation failed"
+    }
+    $destination = Join-Path $authorityCheckout "channels/$Channel/latest.json"
+    if (-not (Test-Path -LiteralPath $destination -PathType Leaf)) { Fail "promotion did not produce the governed channel metadata" }
+    $encoded = [Convert]::ToBase64String([IO.File]::ReadAllBytes($destination))
+    $existing = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/contents/channels/$Channel/latest.json?ref=main") -AllowNotFound
+    $payload = [ordered]@{
+        message = "Promote v4 $Channel metadata for $Version"
+        content = $encoded
+        branch = "main"
+    }
+    if ($null -ne $existing) { $payload.sha = [string]$existing.sha }
+    $payloadPath = Join-Path $root "metadata-commit.json"
+    Write-JsonFile $payloadPath $payload
+    Invoke-AuthorityApi -Arguments @("api", "--method", "PUT", "repos/$authorityRepository/contents/channels/$Channel/latest.json", "--input", $payloadPath) | Out-Null
+    Write-Host "V4 metadata promotion: PASS (channel=$Channel; publication already immutable)"
+}
+
+function Invoke-FinalVerify {
+    $state = Get-State
+    if (-not $state.published) { Fail "final verification requires a published release" }
+    $release = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/releases/tags/$Tag")
+    if ($release.draft -or [string]::IsNullOrWhiteSpace([string]$release.published_at)) { Fail "final release is still draft or unpublished" }
+    Assert-ExactAssetSet $release $state.assets
+    foreach ($expected in $state.assets) {
+        $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })
+        if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "final public asset identity changed" }
+        $finalPath = Join-Path (Get-EffectiveStateRoot) "final-$($expected.name)"
+        Invoke-AuthorityApi -Arguments @("api", [string]$asset[0].url, "--header", "Accept: application/octet-stream") -BinaryOutput -OutputPath $finalPath
+        $hash = (Get-FileHash -LiteralPath $finalPath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($hash -ne [string]$expected.sha256) { Fail "final public asset digest differs from qualified bytes" }
+    }
+    $metadataResponse = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/contents/channels/$Channel/latest.json?ref=main")
+    $metadataPath = Join-Path (Get-EffectiveStateRoot) "final-metadata.json"
+    $metadataBase64 = [regex]::Replace([string]$metadataResponse.content, '\s', '')
+    [IO.File]::WriteAllBytes($metadataPath, [Convert]::FromBase64String($metadataBase64))
+    Invoke-Checked "cargo" @("xtask", "release-authority", "validate", "--channel", $Channel, "--metadata", $metadataPath) "final public metadata failed deterministic validation"
+    $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+    $expectedUrl = "https://github.com/$authorityRepository/releases/download/$Tag/$((Get-ExpectedInstallerName).Replace(' ', '%20'))"
+    if ([string]$metadata.version -ne $Version -or [string]$metadata.platforms.'windows-x86_64'.url -ne $expectedUrl) {
+        Fail "final metadata does not reference the exact immutable public asset"
+    }
+    $finalSignature = Get-Content -LiteralPath (Join-Path (Get-EffectiveStateRoot) "final-$((Get-ExpectedInstallerName)).sig") -Raw
+    $metadataSignature = [string]$metadata.platforms.'windows-x86_64'.signature
+    if ($finalSignature.Trim() -ne $metadataSignature.Trim()) {
+        Fail "final metadata signature does not match the exact public Tauri signature asset"
+    }
+    if ($expectedUrl -match "Sky-Auto-Player/releases") { Fail "v3 source-repository release namespace leaked into v4 metadata" }
+    Invoke-WithAuthorityToken {
+        Invoke-Checked "pwsh" @(
+            "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+            "-File", (Join-Path $PSScriptRoot "ci_v4_release_authority_acceptance.ps1")
+        ) "v3 source-repository release discovery isolation check failed"
+    }
+    Write-Host "V4 final public verification: PASS (published immutable assets and metadata are exact)"
+}
+
+function Invoke-SelfTest {
+    $scriptPath = (Resolve-Path $PSCommandPath).Path
+    $source = Get-Content -LiteralPath $scriptPath -Raw
+    if ($source -notmatch 'draft = \$true' -or $source -notmatch "qualified_after_download" -or
+        $source -notmatch "metadata promotion is forbidden before immutable publication") {
+        Fail "self-test could not find draft/qualification/publication guards"
+    }
+    $mock = [ordered]@{ builds = 0; draft = $false; downloaded = $false; qualified = $false; attested = $false; published = $false; promoted = $false }
+    $mock.builds++
+    $mock.draft = $true
+    $mock.downloaded = $true
+    $mock.qualified = $true
+    try {
+        if (-not $mock.published) { throw "promotion before publication" }
+        Fail "mock promotion-before-publication unexpectedly succeeded"
+    } catch {
+        if ($_.Exception.Message -notmatch "promotion before publication") { throw }
+    }
+    $mock.attested = $true
+    $mock.published = $true
+    $mock.promoted = $true
+    if ($mock.builds -ne 1 -or -not $mock.draft -or -not $mock.downloaded -or -not $mock.qualified -or -not $mock.published -or -not $mock.promoted) {
+        Fail "mock release state machine did not preserve build-once and publication ordering"
+    }
+    Write-Host "V4 release pipeline state-machine self-test: PASS (mock draft/download/qualify/publish/promote; build count=1)"
+}
+
+if ($State -eq "SelfTest") {
+    Invoke-SelfTest
+    exit 0
+}
+
+switch ($State) {
+    "ValidateRequest" { Assert-RequestIdentity; Assert-ReleaseNotes | Out-Null }
+    "ValidateAuthority" { Assert-RequestIdentity; Assert-AuthorityMain }
+    "BuildCandidate" { Invoke-BuildCandidate }
+    "CreateDraft" { Assert-RequestIdentity; Invoke-CreateDraft }
+    "DownloadDraft" { Assert-RequestIdentity; Invoke-DownloadDraft }
+    "QualifyDownloaded" { Assert-RequestIdentity; Invoke-QualifyDownloaded }
+    "RecordAttestations" { Assert-RequestIdentity; Invoke-RecordAttestations }
+    "PublishDraft" { Assert-RequestIdentity; Invoke-PublishDraft }
+    "PromoteMetadata" { Assert-RequestIdentity; Invoke-PromoteMetadata }
+    "FinalVerify" { Assert-RequestIdentity; Invoke-FinalVerify }
+}


### PR DESCRIPTION
Implements issue #109 (WO-07) as a dedicated draft-first v4 release state machine.

Baseline: f9a3d408dac6673e18f704f623d8d68188bb087a
Exact head: 0ed65db6cbd8190128fd0a096a8899ae43fe5c7b

State transitions:
ValidateRequest -> ValidateAuthority -> BuildCandidate -> CreateDraft -> DownloadDraft -> QualifyDownloaded -> RecordAttestations -> PublishDraft -> PromoteMetadata -> FinalVerify

- `.github/workflows/release-v4.yml` is manual-only and targets the dedicated single-tenant Windows runner.
- Request version/channel/tag/source SHA and workflow SHA are checked before build; SemVer stable/beta rules and reused authority tags fail closed.
- `scripts/orchestrate_v4_production_release.ps1` is invoked exactly once, with the externally stored updater-key path only. The governed unsigned-zero-budget policy and Tauri updater signing remain mandatory.
- Authority bootstrap and immutable-release policy are explicit preconditions. Missing `main` or disabled immutable releases fail closed.
- `V4_RELEASE_AUTHORITY_TOKEN` is separate from source `GITHUB_TOKEN`/OIDC; the bounded authority contract uses only dedicated-repository Administration-read and Contents read/write capability. No production key, passphrase, provider credential, or token is present in this PR or CI.
- The exact qualified candidate set is uploaded through the release-specific `upload_url`, re-downloaded, hash/size/name checked, qualified on downloaded bytes, OIDC-attested, then published by changing only the draft flag; publication must return `immutable=true`.
- Post-download qualification runs the existing throwaway previous-v4 bridge against the exact downloaded installer/signature, verifies the packaged playback-active rejection seam, runs exact Defender custom scan evidence with no detection, verifies signature/unsigned state/SBOM/exact bundle, and performs current-user install/GUI/uninstall/reinstall data-preservation checks.
- Metadata promotion is guarded after immutable publication and final public assets/metadata are re-fetched and checked. No rebuild or asset replacement occurs after draft creation.
- `scripts/test_v4_release_authority_rehearsal.ps1 -ConfirmDisposable` provides an explicit real-API upload/download rehearsal that deletes its uniquely tagged draft and tag; it is not run by PR CI or production publication.
- Static Rust contract coverage and `scripts/test_v4_release_pipeline.ps1` mock API coverage prove release-specific upload, exact downloaded qualification, immutable publication, build-once, and promotion ordering; the mock self-test is wired into CI.

Validation:
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`: PASS
- `cargo xtask check static --skip-supply-chain`: PASS
- `cargo xtask check rust`: PASS
- `cargo xtask check desktop`: PASS
- `cargo xtask check all --skip-supply-chain`: PASS
- existing production orchestrator contract: PASS (all 16 cases)
- existing Authenticode signing contract: PASS
- updater private-key secret-output regression: PASS
- promotion self-test: PASS
- release-pipeline PowerShell/mock contract self-test: PASS
- `git diff --check`: PASS
- unskipped `cargo xtask check all`: blocked only by local cargo-vet cache-lock access denied; the dedicated supply-chain portion was not changed.

No real v4 RC was published. The explicit authority rehearsal remains unrun until the dedicated authority is separately bootstrapped. This PR remains Draft pending exact-head ordinary CI and maintainer review.