### PR TITLE
chore(release): prepare v4.0.0-rc.1

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-alpha.1"
+version = "4.0.0-rc.1"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.0-rc.1.md
+++ b/docs/releases/v4.0.0-rc.1.md
@@ -1,0 +1,22 @@
+# Sky Auto Player v4.0.0-rc.1
+
+This release candidate is the first v4 beta-channel candidate prepared for
+qualification through the dedicated v4 release authority.
+
+## Distribution and updates
+
+- The canonical Windows distribution is the Tauri NSIS installer.
+- Updates use the official Tauri updater and its Ed25519 signature.
+- v4 release qualification binds the installer, updater signature, SBOM,
+  provenance, and exact source commit.
+- The project production signing policy is `unsigned-zero-budget`; Windows may
+  display Unknown Publisher or SmartScreen warnings because the shipped PE
+  files are Authenticode-unsigned. This does not bypass updater cryptographic
+  trust.
+
+## Qualification scope
+
+Before publication, the release pipeline must qualify the exact draft assets
+after re-download, including fresh current-user installation, update from the
+previous v4 candidate, install/uninstall behavior, external app-data
+preservation, and stable/beta namespace isolation.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-alpha.1"
+version = "4.0.0-rc.1"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",


### PR DESCRIPTION
## Summary

Prepares the v4.0.0-rc.1 beta-channel release candidate for #109.

- Bumps the canonical desktop package from `4.0.0-alpha.1` to `4.0.0-rc.1`.
- Updates the matching `sky_desktop_shell` entry in `rust/Cargo.lock`.
- Adds `docs/releases/v4.0.0-rc.1.md` with v4 distribution, updater, qualification, and unsigned-zero-budget notes.
- Keeps historical `4.0.0-alpha.1` previous-v4 fixture/test references unchanged.

## Accepted prerequisites

- Release-authority gate accepted after real disposable rehearsal PASS with clean draft/tag cleanup.
- Updater fixture version-independence hotfix #138 merged to canonical main as `1e91738484bb9023a78e161278140a567894c2de`.
- Post-merge main CI #702 / run `34037186701`: full SUCCESS, including `Packaged v4 updater fixture qualification`, `Packaged v4 Tauri NSIS qualification`, attestations, and the aggregate required CI gate.

## Refresh state

This branch was rebuilt directly on accepted main `1e91738484bb9023a78e161278140a567894c2de` with exactly the original three-file release-prep scope. No implementation code, credential, updater private key material, release tag, release object, or authority mutation is included.

Exact head: `dd3504b8830a887af6a92c0446b82533e56f1822`.

Required merge gate: Website CI #128 and CI #703 must complete successfully on this exact head. After squash merge, post-merge main CI must be full green before the merge SHA can be locked as the RC1 `source_sha` and before any production release dispatch.