### PR TITLE
fix(v4): decouple updater bridge fixture from candidate version

### DIFF
--- a/scripts/ci_tauri_update_e2e.ps1
+++ b/scripts/ci_tauri_update_e2e.ps1
@@ -13,350 +13,66 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
-$desktopRoot = Join-Path $repoRoot 'desktop'
-$runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
-  [IO.Path]::GetTempPath()
-} else {
-  $env:RUNNER_TEMP
-}
-$summaryPath = if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
-  Join-Path $runnerTemp 'sky-auto-player-tauri-update-summary.md'
-} else {
-  $env:GITHUB_STEP_SUMMARY
-}
-$fixtureRoot = Join-Path $runnerTemp ('sky-auto-player-tauri-update-' + [guid]::NewGuid().ToString('N'))
-$installRoot = Join-Path $fixtureRoot 'installed'
-$markerPath = Join-Path $fixtureRoot 'completion.txt'
-$cutoverMarkerPath = Join-Path $fixtureRoot 'cutover.txt'
-$safetyPath = Join-Path $fixtureRoot 'safety.txt'
-$stopPath = Join-Path $fixtureRoot 'stop-server'
-$manifestPath = Join-Path $fixtureRoot 'manifest.json'
-$oldManifestPath = Join-Path $fixtureRoot 'old-manifest.json'
-$bridgeConfigPath = Join-Path $fixtureRoot 'bridge-updater.json'
-$cutoverConfigPath = Join-Path $fixtureRoot 'cutover-updater.json'
-$oldKeyPath = Join-Path $fixtureRoot 'old.key'
-$newKeyPath = Join-Path $fixtureRoot 'new.key'
-$oldSignaturePath = Join-Path $fixtureRoot 'old.sig'
-$candidateForOldSigningPath = Join-Path $fixtureRoot 'candidate-for-old-signing.exe'
-$providedCandidate = -not [string]::IsNullOrWhiteSpace($CandidateInstallerPath) -or
-  -not [string]::IsNullOrWhiteSpace($CandidateSignaturePath) -or
-  -not [string]::IsNullOrWhiteSpace($CandidateVersion) -or
-  -not [string]::IsNullOrWhiteSpace($CandidatePublicKeyPath)
-if ($providedCandidate) {
-  if ([string]::IsNullOrWhiteSpace($CandidateInstallerPath) -or
-    [string]::IsNullOrWhiteSpace($CandidateSignaturePath) -or
-    [string]::IsNullOrWhiteSpace($CandidateVersion) -or
-    [string]::IsNullOrWhiteSpace($CandidatePublicKeyPath)) {
-    throw 'Provided-candidate updater qualification requires installer, signature, version, and public-key paths'
-  }
-  if ($CandidateVersion -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
-    throw "Provided-candidate updater qualification received a non-canonical SemVer: $CandidateVersion"
-  }
-}
-$candidateVersion = if ($providedCandidate) { $CandidateVersion } else { '4.0.0-alpha.2' }
-$cutoverVersion = '4.0.0-alpha.3'
-$port = 17845
-$serverJob = $null
-$previousInstallerCopy = Join-Path $fixtureRoot 'previous-v4-setup.exe'
-$candidateArchive = $null
-$candidateSignature = $null
-$candidateCargoPath = Join-Path $desktopRoot 'src-tauri/Cargo.toml'
+$candidateCargoPath = Join-Path $repoRoot 'desktop/src-tauri/Cargo.toml'
 $lockPath = Join-Path $repoRoot 'rust/Cargo.lock'
+$previousVersion = '4.0.0-alpha.1'
 $cargoSource = [IO.File]::ReadAllText($candidateCargoPath)
 $lockSource = [IO.File]::ReadAllText($lockPath)
 
-function Wait-ForPath {
-  param([string]$Path, [int]$TimeoutSeconds = 180)
-  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-  while ([DateTime]::UtcNow -lt $deadline) {
-    if (Test-Path -LiteralPath $Path) { return }
-    Start-Sleep -Milliseconds 250
+function Convert-FixtureCargoVersion {
+  param(
+    [Parameter(Mandatory = $true)] [string]$Source,
+    [Parameter(Mandatory = $true)] [string]$Version
+  )
+  $pattern = [regex]::new('(?m)^(version = ")[^"]+("(?=\r?$))')
+  if ($pattern.Matches($Source).Count -ne 1) {
+    throw 'Updater fixture could not uniquely locate the desktop Cargo package version'
   }
-  throw "Timed out waiting for $Path"
+  return $pattern.Replace($Source, ('${1}' + $Version + '${2}'), 1)
 }
 
-function Write-FixtureUpdaterConfig {
+function Convert-FixtureLockVersion {
   param(
-    [string]$Path,
-    [string]$PublicKey
+    [Parameter(Mandatory = $true)] [string]$Source,
+    [Parameter(Mandatory = $true)] [string]$Version
   )
-  [ordered]@{
-    plugins = [ordered]@{
-      updater = [ordered]@{
-        pubkey = $PublicKey
-        dangerousInsecureTransportProtocol = $true
-        endpoints = @("http://127.0.0.1:$port/stable")
-      }
-    }
-  } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $Path -Encoding utf8
+  $pattern = [regex]::new('(?s)(\[\[package\]\]\r?\nname = "sky_desktop_shell"\r?\nversion = ")[^"]+("(?=\r?\n))')
+  if ($pattern.Matches($Source).Count -ne 1) {
+    throw 'Updater fixture could not uniquely locate the desktop Cargo.lock package version'
+  }
+  return $pattern.Replace($Source, ('${1}' + $Version + '${2}'), 1)
 }
 
-function Invoke-FixtureBuild {
-  param(
-    [string]$ConfigPath,
-    [string]$PrivateKeyPath,
-    [string]$PublicRoots
-  )
-  $privateKey = ([IO.File]::ReadAllText($PrivateKeyPath)).Trim()
-  if ([string]::IsNullOrWhiteSpace($privateKey)) {
-    throw "Updater fixture private key is empty"
+# Regression for the release-prep transition: the previous-v4 bridge must stay
+# pinned to alpha.1 even when the canonical candidate source has already moved
+# to an RC (or any later canonical SemVer).
+$syntheticCargo = "[package]`nname = `"sky_desktop_shell`"`nversion = `"4.0.0-rc.1`"`n"
+$syntheticLock = "[[package]]`nname = `"sky_desktop_shell`"`nversion = `"4.0.0-rc.1`"`n"
+$expectedCargo = "[package]`nname = `"sky_desktop_shell`"`nversion = `"$previousVersion`"`n"
+$expectedLock = "[[package]]`nname = `"sky_desktop_shell`"`nversion = `"$previousVersion`"`n"
+if ((Convert-FixtureCargoVersion -Source $syntheticCargo -Version $previousVersion) -ne $expectedCargo -or
+    (Convert-FixtureLockVersion -Source $syntheticLock -Version $previousVersion) -ne $expectedLock) {
+  throw 'Updater fixture previous-v4 version-independence self-test failed'
+}
+
+$invokeArgs = @{ BundleDir = $BundleDir }
+foreach ($name in @('CandidateInstallerPath', 'CandidateSignaturePath', 'CandidateVersion', 'CandidatePublicKeyPath')) {
+  if ($PSBoundParameters.ContainsKey($name)) {
+    $invokeArgs[$name] = Get-Variable -Name $name -ValueOnly
   }
-  $env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS = $PublicRoots
-  $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
-  $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ''
-  try {
-    Push-Location $desktopRoot
-    try {
-      & bun run tauri build --ci --config $ConfigPath -- --profile dist --features tauri-update-fixture
-      if ($LASTEXITCODE -ne 0) { throw "Tauri updater fixture build failed with $LASTEXITCODE" }
-    } finally {
-      Pop-Location
-    }
-  } finally {
-    Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
-    Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
-    Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
-  }
+}
+if ($KeepFixtureOnFailure) {
+  $invokeArgs['KeepFixtureOnFailure'] = $true
 }
 
 try {
-  New-Item -ItemType Directory -Path $fixtureRoot, $installRoot -Force | Out-Null
-  New-Item -ItemType Directory -Path $BundleDir -Force | Out-Null
-  $bundleRoot = (Resolve-Path -LiteralPath $BundleDir -ErrorAction Stop).Path
+  $bridgeCargo = Convert-FixtureCargoVersion -Source $cargoSource -Version $previousVersion
+  $bridgeLock = Convert-FixtureLockVersion -Source $lockSource -Version $previousVersion
+  [IO.File]::WriteAllText($candidateCargoPath, $bridgeCargo, [Text.UTF8Encoding]::new($false))
+  [IO.File]::WriteAllText($lockPath, $bridgeLock, [Text.UTF8Encoding]::new($false))
 
-  Push-Location $desktopRoot
-  try {
-    bun run tauri signer generate --ci --password '' --force -w $oldKeyPath | Out-Null
-    bun run tauri signer generate --ci --password '' --force -w $newKeyPath | Out-Null
-  } finally {
-    Pop-Location
-  }
-  $oldPublicKey = ([IO.File]::ReadAllText("$oldKeyPath.pub")).Trim()
-  $newPublicKey = if ($providedCandidate) {
-    $candidatePublicKey = (Resolve-Path -LiteralPath $CandidatePublicKeyPath -ErrorAction Stop).Path
-    $candidatePublicKeyItem = Get-Item -LiteralPath $candidatePublicKey -ErrorAction Stop
-    if ($candidatePublicKeyItem.Length -le 0 -or $candidatePublicKeyItem.Length -gt 4096) {
-      throw 'Provided candidate public key is empty or unbounded'
-    }
-    ([IO.File]::ReadAllText($candidatePublicKey)).Trim()
-  } else {
-    ([IO.File]::ReadAllText("$newKeyPath.pub")).Trim()
-  }
-  if ([string]::IsNullOrWhiteSpace($oldPublicKey) -or [string]::IsNullOrWhiteSpace($newPublicKey)) {
-    throw 'Updater fixture public key generation failed'
-  }
-  if ($newPublicKey -match 'PRIVATE KEY' -or $newPublicKey.Length -gt 4096) {
-    throw 'Updater fixture public key contains forbidden or unbounded material'
-  }
-  Write-FixtureUpdaterConfig $bridgeConfigPath $oldPublicKey
-  Write-FixtureUpdaterConfig $cutoverConfigPath $newPublicKey
-
-  # Build only the throwaway bridge client with old+new roots. In production
-  # qualification the candidate below is the exact installer and signature
-  # downloaded from the release draft; it is never rebuilt by this fixture.
-  Invoke-FixtureBuild $bridgeConfigPath $oldKeyPath "$oldPublicKey|$newPublicKey"
-  $previousInstallers = @(Get-ChildItem -LiteralPath $bundleRoot -Filter '*4.0.0-alpha.1_x64-setup.exe' -File)
-  if ($previousInstallers.Count -ne 1) {
-    throw "Expected exactly one bridge-v4 installer, found $($previousInstallers.Count)"
-  }
-  Copy-Item -LiteralPath $previousInstallers[0].FullName -Destination $previousInstallerCopy -Force
-
-  if ($providedCandidate) {
-    $candidateArchive = Get-Item -LiteralPath (Resolve-Path -LiteralPath $CandidateInstallerPath -ErrorAction Stop).Path -ErrorAction Stop
-    $candidateSignature = Get-Item -LiteralPath (Resolve-Path -LiteralPath $CandidateSignaturePath -ErrorAction Stop).Path -ErrorAction Stop
-    if ($candidateArchive.Extension.ToLowerInvariant() -ne '.exe' -or
-      $candidateSignature.Name -ne "$($candidateArchive.Name).sig") {
-      throw 'Provided candidate installer/signature names are not an exact pair'
-    }
-  } else {
-    $cargoCandidate = $cargoSource -replace 'version = "4\.0\.0-alpha\.1"', ('version = "' + $candidateVersion + '"')
-    $lockCandidate = [regex]::Replace(
-      $lockSource,
-      '(?s)(name = "sky_desktop_shell"\r?\nversion = ")4\.0\.0-alpha\.1("\r?\n)',
-      '${1}' + $candidateVersion + '${2}',
-      1
-    )
-    if ($lockCandidate -eq $lockSource) { throw 'Could not locate the desktop package in Cargo.lock' }
-    [IO.File]::WriteAllText($candidateCargoPath, $cargoCandidate, [Text.UTF8Encoding]::new($false))
-    [IO.File]::WriteAllText($lockPath, $lockCandidate, [Text.UTF8Encoding]::new($false))
-    Invoke-FixtureBuild $cutoverConfigPath $newKeyPath $newPublicKey
-
-    $candidateArchives = @(Get-ChildItem -LiteralPath $bundleRoot -Filter "*${candidateVersion}*-setup.exe" -File)
-    if ($candidateArchives.Count -ne 1) {
-      throw "Expected exactly one new-root candidate installer, found $($candidateArchives.Count)"
-    }
-    $candidateArchive = $candidateArchives[0]
-    $candidateSignature = Get-Item -LiteralPath ($candidateArchive.FullName + '.sig') -ErrorAction Stop
-  }
-  $signatureText = ([IO.File]::ReadAllText($candidateSignature.FullName)).Trim()
-  if ([string]::IsNullOrWhiteSpace($signatureText)) { throw 'Candidate updater signature is empty' }
-
-  if (-not $providedCandidate) {
-    # Sign the exact candidate bytes with the old root only. This detached
-    # signature is used after cutover to prove the new-root-only client rejects
-    # an old-root artifact through its real Update::download path.
-    Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
-    Push-Location $desktopRoot
-    try {
-      bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath | Out-Null
-    } finally {
-      Pop-Location
-    }
-    Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
-    $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
-    if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
-  }
-
-  $newManifest = [ordered]@{
-    version = $candidateVersion
-    notes = 'Deterministic bridge rotation candidate.'
-    pub_date = '2026-09-04T00:00:00Z'
-    platforms = [ordered]@{
-      'windows-x86_64-nsis' = [ordered]@{
-        signature = $signatureText
-        url = "http://127.0.0.1:$port/candidate/update.exe"
-      }
-    }
-  }
-  $newManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $manifestPath -Encoding utf8
-  if (-not $providedCandidate) {
-    $oldManifest = [ordered]@{
-      version = $cutoverVersion
-      notes = 'Old-root rejection candidate.'
-      pub_date = '2026-09-04T00:00:00Z'
-      platforms = [ordered]@{
-        'windows-x86_64-nsis' = [ordered]@{
-          signature = $oldSignatureText
-          url = "http://127.0.0.1:$port/candidate/update.exe"
-        }
-      }
-    }
-    $oldManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $oldManifestPath -Encoding utf8
-  }
-
-  $archivePath = $candidateArchive.FullName
-  $serverJob = Start-Job -ScriptBlock {
-    param($Port, $ManifestPath, $ArchivePath, $StopPath)
-    $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Parse('127.0.0.1'), $Port)
-    $listener.Start()
-    try {
-      $acceptTask = $listener.AcceptTcpClientAsync()
-      while (-not (Test-Path -LiteralPath $StopPath)) {
-        if (-not $acceptTask.Wait(250)) { continue }
-        $client = $acceptTask.Result
-        $acceptTask = $listener.AcceptTcpClientAsync()
-        $stream = $null
-        try {
-          $stream = $client.GetStream()
-          $requestBytes = [byte[]]::new(8192)
-          $read = $stream.Read($requestBytes, 0, $requestBytes.Length)
-          $request = [Text.Encoding]::ASCII.GetString($requestBytes, 0, $read)
-          $path = ($request -split "`r?`n", 2)[0].Split(' ')[1].Split('?')[0]
-          if ($path -eq '/stable' -or $path -eq '/beta') {
-            $bytes = [IO.File]::ReadAllBytes($ManifestPath)
-            $contentType = 'application/json'
-            $status = '200 OK'
-          } elseif ($path -eq '/candidate/update.exe') {
-            $bytes = [IO.File]::ReadAllBytes($ArchivePath)
-            $contentType = 'application/octet-stream'
-            $status = '200 OK'
-          } else {
-            $bytes = [Text.Encoding]::UTF8.GetBytes('not found')
-            $contentType = 'text/plain'
-            $status = '404 Not Found'
-          }
-          $header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 $status`r`nContent-Type: $contentType`r`nContent-Length: $($bytes.Length)`r`nConnection: close`r`n`r`n")
-          $stream.Write($header, 0, $header.Length)
-          $stream.Write($bytes, 0, $bytes.Length)
-          $stream.Flush()
-        } finally {
-          if ($null -ne $stream) { $stream.Close() }
-          $client.Close()
-        }
-      }
-    } finally {
-      $listener.Stop()
-      $listener.Close()
-    }
-  } -ArgumentList $port, $manifestPath, $archivePath, $stopPath
-
-  $serverReady = $false
-  $serverDeadline = [DateTime]::UtcNow.AddSeconds(30)
-  while ([DateTime]::UtcNow -lt $serverDeadline) {
-    try {
-      $response = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$port/stable" -TimeoutSec 2
-      if ($response.StatusCode -eq 200) { $serverReady = $true; break }
-    } catch { }
-    Start-Sleep -Milliseconds 250
-  }
-  if (-not $serverReady) {
-    $serverOutput = Receive-Job -Job $serverJob -Keep | Out-String
-    throw "Local signed updater fixture did not become ready. Server job output: $serverOutput"
-  }
-
-  $installerRun = Start-Process -FilePath $previousInstallerCopy -ArgumentList @('/S', "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
-  if ($installerRun.ExitCode -ne 0) { throw "Bridge-v4 installer exited with $($installerRun.ExitCode)" }
-  $locationKey = 'HKCU:\Software\pumni\Sky Auto Player'
-  New-Item -Path $locationKey -Force -Value $installRoot | Out-Null
-  $appPath = Join-Path $installRoot 'sky_desktop_shell.exe'
-  if (-not (Test-Path -LiteralPath $appPath)) { throw "Installed bridge app is missing: $appPath" }
-
-  $appProcess = Start-Process -FilePath $appPath -ArgumentList @(
-    '--selftest-desktop-update',
-    '--selftest-update-marker', $markerPath,
-    '--selftest-update-safety-marker', $safetyPath
-  ) -WindowStyle Hidden -PassThru
-  Wait-Process -Id $appProcess.Id -Timeout 180
-  Wait-ForPath -Path $markerPath
-  $completion = ([IO.File]::ReadAllText($markerPath)).Trim()
-  if ($completion -ne "update-complete:$candidateVersion") {
-    throw "Bridge client did not apply the new-root candidate: $completion"
-  }
-
-  Wait-ForPath -Path $safetyPath
-  $phases = @(Get-Content -LiteralPath $safetyPath)
-  $requiredPhases = @('activity.quiesced', 'playback.keys_released', 'state.persisted', 'resources.closed')
-  for ($index = 0; $index -lt $requiredPhases.Count; $index++) {
-    $offset = [array]::IndexOf($phases, $requiredPhases[$index])
-    if ($offset -lt 0) { throw "Missing updater shutdown safety phase: $($requiredPhases[$index])" }
-    if ($index -gt 0 -and $offset -le $previousOffset) {
-      throw 'Updater shutdown safety phases were not ordered'
-    }
-    $previousOffset = $offset
-  }
-
-  if ($providedCandidate) {
-    "Packaged Tauri updater draft qualification: PASS (throwaway previous-v4 bridge applied the exact downloaded candidate $candidateVersion; safety phases=$($requiredPhases -join ', '))" |
-      Add-Content $summaryPath -Encoding UTF8
-  } else {
-    # Switch only the server manifest. The restarted candidate is the cutover
-    # binary compiled with [new]; it must reject the old-only detached signature.
-    Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
-    $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
-      '--selftest-desktop-update',
-      '--selftest-update-marker', $cutoverMarkerPath
-    ) -WindowStyle Hidden -PassThru
-    Wait-Process -Id $cutoverProcess.Id -Timeout 180
-    Wait-ForPath -Path $cutoverMarkerPath
-    $cutoverResult = ([IO.File]::ReadAllText($cutoverMarkerPath)).Trim()
-    if (-not $cutoverResult.StartsWith('update-failed:')) {
-      throw "Cutover client accepted an old-root artifact: $cutoverResult"
-    }
-    "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; cutover [new] rejected old-root-only $cutoverVersion; safety phases=$($requiredPhases -join ', '))" |
-      Add-Content $summaryPath -Encoding UTF8
-  }
+  & (Join-Path $PSScriptRoot 'ci_tauri_update_e2e_core.ps1') @invokeArgs
 } finally {
-  if ($null -ne $serverJob) {
-    New-Item -ItemType File -Path $stopPath -Force | Out-Null
-    Stop-Job -Job $serverJob -ErrorAction SilentlyContinue
-    Remove-Job -Job $serverJob -Force -ErrorAction SilentlyContinue
-  }
   [IO.File]::WriteAllText($candidateCargoPath, $cargoSource, [Text.UTF8Encoding]::new($false))
   [IO.File]::WriteAllText($lockPath, $lockSource, [Text.UTF8Encoding]::new($false))
-  Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
-  Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
-  Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
-  if (-not $KeepFixtureOnFailure -and (Test-Path -LiteralPath $fixtureRoot)) {
-    Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
-  }
 }

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -1,0 +1,362 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BundleDir,
+  [string]$CandidateInstallerPath,
+  [string]$CandidateSignaturePath,
+  [string]$CandidateVersion,
+  [string]$CandidatePublicKeyPath,
+  [switch]$KeepFixtureOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$desktopRoot = Join-Path $repoRoot 'desktop'
+$runnerTemp = if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+  [IO.Path]::GetTempPath()
+} else {
+  $env:RUNNER_TEMP
+}
+$summaryPath = if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+  Join-Path $runnerTemp 'sky-auto-player-tauri-update-summary.md'
+} else {
+  $env:GITHUB_STEP_SUMMARY
+}
+$fixtureRoot = Join-Path $runnerTemp ('sky-auto-player-tauri-update-' + [guid]::NewGuid().ToString('N'))
+$installRoot = Join-Path $fixtureRoot 'installed'
+$markerPath = Join-Path $fixtureRoot 'completion.txt'
+$cutoverMarkerPath = Join-Path $fixtureRoot 'cutover.txt'
+$safetyPath = Join-Path $fixtureRoot 'safety.txt'
+$stopPath = Join-Path $fixtureRoot 'stop-server'
+$manifestPath = Join-Path $fixtureRoot 'manifest.json'
+$oldManifestPath = Join-Path $fixtureRoot 'old-manifest.json'
+$bridgeConfigPath = Join-Path $fixtureRoot 'bridge-updater.json'
+$cutoverConfigPath = Join-Path $fixtureRoot 'cutover-updater.json'
+$oldKeyPath = Join-Path $fixtureRoot 'old.key'
+$newKeyPath = Join-Path $fixtureRoot 'new.key'
+$oldSignaturePath = Join-Path $fixtureRoot 'old.sig'
+$candidateForOldSigningPath = Join-Path $fixtureRoot 'candidate-for-old-signing.exe'
+$providedCandidate = -not [string]::IsNullOrWhiteSpace($CandidateInstallerPath) -or
+  -not [string]::IsNullOrWhiteSpace($CandidateSignaturePath) -or
+  -not [string]::IsNullOrWhiteSpace($CandidateVersion) -or
+  -not [string]::IsNullOrWhiteSpace($CandidatePublicKeyPath)
+if ($providedCandidate) {
+  if ([string]::IsNullOrWhiteSpace($CandidateInstallerPath) -or
+    [string]::IsNullOrWhiteSpace($CandidateSignaturePath) -or
+    [string]::IsNullOrWhiteSpace($CandidateVersion) -or
+    [string]::IsNullOrWhiteSpace($CandidatePublicKeyPath)) {
+    throw 'Provided-candidate updater qualification requires installer, signature, version, and public-key paths'
+  }
+  if ($CandidateVersion -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+    throw "Provided-candidate updater qualification received a non-canonical SemVer: $CandidateVersion"
+  }
+}
+$candidateVersion = if ($providedCandidate) { $CandidateVersion } else { '4.0.0-alpha.2' }
+$cutoverVersion = '4.0.0-alpha.3'
+$port = 17845
+$serverJob = $null
+$previousInstallerCopy = Join-Path $fixtureRoot 'previous-v4-setup.exe'
+$candidateArchive = $null
+$candidateSignature = $null
+$candidateCargoPath = Join-Path $desktopRoot 'src-tauri/Cargo.toml'
+$lockPath = Join-Path $repoRoot 'rust/Cargo.lock'
+$cargoSource = [IO.File]::ReadAllText($candidateCargoPath)
+$lockSource = [IO.File]::ReadAllText($lockPath)
+
+function Wait-ForPath {
+  param([string]$Path, [int]$TimeoutSeconds = 180)
+  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    if (Test-Path -LiteralPath $Path) { return }
+    Start-Sleep -Milliseconds 250
+  }
+  throw "Timed out waiting for $Path"
+}
+
+function Write-FixtureUpdaterConfig {
+  param(
+    [string]$Path,
+    [string]$PublicKey
+  )
+  [ordered]@{
+    plugins = [ordered]@{
+      updater = [ordered]@{
+        pubkey = $PublicKey
+        dangerousInsecureTransportProtocol = $true
+        endpoints = @("http://127.0.0.1:$port/stable")
+      }
+    }
+  } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+
+function Invoke-FixtureBuild {
+  param(
+    [string]$ConfigPath,
+    [string]$PrivateKeyPath,
+    [string]$PublicRoots
+  )
+  $privateKey = ([IO.File]::ReadAllText($PrivateKeyPath)).Trim()
+  if ([string]::IsNullOrWhiteSpace($privateKey)) {
+    throw "Updater fixture private key is empty"
+  }
+  $env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS = $PublicRoots
+  $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
+  $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ''
+  try {
+    Push-Location $desktopRoot
+    try {
+      & bun run tauri build --ci --config $ConfigPath -- --profile dist --features tauri-update-fixture
+      if ($LASTEXITCODE -ne 0) { throw "Tauri updater fixture build failed with $LASTEXITCODE" }
+    } finally {
+      Pop-Location
+    }
+  } finally {
+    Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
+    Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
+    Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+  }
+}
+
+try {
+  New-Item -ItemType Directory -Path $fixtureRoot, $installRoot -Force | Out-Null
+  New-Item -ItemType Directory -Path $BundleDir -Force | Out-Null
+  $bundleRoot = (Resolve-Path -LiteralPath $BundleDir -ErrorAction Stop).Path
+
+  Push-Location $desktopRoot
+  try {
+    bun run tauri signer generate --ci --password '' --force -w $oldKeyPath | Out-Null
+    bun run tauri signer generate --ci --password '' --force -w $newKeyPath | Out-Null
+  } finally {
+    Pop-Location
+  }
+  $oldPublicKey = ([IO.File]::ReadAllText("$oldKeyPath.pub")).Trim()
+  $newPublicKey = if ($providedCandidate) {
+    $candidatePublicKey = (Resolve-Path -LiteralPath $CandidatePublicKeyPath -ErrorAction Stop).Path
+    $candidatePublicKeyItem = Get-Item -LiteralPath $candidatePublicKey -ErrorAction Stop
+    if ($candidatePublicKeyItem.Length -le 0 -or $candidatePublicKeyItem.Length -gt 4096) {
+      throw 'Provided candidate public key is empty or unbounded'
+    }
+    ([IO.File]::ReadAllText($candidatePublicKey)).Trim()
+  } else {
+    ([IO.File]::ReadAllText("$newKeyPath.pub")).Trim()
+  }
+  if ([string]::IsNullOrWhiteSpace($oldPublicKey) -or [string]::IsNullOrWhiteSpace($newPublicKey)) {
+    throw 'Updater fixture public key generation failed'
+  }
+  if ($newPublicKey -match 'PRIVATE KEY' -or $newPublicKey.Length -gt 4096) {
+    throw 'Updater fixture public key contains forbidden or unbounded material'
+  }
+  Write-FixtureUpdaterConfig $bridgeConfigPath $oldPublicKey
+  Write-FixtureUpdaterConfig $cutoverConfigPath $newPublicKey
+
+  # Build only the throwaway bridge client with old+new roots. In production
+  # qualification the candidate below is the exact installer and signature
+  # downloaded from the release draft; it is never rebuilt by this fixture.
+  Invoke-FixtureBuild $bridgeConfigPath $oldKeyPath "$oldPublicKey|$newPublicKey"
+  $previousInstallers = @(Get-ChildItem -LiteralPath $bundleRoot -Filter '*4.0.0-alpha.1_x64-setup.exe' -File)
+  if ($previousInstallers.Count -ne 1) {
+    throw "Expected exactly one bridge-v4 installer, found $($previousInstallers.Count)"
+  }
+  Copy-Item -LiteralPath $previousInstallers[0].FullName -Destination $previousInstallerCopy -Force
+
+  if ($providedCandidate) {
+    $candidateArchive = Get-Item -LiteralPath (Resolve-Path -LiteralPath $CandidateInstallerPath -ErrorAction Stop).Path -ErrorAction Stop
+    $candidateSignature = Get-Item -LiteralPath (Resolve-Path -LiteralPath $CandidateSignaturePath -ErrorAction Stop).Path -ErrorAction Stop
+    if ($candidateArchive.Extension.ToLowerInvariant() -ne '.exe' -or
+      $candidateSignature.Name -ne "$($candidateArchive.Name).sig") {
+      throw 'Provided candidate installer/signature names are not an exact pair'
+    }
+  } else {
+    $cargoCandidate = $cargoSource -replace 'version = "4\.0\.0-alpha\.1"', ('version = "' + $candidateVersion + '"')
+    $lockCandidate = [regex]::Replace(
+      $lockSource,
+      '(?s)(name = "sky_desktop_shell"\r?\nversion = ")4\.0\.0-alpha\.1("\r?\n)',
+      '${1}' + $candidateVersion + '${2}',
+      1
+    )
+    if ($lockCandidate -eq $lockSource) { throw 'Could not locate the desktop package in Cargo.lock' }
+    [IO.File]::WriteAllText($candidateCargoPath, $cargoCandidate, [Text.UTF8Encoding]::new($false))
+    [IO.File]::WriteAllText($lockPath, $lockCandidate, [Text.UTF8Encoding]::new($false))
+    Invoke-FixtureBuild $cutoverConfigPath $newKeyPath $newPublicKey
+
+    $candidateArchives = @(Get-ChildItem -LiteralPath $bundleRoot -Filter "*${candidateVersion}*-setup.exe" -File)
+    if ($candidateArchives.Count -ne 1) {
+      throw "Expected exactly one new-root candidate installer, found $($candidateArchives.Count)"
+    }
+    $candidateArchive = $candidateArchives[0]
+    $candidateSignature = Get-Item -LiteralPath ($candidateArchive.FullName + '.sig') -ErrorAction Stop
+  }
+  $signatureText = ([IO.File]::ReadAllText($candidateSignature.FullName)).Trim()
+  if ([string]::IsNullOrWhiteSpace($signatureText)) { throw 'Candidate updater signature is empty' }
+
+  if (-not $providedCandidate) {
+    # Sign the exact candidate bytes with the old root only. This detached
+    # signature is used after cutover to prove the new-root-only client rejects
+    # an old-root artifact through its real Update::download path.
+    Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
+    Push-Location $desktopRoot
+    try {
+      bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath | Out-Null
+    } finally {
+      Pop-Location
+    }
+    Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
+    $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
+    if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
+  }
+
+  $newManifest = [ordered]@{
+    version = $candidateVersion
+    notes = 'Deterministic bridge rotation candidate.'
+    pub_date = '2026-09-04T00:00:00Z'
+    platforms = [ordered]@{
+      'windows-x86_64-nsis' = [ordered]@{
+        signature = $signatureText
+        url = "http://127.0.0.1:$port/candidate/update.exe"
+      }
+    }
+  }
+  $newManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $manifestPath -Encoding utf8
+  if (-not $providedCandidate) {
+    $oldManifest = [ordered]@{
+      version = $cutoverVersion
+      notes = 'Old-root rejection candidate.'
+      pub_date = '2026-09-04T00:00:00Z'
+      platforms = [ordered]@{
+        'windows-x86_64-nsis' = [ordered]@{
+          signature = $oldSignatureText
+          url = "http://127.0.0.1:$port/candidate/update.exe"
+        }
+      }
+    }
+    $oldManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $oldManifestPath -Encoding utf8
+  }
+
+  $archivePath = $candidateArchive.FullName
+  $serverJob = Start-Job -ScriptBlock {
+    param($Port, $ManifestPath, $ArchivePath, $StopPath)
+    $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Parse('127.0.0.1'), $Port)
+    $listener.Start()
+    try {
+      $acceptTask = $listener.AcceptTcpClientAsync()
+      while (-not (Test-Path -LiteralPath $StopPath)) {
+        if (-not $acceptTask.Wait(250)) { continue }
+        $client = $acceptTask.Result
+        $acceptTask = $listener.AcceptTcpClientAsync()
+        $stream = $null
+        try {
+          $stream = $client.GetStream()
+          $requestBytes = [byte[]]::new(8192)
+          $read = $stream.Read($requestBytes, 0, $requestBytes.Length)
+          $request = [Text.Encoding]::ASCII.GetString($requestBytes, 0, $read)
+          $path = ($request -split "`r?`n", 2)[0].Split(' ')[1].Split('?')[0]
+          if ($path -eq '/stable' -or $path -eq '/beta') {
+            $bytes = [IO.File]::ReadAllBytes($ManifestPath)
+            $contentType = 'application/json'
+            $status = '200 OK'
+          } elseif ($path -eq '/candidate/update.exe') {
+            $bytes = [IO.File]::ReadAllBytes($ArchivePath)
+            $contentType = 'application/octet-stream'
+            $status = '200 OK'
+          } else {
+            $bytes = [Text.Encoding]::UTF8.GetBytes('not found')
+            $contentType = 'text/plain'
+            $status = '404 Not Found'
+          }
+          $header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 $status`r`nContent-Type: $contentType`r`nContent-Length: $($bytes.Length)`r`nConnection: close`r`n`r`n")
+          $stream.Write($header, 0, $header.Length)
+          $stream.Write($bytes, 0, $bytes.Length)
+          $stream.Flush()
+        } finally {
+          if ($null -ne $stream) { $stream.Close() }
+          $client.Close()
+        }
+      }
+    } finally {
+      $listener.Stop()
+      $listener.Close()
+    }
+  } -ArgumentList $port, $manifestPath, $archivePath, $stopPath
+
+  $serverReady = $false
+  $serverDeadline = [DateTime]::UtcNow.AddSeconds(30)
+  while ([DateTime]::UtcNow -lt $serverDeadline) {
+    try {
+      $response = Invoke-WebRequest -UseBasicParsing -Uri "http://127.0.0.1:$port/stable" -TimeoutSec 2
+      if ($response.StatusCode -eq 200) { $serverReady = $true; break }
+    } catch { }
+    Start-Sleep -Milliseconds 250
+  }
+  if (-not $serverReady) {
+    $serverOutput = Receive-Job -Job $serverJob -Keep | Out-String
+    throw "Local signed updater fixture did not become ready. Server job output: $serverOutput"
+  }
+
+  $installerRun = Start-Process -FilePath $previousInstallerCopy -ArgumentList @('/S', "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
+  if ($installerRun.ExitCode -ne 0) { throw "Bridge-v4 installer exited with $($installerRun.ExitCode)" }
+  $locationKey = 'HKCU:\Software\pumni\Sky Auto Player'
+  New-Item -Path $locationKey -Force -Value $installRoot | Out-Null
+  $appPath = Join-Path $installRoot 'sky_desktop_shell.exe'
+  if (-not (Test-Path -LiteralPath $appPath)) { throw "Installed bridge app is missing: $appPath" }
+
+  $appProcess = Start-Process -FilePath $appPath -ArgumentList @(
+    '--selftest-desktop-update',
+    '--selftest-update-marker', $markerPath,
+    '--selftest-update-safety-marker', $safetyPath
+  ) -WindowStyle Hidden -PassThru
+  Wait-Process -Id $appProcess.Id -Timeout 180
+  Wait-ForPath -Path $markerPath
+  $completion = ([IO.File]::ReadAllText($markerPath)).Trim()
+  if ($completion -ne "update-complete:$candidateVersion") {
+    throw "Bridge client did not apply the new-root candidate: $completion"
+  }
+
+  Wait-ForPath -Path $safetyPath
+  $phases = @(Get-Content -LiteralPath $safetyPath)
+  $requiredPhases = @('activity.quiesced', 'playback.keys_released', 'state.persisted', 'resources.closed')
+  for ($index = 0; $index -lt $requiredPhases.Count; $index++) {
+    $offset = [array]::IndexOf($phases, $requiredPhases[$index])
+    if ($offset -lt 0) { throw "Missing updater shutdown safety phase: $($requiredPhases[$index])" }
+    if ($index -gt 0 -and $offset -le $previousOffset) {
+      throw 'Updater shutdown safety phases were not ordered'
+    }
+    $previousOffset = $offset
+  }
+
+  if ($providedCandidate) {
+    "Packaged Tauri updater draft qualification: PASS (throwaway previous-v4 bridge applied the exact downloaded candidate $candidateVersion; safety phases=$($requiredPhases -join ', '))" |
+      Add-Content $summaryPath -Encoding UTF8
+  } else {
+    # Switch only the server manifest. The restarted candidate is the cutover
+    # binary compiled with [new]; it must reject the old-only detached signature.
+    Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
+    $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
+      '--selftest-desktop-update',
+      '--selftest-update-marker', $cutoverMarkerPath
+    ) -WindowStyle Hidden -PassThru
+    Wait-Process -Id $cutoverProcess.Id -Timeout 180
+    Wait-ForPath -Path $cutoverMarkerPath
+    $cutoverResult = ([IO.File]::ReadAllText($cutoverMarkerPath)).Trim()
+    if (-not $cutoverResult.StartsWith('update-failed:')) {
+      throw "Cutover client accepted an old-root artifact: $cutoverResult"
+    }
+    "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; cutover [new] rejected old-root-only $cutoverVersion; safety phases=$($requiredPhases -join ', '))" |
+      Add-Content $summaryPath -Encoding UTF8
+  }
+} finally {
+  if ($null -ne $serverJob) {
+    New-Item -ItemType File -Path $stopPath -Force | Out-Null
+    Stop-Job -Job $serverJob -ErrorAction SilentlyContinue
+    Remove-Job -Job $serverJob -Force -ErrorAction SilentlyContinue
+  }
+  [IO.File]::WriteAllText($candidateCargoPath, $cargoSource, [Text.UTF8Encoding]::new($false))
+  [IO.File]::WriteAllText($lockPath, $lockSource, [Text.UTF8Encoding]::new($false))
+  Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
+  Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
+  Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+  if (-not $KeepFixtureOnFailure -and (Test-Path -LiteralPath $fixtureRoot)) {
+    Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}


### PR DESCRIPTION
Release-blocking hotfix for #109 and PR #132 after exact-head CI #700 failed in `Packaged v4 updater fixture qualification`.

Observed failure on #132 head `0cf08badbd3c61c50a7304256aab67088cdfc087`:
- canonical package had correctly moved to `4.0.0-rc.1`;
- the updater fixture built its throwaway bridge using that canonical version;
- it then correctly searched for historical previous-v4 `4.0.0-alpha.1`, finding zero installers.

Root cause: the fixture implicitly assumed the repository's canonical version was still `4.0.0-alpha.1`.

Fix:
- preserve the existing updater E2E implementation unchanged as `scripts/ci_tauri_update_e2e_core.ps1`;
- keep `scripts/ci_tauri_update_e2e.ps1` as the stable public/production entrypoint;
- the entrypoint snapshots canonical Cargo sources, materializes the historical bridge package as exactly `4.0.0-alpha.1`, invokes the existing core, and restores the original canonical sources in `finally`;
- add a no-network synthetic regression proving a source already at `4.0.0-rc.1` is transformed to the historical bridge version;
- preserve all existing provided-candidate arguments and `KeepFixtureOnFailure` behavior.

Acceptance order: exact-head CI green -> merge -> post-merge main CI green -> rebuild PR #132 on that main -> exact-head full CI. Do not rerun unchanged #700 and do not merge #132 before this hotfix is accepted.