### PR TITLE
fix(v4): construct release upload URL without ambiguous interpolation

### DIFF
--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -684,6 +684,23 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     if upload_helper.contains("gh ") || upload_helper.contains("ArgumentList") {
         return Err("raw release asset upload helper must not invoke GitHub CLI".into());
     }
+    if upload_helper.contains("$UploadUrl?name=") {
+        return Err(
+            "raw release asset upload helper uses ambiguous PowerShell URL interpolation".into(),
+        );
+    }
+    for marker in [
+        "UploadUrl.Contains(\"?\")",
+        "[string]::Concat($UploadUrl, \"?name=\"",
+        "escapedAssetName",
+    ] {
+        if !upload_helper.contains(marker) {
+            return Err(format!(
+                "raw release asset upload URL construction guard is missing: {marker}"
+            )
+            .into());
+        }
+    }
     println!("[xtask] v4 release pipeline state-machine contract: PASS");
     Ok(())
 }

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -54,6 +54,16 @@ foreach ($marker in @(
 if ($uploadHelper.Contains('gh ') -or $uploadHelper.Contains('ArgumentList')) {
     Fail "raw release asset upload helper must not invoke GitHub CLI"
 }
+if ($uploadHelper.Contains('$UploadUrl?name=')) {
+    Fail "raw release asset upload helper must not use ambiguous PowerShell URL interpolation"
+}
+foreach ($marker in @(
+    'UploadUrl.Contains("?")', '[string]::Concat($UploadUrl, "?name="', 'escapedAssetName'
+)) {
+    if (-not $uploadHelper.Contains($marker)) {
+        Fail "raw release asset upload URL construction guard is missing: $marker"
+    }
+}
 
 function Test-RawUploadBodyByteIdentity {
     $testRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-raw-upload-test-" + [guid]::NewGuid().ToString("N"))

--- a/scripts/v4_release_authority_upload.ps1
+++ b/scripts/v4_release_authority_upload.ps1
@@ -16,6 +16,28 @@ function Get-V4ReleaseAuthorityAssetUploadUrl {
     return $assetUrl
 }
 
+$uploadUrlSelfTestBase = "https://uploads.github.com/repos/pumni/Sky-Auto-Player-Releases/releases/42/assets"
+$uploadUrlSelfTestAsset = "fixture +#.bin"
+$uploadUrlSelfTestExpected = "https://uploads.github.com/repos/pumni/Sky-Auto-Player-Releases/releases/42/assets?name=fixture%20%2B%23.bin"
+$uploadUrlSelfTestActual = Get-V4ReleaseAuthorityAssetUploadUrl `
+    -UploadUrl $uploadUrlSelfTestBase `
+    -AssetName $uploadUrlSelfTestAsset
+if ($uploadUrlSelfTestActual -ne $uploadUrlSelfTestExpected) {
+    throw "release asset upload URL escaping self-test failed"
+}
+$uploadUrlSelfTestRejectedExistingQuery = $false
+try {
+    [void](Get-V4ReleaseAuthorityAssetUploadUrl `
+        -UploadUrl ($uploadUrlSelfTestBase + "?existing=1") `
+        -AssetName $uploadUrlSelfTestAsset)
+} catch {
+    $uploadUrlSelfTestRejectedExistingQuery = $true
+}
+if (-not $uploadUrlSelfTestRejectedExistingQuery) {
+    throw "release asset upload URL query rejection self-test failed"
+}
+Remove-Variable uploadUrlSelfTestBase, uploadUrlSelfTestAsset, uploadUrlSelfTestExpected, uploadUrlSelfTestActual, uploadUrlSelfTestRejectedExistingQuery -ErrorAction SilentlyContinue
+
 function Invoke-V4ReleaseAuthorityAssetUpload {
     param(
         [Parameter(Mandatory = $true)] [string]$UploadUrl,

--- a/scripts/v4_release_authority_upload.ps1
+++ b/scripts/v4_release_authority_upload.ps1
@@ -13,8 +13,16 @@ function Invoke-V4ReleaseAuthorityAssetUpload {
     if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
         throw "release asset upload file is missing"
     }
+    if ($UploadUrl.Contains("?")) {
+        throw "release asset upload base URL must not already contain a query"
+    }
 
-    $assetUrl = "$UploadUrl?name=$([Uri]::EscapeDataString($AssetName))"
+    $escapedAssetName = [Uri]::EscapeDataString($AssetName)
+    $assetUrl = [string]::Concat($UploadUrl, "?name=", $escapedAssetName)
+    if (-not $assetUrl.StartsWith(($UploadUrl + "?name="), [StringComparison]::Ordinal)) {
+        throw "release asset upload URL construction failed"
+    }
+
     $client = [System.Net.Http.HttpClient]::new()
     $request = $null
     $fileStream = $null

--- a/scripts/v4_release_authority_upload.ps1
+++ b/scripts/v4_release_authority_upload.ps1
@@ -1,3 +1,21 @@
+function Get-V4ReleaseAuthorityAssetUploadUrl {
+    param(
+        [Parameter(Mandatory = $true)] [string]$UploadUrl,
+        [Parameter(Mandatory = $true)] [string]$AssetName
+    )
+
+    if ($UploadUrl.Contains("?")) {
+        throw "release asset upload base URL must not already contain a query"
+    }
+
+    $escapedAssetName = [Uri]::EscapeDataString($AssetName)
+    $assetUrl = [string]::Concat($UploadUrl, "?name=", $escapedAssetName)
+    if (-not $assetUrl.StartsWith(($UploadUrl + "?name="), [StringComparison]::Ordinal)) {
+        throw "release asset upload URL construction failed"
+    }
+    return $assetUrl
+}
+
 function Invoke-V4ReleaseAuthorityAssetUpload {
     param(
         [Parameter(Mandatory = $true)] [string]$UploadUrl,
@@ -13,16 +31,8 @@ function Invoke-V4ReleaseAuthorityAssetUpload {
     if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) {
         throw "release asset upload file is missing"
     }
-    if ($UploadUrl.Contains("?")) {
-        throw "release asset upload base URL must not already contain a query"
-    }
 
-    $escapedAssetName = [Uri]::EscapeDataString($AssetName)
-    $assetUrl = [string]::Concat($UploadUrl, "?name=", $escapedAssetName)
-    if (-not $assetUrl.StartsWith(($UploadUrl + "?name="), [StringComparison]::Ordinal)) {
-        throw "release asset upload URL construction failed"
-    }
-
+    $assetUrl = Get-V4ReleaseAuthorityAssetUploadUrl -UploadUrl $UploadUrl -AssetName $AssetName
     $client = [System.Net.Http.HttpClient]::new()
     $request = $null
     $fileStream = $null


### PR DESCRIPTION
Release-blocking hotfix for #109 after the real disposable authority rehearsal on main `f9121c4941ce28aee62157aa133cb13768a86d88` still failed closed at phase `upload-asset`.

Root cause: PowerShell permits `?` in variable names. The helper used `"$UploadUrl?name=..."`, which is parser-ambiguous and can bind as `$UploadUrl?name` instead of `${UploadUrl}` followed by the required `?name=` query. This is consistent with draft creation succeeding and the raw upload request failing.

Current fix:
- build the release asset URL with `[string]::Concat($UploadUrl, "?name=", $escapedAssetName)`;
- reject an upload base URL that already contains a query;
- retain raw FileStream/StreamContent transport, exact Content-Length, GitHub protocol headers, Bearer token isolation, and exact HTTP 201 semantics.

Required before merge:
- add/confirm regression coverage that rejects the unsafe `"$UploadUrl?name=` interpolation pattern in the upload helper and requires unambiguous URL construction;
- exact-head applicable CI green;
- post-merge main CI green;
- then rerun the real disposable authority rehearsal. Do not run RC1 or bring the production release runner online before rehearsal PASS.

The failed rehearsal cleanup was verified clean: authority releases `[]`, matching rehearsal tags `[]`; no release/RC identity was consumed.