### PR TITLE
fix(v4): preserve binary release asset downloads

### DIFF
--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -592,10 +592,12 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     let workflow_path = root.join(".github/workflows/release-v4.yml");
     let pipeline_path = root.join("scripts/v4_release_pipeline.ps1");
     let regression_path = root.join("scripts/test_v4_release_pipeline.ps1");
+    let pipeline = fs::read_to_string(&pipeline_path)?;
+    let regression = fs::read_to_string(&regression_path)?;
     v4_release_pipeline_contract_source(
         &fs::read_to_string(&workflow_path)?,
-        &fs::read_to_string(&pipeline_path)?,
-        &fs::read_to_string(&regression_path)?,
+        &pipeline,
+        &regression,
     )
     .map_err(|error| -> Box<dyn std::error::Error + Send + Sync> {
         format!("v4 release pipeline contract: {error}").into()
@@ -616,6 +618,39 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
                 "v4 authority rehearsal is missing its bounded cleanup marker: {marker}"
             )
             .into());
+        }
+    }
+    for (name, source) in [
+        ("production release pipeline", pipeline.as_str()),
+        ("authority rehearsal", rehearsal.as_str()),
+    ] {
+        for forbidden in [
+            "gh @Arguments --output",
+            "gh.exe @Arguments --output",
+            "--output $OutputPath",
+        ] {
+            if source.contains(forbidden) {
+                return Err(format!(
+                    "{name} must not use gh api --output for binary asset downloads"
+                )
+                .into());
+            }
+        }
+        for marker in [
+            "Invoke-GhBinaryOutput",
+            "PSVersionTable.PSVersion",
+            "7.4.0",
+            "RedirectStandardOutput",
+            "RedirectStandardError",
+            "StandardOutput.BaseStream",
+            "ReadToEndAsync",
+            "ArgumentList",
+        ] {
+            if !source.contains(marker) {
+                return Err(
+                    format!("{name} binary download helper is missing marker: {marker}").into(),
+                );
+            }
         }
     }
     println!("[xtask] v4 release pipeline state-machine contract: PASS");

--- a/scripts/test_v4_release_authority_rehearsal.ps1
+++ b/scripts/test_v4_release_authority_rehearsal.ps1
@@ -29,6 +29,60 @@ $releaseId = $null
 $oldGhToken = [Environment]::GetEnvironmentVariable("GH_TOKEN", "Process")
 $failure = $null
 
+function Invoke-GhBinaryOutput {
+    param(
+        [Parameter(Mandatory = $true)] [string[]]$Arguments,
+        [Parameter(Mandatory = $true)] [string]$OutputPath,
+        [Parameter(Mandatory = $true)] [string]$ErrorPath
+    )
+    if ($PSVersionTable.PSVersion -lt [Version]"7.4.0") {
+        throw "binary release-asset download requires PowerShell 7.4 or newer"
+    }
+    if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+        throw "binary release-asset output path is required"
+    }
+
+    $ghPath = (Get-Command gh -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $ghPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $Arguments) {
+        [void]$startInfo.ArgumentList.Add([string]$argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $outputStream = $null
+    $stderrTask = $null
+    $started = $false
+    try {
+        $outputStream = [IO.File]::Open(
+            $OutputPath,
+            [IO.FileMode]::Create,
+            [IO.FileAccess]::Write,
+            [IO.FileShare]::None
+        )
+        $started = $process.Start()
+        if (-not $started) { throw "could not start GitHub CLI for binary release-asset download" }
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $process.StandardOutput.BaseStream.CopyTo($outputStream)
+        $process.WaitForExit()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+        [IO.File]::WriteAllText($ErrorPath, $stderr, [Text.UTF8Encoding]::new($false))
+        return [int]$process.ExitCode
+    } finally {
+        if ($started -and -not $process.HasExited) {
+            $process.Kill()
+            $process.WaitForExit()
+        }
+        if ($null -ne $outputStream) { $outputStream.Dispose() }
+        $process.Dispose()
+    }
+}
+
 function Invoke-AuthorityApi {
     param(
         [Parameter(Mandatory = $true)] [string[]]$Arguments,
@@ -40,11 +94,12 @@ function Invoke-AuthorityApi {
     try {
         [Environment]::SetEnvironmentVariable("GH_TOKEN", $token, "Process")
         if ($BinaryOutput) {
-            & gh @Arguments --output $OutputPath 2>$errorPath | Out-Null
+            $exitCode = Invoke-GhBinaryOutput `
+                -Arguments $Arguments -OutputPath $OutputPath -ErrorPath $errorPath
         } else {
             $result = & gh @Arguments 2>$errorPath
+            $exitCode = $LASTEXITCODE
         }
-        $exitCode = $LASTEXITCODE
     } finally {
         if ($null -eq $oldGhToken) {
             [Environment]::SetEnvironmentVariable("GH_TOKEN", $null, "Process")

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -6,11 +6,35 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $pipelinePath = Join-Path $PSScriptRoot "v4_release_pipeline.ps1"
+$rehearsalPath = Join-Path $PSScriptRoot "test_v4_release_authority_rehearsal.ps1"
 $workflowPath = Join-Path $repoRoot ".github/workflows/release-v4.yml"
 $pipeline = Get-Content -LiteralPath $pipelinePath -Raw
+$rehearsal = Get-Content -LiteralPath $rehearsalPath -Raw
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
 
 function Fail([string]$Message) { throw "FAILED: $Message" }
+
+foreach ($script in @(
+    [pscustomobject]@{ Name = "production release pipeline"; Source = $pipeline },
+    [pscustomobject]@{ Name = "authority rehearsal"; Source = $rehearsal }
+)) {
+    foreach ($forbidden in @(
+        'gh @Arguments --output', 'gh.exe @Arguments --output', '--output $OutputPath'
+    )) {
+        if ($script.Source.Contains($forbidden)) {
+            Fail "$($script.Name) must not use gh api --output for binary asset downloads"
+        }
+    }
+    foreach ($marker in @(
+        'Invoke-GhBinaryOutput', 'PSVersionTable.PSVersion', '7.4.0', 'RedirectStandardOutput',
+        'RedirectStandardError', 'StandardOutput.BaseStream', 'ReadToEndAsync',
+        'ArgumentList'
+    )) {
+        if (-not $script.Source.Contains($marker)) {
+            Fail "$($script.Name) binary download helper is missing marker: $marker"
+        }
+    }
+}
 
 if (([regex]::Matches($pipeline, "orchestrate_v4_production_release\.ps1")).Count -ne 1) {
     Fail "production orchestrator must have exactly one call site"

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -164,6 +164,58 @@ function Invoke-WithAuthorityToken([scriptblock]$Action) {
     }
 }
 
+function Invoke-GhBinaryOutput {
+    param(
+        [Parameter(Mandatory = $true)] [string[]]$Arguments,
+        [Parameter(Mandatory = $true)] [string]$OutputPath,
+        [Parameter(Mandatory = $true)] [string]$ErrorPath
+    )
+    if ($PSVersionTable.PSVersion -lt [Version]"7.4.0") {
+        Fail "binary release-asset download requires PowerShell 7.4 or newer"
+    }
+    if ([string]::IsNullOrWhiteSpace($OutputPath)) { Fail "binary release-asset output path is required" }
+
+    $ghPath = (Get-Command gh -CommandType Application -ErrorAction Stop | Select-Object -First 1).Source
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $ghPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $Arguments) {
+        [void]$startInfo.ArgumentList.Add([string]$argument)
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $outputStream = $null
+    $stderrTask = $null
+    $started = $false
+    try {
+        $outputStream = [IO.File]::Open(
+            $OutputPath,
+            [IO.FileMode]::Create,
+            [IO.FileAccess]::Write,
+            [IO.FileShare]::None
+        )
+        $started = $process.Start()
+        if (-not $started) { Fail "could not start GitHub CLI for binary release-asset download" }
+        $stderrTask = $process.StandardError.ReadToEndAsync()
+        $process.StandardOutput.BaseStream.CopyTo($outputStream)
+        $process.WaitForExit()
+        $stderr = $stderrTask.GetAwaiter().GetResult()
+        [IO.File]::WriteAllText($ErrorPath, $stderr, [Text.UTF8Encoding]::new($false))
+        return [int]$process.ExitCode
+    } finally {
+        if ($started -and -not $process.HasExited) {
+            $process.Kill()
+            $process.WaitForExit()
+        }
+        if ($null -ne $outputStream) { $outputStream.Dispose() }
+        $process.Dispose()
+    }
+}
+
 function Invoke-AuthorityApi {
     param(
         [Parameter(Mandatory = $true)] [string[]]$Arguments,
@@ -176,11 +228,12 @@ function Invoke-AuthorityApi {
     try {
         Invoke-WithAuthorityToken {
             if ($BinaryOutput) {
-                & gh @Arguments --output $OutputPath 2>$errorPath | Out-Null
+                $script:authorityApiExitCode = Invoke-GhBinaryOutput `
+                    -Arguments $Arguments -OutputPath $OutputPath -ErrorPath $errorPath
             } else {
                 $script:authorityApiResult = & gh @Arguments 2>$errorPath
+                $script:authorityApiExitCode = $LASTEXITCODE
             }
-            $script:authorityApiExitCode = $LASTEXITCODE
         }
         if ($authorityApiExitCode -ne 0) {
             $errorText = if (Test-Path -LiteralPath $errorPath) { Get-Content -LiteralPath $errorPath -Raw } else { "" }


### PR DESCRIPTION
Fixes the v4 binary release-asset download boundary for issue #109 without closing it.\n\nBaseline: 5c0cbdc661911df12e71cefd693c3116cafabdfd\nHead: 8a9eb08e\n\nChanges:\n- replace gh api --output asset downloads in the production pipeline and authority rehearsal with a PowerShell 7.4+ ProcessStartInfo binary stdout stream; stderr remains separate\n- add regression coverage that checks both scripts and rejects the old invocation\n- no version/tag/release/production secret changes\n\nValidation:\n- PowerShell pipeline contract/self-test: PASS\n- PowerShell parse checks: PASS\n- cargo fmt --manifest-path rust/Cargo.toml --all -- --check: PASS\n- cargo test -p sky_xtask v4 release pipeline contract: PASS\n- cargo xtask check static --skip-supply-chain: PASS\n- cargo xtask check rust: clippy/build pass; one unrelated pre-existing sky_player timing test failed\n- authority rehearsal: intentionally not run\n- no release runner enabled and no production credentials used\n\nThe full ordinary PR CI must be evaluated on exact head 8a9eb08e before acceptance.