### PR TITLE
fix(ci): validate v4 release workflow context

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -59,7 +59,6 @@ jobs:
     runs-on: [self-hosted, windows, v4-release, single-tenant]
     environment: v4-production-release
     env:
-      V4_RELEASE_STATE_ROOT: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}
       V4_RELEASE_VERSION: ${{ inputs.version }}
       V4_RELEASE_CHANNEL: ${{ inputs.channel }}
       V4_RELEASE_TAG: ${{ inputs.tag }}
@@ -70,6 +69,12 @@ jobs:
       V4_RELEASE_UPDATER_PASSWORD_ENV: ${{ inputs.updater_password_env }}
 
     steps:
+      - name: Initialize release state root
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { throw "RUNNER_TEMP is unavailable" }
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { throw "GITHUB_RUN_ID is unavailable" }
+          "V4_RELEASE_STATE_ROOT=$env:RUNNER_TEMP\sky-v4-release-$env:GITHUB_RUN_ID" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Check out the exact requested source SHA
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -40,6 +40,7 @@ foreach ($marker in @(
     'persist-credentials: false',
     'actions/attest@',
     '--source-digest $env:GITHUB_SHA',
+    'Initialize release state root', 'RUNNER_TEMP', 'GITHUB_RUN_ID', 'GITHUB_ENV',
     'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
 )) {
     if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }
@@ -47,9 +48,15 @@ foreach ($marker in @(
 foreach ($forbidden in @(
     'cargo xtask dist', 'Sky-Auto-Player-Updater.exe', 'MANIFEST.json.sig',
     'softprops/action-gh-release', 'secrets.TAURI_SIGNING_PRIVATE_KEY',
-    'secrets.UPDATER_PRIVATE_KEY', 'secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD'
+    'secrets.UPDATER_PRIVATE_KEY', 'secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD',
+    'V4_RELEASE_STATE_ROOT: ${{ runner.temp }}'
 )) {
     if ($workflow.Contains($forbidden)) { Fail "forbidden production workflow marker remains: $forbidden" }
+}
+$stateRootInit = $workflow.IndexOf('- name: Initialize release state root', [StringComparison]::Ordinal)
+$checkout = $workflow.IndexOf('- name: Check out the exact requested source SHA', [StringComparison]::Ordinal)
+if ($stateRootInit -lt 0 -or $checkout -lt 0 -or $stateRootInit -gt $checkout) {
+    Fail "release state root must be initialized from runner default environment before checkout and release steps"
 }
 
 class MockReleaseApi {


### PR DESCRIPTION
Follow-up to #130 / WO-07 (#109).

Post-merge GitHub Actions registered `.github/workflows/release-v4.yml` on `main` and immediately failed the workflow on the push event before any job was created. Root cause: `jobs.release.env.V4_RELEASE_STATE_ROOT` referenced `${{ runner.temp }}`, but the `runner` context is not valid in job-level `env`.

This hotfix is intentionally narrow:
- remove `runner.temp` from job-level `env`;
- initialize `V4_RELEASE_STATE_ROOT` in the first PowerShell step from the runner-provided `RUNNER_TEMP` and `GITHUB_RUN_ID` default environment variables, exporting it through `GITHUB_ENV` for later steps;
- add a static regression that requires the step-scoped initialization and rejects reintroducing `V4_RELEASE_STATE_ROOT: ${{ runner.temp }}`.

No release state-machine semantics, authority boundaries, signing/updater-key handling, artifact qualification, publication order, or metadata promotion behavior is changed.

Baseline: `e9a707cf4881a981f69fbb91a8e2142f7201538b` (squash merge of #130).

Acceptance: exact-head ordinary CI green and the workflow is accepted by GitHub Actions without a zero-job validation failure. Keep #109 open for the remaining operational gates.