### PR TITLE
fix(v4): implement Windows Credential Manager session broker for updater passphrase

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -24,11 +24,6 @@ on:
         description: "Path to the externally stored updater key on the dedicated runner"
         required: true
         type: string
-      updater_password_env:
-        description: "Name of the runner-local environment variable containing the key passphrase"
-        required: true
-        default: TAURI_SIGNING_PRIVATE_KEY_PASSWORD
-        type: string
       release_notes_path:
         description: "Bounded release notes file in the checked-out source"
         required: true
@@ -66,7 +61,6 @@ jobs:
       V4_RELEASE_WORKFLOW_SHA: ${{ github.sha }}
       V4_RELEASE_NOTES_PATH: ${{ inputs.release_notes_path }}
       V4_RELEASE_PUBLICATION_DATE: ${{ inputs.publication_date_utc }}
-      V4_RELEASE_UPDATER_PASSWORD_ENV: ${{ inputs.updater_password_env }}
 
     steps:
       - name: Initialize release state root
@@ -124,8 +118,7 @@ jobs:
             -SourceSha $env:V4_RELEASE_SOURCE_SHA `
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT `
-            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH `
-            -UpdaterPasswordEnv $env:V4_RELEASE_UPDATER_PASSWORD_ENV
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
 
       - name: Create exact candidate draft in release authority
         env:

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -133,9 +133,54 @@ cryptographic provenance design.
 
 Dedicated self-hosted Windows runners executing production releases must satisfy strict hygiene preconditions:
 1. **Clean Workspace Checkout**: The runner workspace must be checked out cleanly to the exact target release commit SHA with no uncommitted modifications or untracked dirty files (`git status --porcelain` is empty).
-2. **Unpolluted Environment Overrides**: The runner environment must not inherit ambient signing environment variables (such as pre-set `TAURI_SIGNING_PRIVATE_KEY` or `TAURI_SIGNING_PRIVATE_KEY_PATH`). The orchestrator checks this pre-flight and fails closed if pre-existing keys or paths are detected.
+2. **Unpolluted Environment Overrides**: The runner environment must not inherit ambient signing environment variables (such as pre-set `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PATH`, or `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`). The orchestrator checks this pre-flight and fails closed if pre-existing keys or paths are detected.
 3. **Stale Output Purge**: Target bundle and evidence directories are purged of previous candidate installers, signatures, and evidence prior to building. Stale outputs from aborted or previous runs can never be reused.
 4. **Isolated Key Storage**: Private updater keys and certificate stores must reside outside the repository tree, accessible only via restricted paths or secure hardware/cloud seams.
+
+### 2.4 Production Passphrase Transport: Windows Credential Manager Session Broker
+
+Incident #140 established that parent-process environment variable inheritance does not reach Actions step processes on dedicated runner hosts (such as PUMZ). Parent-process env inheritance is explicitly **not** the production transport.
+
+Production passphrase custody and transport is governed by the Windows Credential Manager generic session broker:
+
+```text
+[Secure Operator Prompt (Read-Host -AsSecureString)]
+               |
+               v
+  (1) PROVISION SESSION CREDENTIAL
+      - CredWriteW (CRED_TYPE_GENERIC, CRED_PERSIST_SESSION)
+      - Fixed canonical target: SkyAutoPlayer/V4UpdaterProduction (public metadata)
+               |
+               v
+  (2) ACTIONS DISPATCH (release-v4.yml)
+      - Runs BuildCandidate on dedicated runner
+      - No passphrase in workflow inputs, secrets, or runner .env
+               |
+               v
+  (3) BROKER CONSUMPTION (v4_updater_credential_broker.ps1)
+      - CredReadW against fixed target SkyAutoPlayer/V4UpdaterProduction
+      - Fail-closed if absent or empty
+      - Set TAURI_SIGNING_PRIVATE_KEY_PASSWORD at Process scope only
+               |
+               v
+  (4) ORCHESTRATION & PRE-PACKAGING VERIFIER
+      - Pre-packaging verification: cargo xtask updater-trust verify-private-key
+      - Canonical Public Key ID: 19AABD2E7838818C
+      - Single build once and qualify exact bytes
+               |
+               v
+  (5) MANDATORY CLEANUP (finally block)
+      - Restore / clear process-scoped TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+      - CredDeleteW against SkyAutoPlayer/V4UpdaterProduction
+      - Clear managed references
+```
+
+**Security Invariants**:
+- **No Parent-Process Inheritance**: Production does not rely on ambient shell inheritance.
+- **Fixed Canonical Target**: The Credential Manager target name is `SkyAutoPlayer/V4UpdaterProduction`. This target name is public metadata committed in source; workflow dispatch never accepts arbitrary credential targets.
+- **Zero Cloud Secret Exposure**: The passphrase is never stored in GitHub Secrets, runner `.env` files, command-line flags, GitHub issues/PRs/chat, or repository source files.
+- **Ephemeral Session Material**: Provisioned under `CRED_PERSIST_SESSION` and deterministically deleted by the `finally` block of `BuildCandidate`.
+- **Pre-Packaging Verifier**: Pre-packaging verification remains mandatory and enforces Key ID `19AABD2E7838818C`.
 
 ---
 
@@ -251,8 +296,12 @@ ValidateRequest -> ValidateAuthority -> BuildCandidate -> CreateDraft
 ```
 
 Only `BuildCandidate` calls
-`scripts/orchestrate_v4_production_release.ps1`, exactly once. The candidate
-manifest is the only asset upload authority. The following states download the
+`scripts/orchestrate_v4_production_release.ps1`, exactly once. `BuildCandidate`
+acquires the updater key passphrase through the fixed Windows Credential Manager
+session broker (`scripts/v4_updater_credential_broker.ps1`, target `SkyAutoPlayer/V4UpdaterProduction`)
+into process-scoped `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, passing no plaintext password
+CLI arguments, and automatically deletes the session credential in its `finally` block.
+The candidate manifest is the only asset upload authority. The following states download the
 draft assets again and compare names, sizes, and SHA-256 digests before running
 the Authenticode `unsigned-zero-budget`, Tauri updater signature, SPDX SBOM,
 exact-bundle, current-user install/launch/uninstall, GUI/input-safety, and

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -64,12 +64,33 @@ cargo xtask updater-trust inventory
    - This is an output-secrecy guarantee only. PowerShell/.NET managed strings are not claimed
      to be cryptographically zeroized by this runbook.
 
+5. **Production Release Passphrase Transport (Windows Credential Manager Broker)**:
+   - Parent-process environment variable inheritance does NOT reach Actions step processes
+     on dedicated runner hosts (incident #140). It is explicitly **not** the production transport.
+   - For production release dispatch, the Release Operator provisions a generic session credential
+     in Windows Credential Manager using `scripts/set_v4_updater_session_credential.ps1`.
+   - The provisioning script uses `Read-Host -AsSecureString` and writes the credential via
+     `CredWriteW` with `CRED_TYPE_GENERIC` and `CRED_PERSIST_SESSION`.
+   - The credential target name is fixed public metadata: `SkyAutoPlayer/V4UpdaterProduction`.
+   - The production workflow (`release-v4.yml`) `BuildCandidate` step calls the broker
+     (`scripts/v4_updater_credential_broker.ps1`) using `CredReadW`, injects the passphrase
+     strictly into process-scoped `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, invokes the release
+     orchestrator, and automatically deletes the credential in `finally` via `CredDeleteW`.
+   - The updater private key remains stored outside the repository and workspace.
+   - Passphrases **never** go into GitHub Secrets, runner `.env` files, command-line arguments,
+     GitHub issues/chat/PRs, or repository files.
+
 ## 3. Local Private Key Verification
 
 Release Operators must verify that their local private key matches the canonical public root
 prior to initiating release packaging. The verification tool signs an ephemeral cryptographic
 nonce and verifies the resulting signature against the compiled public root, without ever
 printing private key material or passphrases to stdout, stderr, or log files.
+
+The canonical public Key ID enforced by the verifier is:
+```text
+Key ID: 19AABD2E7838818C
+```
 
 To prevent password exposure in shell history (such as `PSReadLine` history files) or process listings,
 the verification tools avoid command-line password flags.
@@ -83,6 +104,21 @@ logs or history files:
 ```powershell
 # Prompts securely for passphrase if the private key is encrypted:
 pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key"
+```
+
+### Verification via Windows Credential Manager Broker (Pre-Release / Non-Release Proof)
+
+To verify the private key against the provisioned session credential without interactive prompts:
+
+```powershell
+# 1. Provision session credential as operator:
+pwsh scripts/set_v4_updater_session_credential.ps1
+
+# 2. Verify private key through the credential broker:
+pwsh scripts/verify_v4_updater_private_key.ps1 -KeyPath "E:\secure\v4-updater.key" -UseCredentialBroker
+
+# 3. Clean up session credential when finished (if not consumed by BuildCandidate):
+pwsh scripts/remove_v4_updater_session_credential.ps1
 ```
 
 ### Non-Interactive / Automation Verification via xtask
@@ -100,7 +136,7 @@ cargo xtask updater-trust verify-private-key --key-file "E:\secure\v4-updater.ke
 
 Expected output:
 ```text
-[xtask] Local updater private key matches canonical production v4 root (Key ID: <canonical public-root identity>)
+[xtask] Local updater private key matches canonical production v4 root (Key ID: 19AABD2E7838818C)
 [PASS] Local updater private key matches canonical production v4 root
 ```
 

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -494,6 +494,10 @@ fn v4_release_pipeline_contract_source(
         "secrets.TAURI_SIGNING_PRIVATE_KEY",
         "secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
         "secrets.UPDATER_PRIVATE_KEY",
+        "secrets.UPDATER_PASSWORD",
+        "secrets.V4_UPDATER_PASSWORD",
+        "updater_password_env",
+        "credential_target",
         "Sky-Auto-Player-Updater.exe",
         "MANIFEST.json.sig",
         ".github/workflows/release.yml",
@@ -559,6 +563,7 @@ fn v4_release_pipeline_contract_source(
         "scan_performed",
         "selftest-update-active-playback",
         "scan_v4_defender_exact.ps1",
+        "v4_updater_credential_broker.ps1",
     ] {
         if !pipeline.contains(marker) {
             return Err(
@@ -602,6 +607,18 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     .map_err(|error| -> Box<dyn std::error::Error + Send + Sync> {
         format!("v4 release pipeline contract: {error}").into()
     })?;
+    for script_name in [
+        "scripts/v4_updater_credential_broker.ps1",
+        "scripts/set_v4_updater_session_credential.ps1",
+        "scripts/remove_v4_updater_session_credential.ps1",
+        "scripts/test_v4_updater_credential_broker.ps1",
+    ] {
+        if !root.join(script_name).exists() {
+            return Err(
+                format!("v4 release pipeline is missing required helper: {script_name}").into(),
+            );
+        }
+    }
     let rehearsal_path = root.join("scripts/test_v4_release_authority_rehearsal.ps1");
     let rehearsal = fs::read_to_string(&rehearsal_path)?;
     let upload_helper_path = root.join("scripts/v4_release_authority_upload.ps1");
@@ -3173,7 +3190,7 @@ jobs:
     GH_TOKEN: ${{ github.token }}
 "#;
         let pipeline = r#"
-ValidateRequest ValidateAuthority BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify authority main is not initialized upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1
+ValidateRequest ValidateAuthority BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify authority main is not initialized upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1
 function Invoke-BuildCandidate {
   & pwsh -File orchestrate_v4_production_release.ps1
 }

--- a/scripts/remove_v4_updater_session_credential.ps1
+++ b/scripts/remove_v4_updater_session_credential.ps1
@@ -1,0 +1,28 @@
+# scripts/remove_v4_updater_session_credential.ps1
+# Secure operator cleanup script for Windows Credential Manager generic session credential.
+# Governed by docs/v4-release-execution-topology.md, docs/v4-updater-key-custody.md, and SECURITY.md.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Target = "SkyAutoPlayer/V4UpdaterProduction"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not [System.OperatingSystem]::IsWindows()) {
+    Write-Host "[FAIL] Windows Credential Manager is only supported on Windows"
+    exit 1
+}
+
+. (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
+
+try {
+    Remove-V4UpdaterProductionCredential -Target $Target
+    Write-Host "[PASS] V4 updater session credential removed for target: $Target"
+    exit 0
+} catch {
+    Write-Host "[FAIL] Failed to remove session credential: $($_.Exception.Message)"
+    exit 1
+}

--- a/scripts/remove_v4_updater_session_credential.ps1
+++ b/scripts/remove_v4_updater_session_credential.ps1
@@ -4,8 +4,9 @@
 
 [CmdletBinding()]
 param(
+    # Internal test seam only: non-production target isolation for regression tests.
     [Parameter(Mandatory = $false)]
-    [string]$Target = "SkyAutoPlayer/V4UpdaterProduction"
+    [string]$InternalTestTarget
 )
 
 Set-StrictMode -Version Latest
@@ -16,11 +17,19 @@ if (-not [System.OperatingSystem]::IsWindows()) {
     exit 1
 }
 
+$explicitTarget = $InternalTestTarget
+
 . (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
 
 try {
-    Remove-V4UpdaterProductionCredential -Target $Target
-    Write-Host "[PASS] V4 updater session credential removed for target: $Target"
+    $targetToUse = if (-not [string]::IsNullOrWhiteSpace($explicitTarget)) {
+        $explicitTarget
+    } else {
+        $script:CanonicalCredentialTarget
+    }
+
+    Remove-V4UpdaterProductionCredential -InternalTestTarget $targetToUse
+    Write-Host "[PASS] V4 updater session credential removed for target: $targetToUse"
     exit 0
 } catch {
     Write-Host "[FAIL] Failed to remove session credential: $($_.Exception.Message)"

--- a/scripts/set_v4_updater_session_credential.ps1
+++ b/scripts/set_v4_updater_session_credential.ps1
@@ -1,0 +1,59 @@
+# scripts/set_v4_updater_session_credential.ps1
+# Secure operator provisioning script for Windows Credential Manager generic session credential.
+# Governed by docs/v4-release-execution-topology.md, docs/v4-updater-key-custody.md, and SECURITY.md.
+
+[CmdletBinding()]
+param(
+    # Non-interactive testing seam: only SecureString is accepted; no plaintext password CLI parameter exists.
+    [Parameter(Mandatory = $false)]
+    [System.Security.SecureString]$TestSecureString,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Target = "SkyAutoPlayer/V4UpdaterProduction"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not [System.OperatingSystem]::IsWindows()) {
+    Write-Host "[FAIL] Windows Credential Manager is only supported on Windows"
+    exit 1
+}
+
+. (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
+
+try {
+    $secureInput = if ($null -ne $TestSecureString) {
+        $TestSecureString
+    } else {
+        Read-Host -Prompt "Enter V4 updater production private key passphrase" -AsSecureString
+    }
+
+    if ($null -eq $secureInput -or $secureInput.Length -eq 0) {
+        Write-Host "[FAIL] Passphrase input cannot be empty"
+        exit 1
+    }
+
+    $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureInput)
+    $passwordValue = $null
+    try {
+        $passwordValue = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+        if ([string]::IsNullOrEmpty($passwordValue)) {
+            Write-Host "[FAIL] Passphrase input cannot be empty"
+            exit 1
+        }
+        [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($Target, $passwordValue)
+    } finally {
+        if ($bstr -ne [IntPtr]::Zero) {
+            [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
+        $passwordValue = $null
+        Remove-Variable passwordValue -ErrorAction SilentlyContinue
+    }
+
+    Write-Host "[PASS] V4 updater session credential provisioned for target: $Target"
+    exit 0
+} catch {
+    Write-Host "[FAIL] Failed to provision session credential: $($_.Exception.Message)"
+    exit 1
+}

--- a/scripts/set_v4_updater_session_credential.ps1
+++ b/scripts/set_v4_updater_session_credential.ps1
@@ -8,8 +8,9 @@ param(
     [Parameter(Mandatory = $false)]
     [System.Security.SecureString]$TestSecureString,
 
+    # Internal test seam only: non-production target isolation for regression tests.
     [Parameter(Mandatory = $false)]
-    [string]$Target = "SkyAutoPlayer/V4UpdaterProduction"
+    [string]$InternalTestTarget
 )
 
 Set-StrictMode -Version Latest
@@ -20,9 +21,17 @@ if (-not [System.OperatingSystem]::IsWindows()) {
     exit 1
 }
 
+$explicitTarget = $InternalTestTarget
+
 . (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
 
 try {
+    $targetToUse = if (-not [string]::IsNullOrWhiteSpace($explicitTarget)) {
+        $explicitTarget
+    } else {
+        $script:CanonicalCredentialTarget
+    }
+
     $secureInput = if ($null -ne $TestSecureString) {
         $TestSecureString
     } else {
@@ -42,7 +51,7 @@ try {
             Write-Host "[FAIL] Passphrase input cannot be empty"
             exit 1
         }
-        [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($Target, $passwordValue)
+        [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($targetToUse, $passwordValue)
     } finally {
         if ($bstr -ne [IntPtr]::Zero) {
             [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
@@ -51,7 +60,7 @@ try {
         Remove-Variable passwordValue -ErrorAction SilentlyContinue
     }
 
-    Write-Host "[PASS] V4 updater session credential provisioned for target: $Target"
+    Write-Host "[PASS] V4 updater session credential provisioned for target: $targetToUse"
     exit 0
 } catch {
     Write-Host "[FAIL] Failed to provision session credential: $($_.Exception.Message)"

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -166,9 +166,22 @@ foreach ($marker in @(
     'current-user', 'active-playback-install-rejected', 'upload_url',
     'immutable-releases', 'Assert-ImmutableRelease', 'Start-MpScan',
     'previous-v4-to-exact-downloaded-candidate-update',
-    'selftest-update-active-playback', 'scan_performed'
+    'selftest-update-active-playback', 'scan_performed',
+    'v4_updater_credential_broker.ps1'
 )) {
     if (-not $pipeline.Contains($marker)) { Fail "pipeline marker is missing: $marker" }
+}
+
+foreach ($brokerFile in @(
+    'v4_updater_credential_broker.ps1',
+    'set_v4_updater_session_credential.ps1',
+    'remove_v4_updater_session_credential.ps1',
+    'test_v4_updater_credential_broker.ps1'
+)) {
+    $path = Join-Path $PSScriptRoot $brokerFile
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Fail "required credential broker file is missing: $brokerFile"
+    }
 }
 
 foreach ($marker in @(
@@ -190,6 +203,8 @@ foreach ($forbidden in @(
     'cargo xtask dist', 'Sky-Auto-Player-Updater.exe', 'MANIFEST.json.sig',
     'softprops/action-gh-release', 'secrets.TAURI_SIGNING_PRIVATE_KEY',
     'secrets.UPDATER_PRIVATE_KEY', 'secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD',
+    'secrets.UPDATER_PASSWORD', 'secrets.V4_UPDATER_PASSWORD',
+    'updater_password_env', 'credential_target',
     'V4_RELEASE_STATE_ROOT: ${{ runner.temp }}'
 )) {
     if ($workflow.Contains($forbidden)) { Fail "forbidden production workflow marker remains: $forbidden" }

--- a/scripts/test_v4_updater_credential_broker.ps1
+++ b/scripts/test_v4_updater_credential_broker.ps1
@@ -1,0 +1,335 @@
+# scripts/test_v4_updater_credential_broker.ps1
+# Regression tests for Windows Credential Manager broker, provisioning scripts, and BuildCandidate boundary.
+# Governed by docs/v4-release-execution-topology.md, docs/v4-updater-key-custody.md, and SECURITY.md.
+
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not [System.OperatingSystem]::IsWindows()) {
+    throw "Credential broker regression tests require Windows platform"
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+. (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
+
+function Fail([string]$Message) {
+    throw "FAILED: $Message"
+}
+
+function Assert-NoSecretInText([string]$Secret, [string]$Text, [string]$Context) {
+    if (-not [string]::IsNullOrEmpty($Secret) -and $Text.Contains($Secret)) {
+        Fail "Secret material was emitted in output during: $Context"
+    }
+}
+
+$testTarget = "SkyAutoPlayer/V4UpdaterUnitTest_" + [guid]::NewGuid().ToString("N")
+$testSentinel = "V4_BENIGN_SENTINEL_" + [guid]::NewGuid().ToString("N")
+$fixtureRoot = $null
+
+try {
+    Write-Host "Starting V4 updater credential broker tests..."
+
+    # =========================================================================
+    # Test 1: ABSENT fails closed
+    # =========================================================================
+    Write-Host "Test 1: ABSENT fails closed..."
+    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+        Fail "Test target should not exist before test"
+    }
+    $absentFailedClosed = $false
+    try {
+        $null = Get-V4UpdaterProductionCredential -Target $testTarget
+    } catch {
+        $absentFailedClosed = $true
+        if ($_.Exception.Message -notmatch "absent") {
+            Fail "Absent credential error message did not indicate absence: $($_.Exception.Message)"
+        }
+    }
+    if (-not $absentFailedClosed) {
+        Fail "Get-V4UpdaterProductionCredential did not fail closed on absent credential"
+    }
+    Write-Host "Test 1: PASS"
+
+    # =========================================================================
+    # Test 2: CRED_PERSIST_SESSION credential is readable
+    # =========================================================================
+    Write-Host "Test 2: CRED_PERSIST_SESSION credential is readable..."
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+    if (-not (Test-V4UpdaterProductionCredential -Target $testTarget)) {
+        Fail "Test target should be present after WriteSessionCredential"
+    }
+    $readBack = Get-V4UpdaterProductionCredential -Target $testTarget
+    if ($readBack -ne $testSentinel) {
+        Fail "Read credential does not match written sentinel"
+    }
+    Write-Host "Test 2: PASS"
+
+    # =========================================================================
+    # Test 3: Empty credential blob is rejected
+    # =========================================================================
+    Write-Host "Test 3: Empty credential blob is rejected..."
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteRawCredential($testTarget, [byte[]]@(), 1)
+    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+        Fail "Test-V4UpdaterProductionCredential should report false for empty credential blob"
+    }
+    $emptyFailedClosed = $false
+    try {
+        $null = Get-V4UpdaterProductionCredential -Target $testTarget
+    } catch {
+        $emptyFailedClosed = $true
+        if ($_.Exception.Message -notmatch "empty") {
+            Fail "Empty credential error message did not indicate empty blob: $($_.Exception.Message)"
+        }
+    }
+    if (-not $emptyFailedClosed) {
+        Fail "Get-V4UpdaterProductionCredential did not fail closed on empty credential blob"
+    }
+    Write-Host "Test 3: PASS"
+
+    # =========================================================================
+    # Test 4: Deletion works and is idempotent
+    # =========================================================================
+    Write-Host "Test 4: Deletion works and is idempotent..."
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+    Remove-V4UpdaterProductionCredential -Target $testTarget
+    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+        Fail "Test target should not be present after Remove-V4UpdaterProductionCredential"
+    }
+    # Second removal should succeed without error (idempotent)
+    Remove-V4UpdaterProductionCredential -Target $testTarget
+    Write-Host "Test 4: PASS"
+
+    # =========================================================================
+    # Test 5: Secret material is never printed by broker actions
+    # =========================================================================
+    Write-Host "Test 5: Secret material is never printed by broker actions..."
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+
+    $readOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1") `
+        -Action Read -BrokerTarget $testTarget 2>&1 | Out-String
+    Assert-NoSecretInText -Secret $testSentinel -Text $readOutput -Context "Broker -Action Read"
+    if ($readOutput -notmatch "\[PASS\]") {
+        Fail "Broker -Action Read did not report sanitized PASS"
+    }
+
+    $deleteOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1") `
+        -Action Delete -BrokerTarget $testTarget 2>&1 | Out-String
+    Assert-NoSecretInText -Secret $testSentinel -Text $deleteOutput -Context "Broker -Action Delete"
+    if ($deleteOutput -notmatch "\[PASS\]") {
+        Fail "Broker -Action Delete did not report sanitized PASS"
+    }
+    Write-Host "Test 5: PASS"
+
+    # =========================================================================
+    # Test 6: Operator provisioning script (set_v4_updater_session_credential.ps1)
+    # =========================================================================
+    Write-Host "Test 6: Operator provisioning script contract..."
+    # Empty input rejected
+    $emptyCommand = "`$sec = [System.Security.SecureString]::new(); & '$($repoRoot.Replace('\', '/'))/scripts/set_v4_updater_session_credential.ps1' -TestSecureString `$sec -Target '$testTarget'; exit `$LASTEXITCODE"
+    $emptyOutput = & pwsh -NoProfile -Command $emptyCommand 2>&1 | Out-String
+    $emptyExitCode = $LASTEXITCODE
+    if ($emptyExitCode -eq 0 -or $emptyOutput -notmatch "\[FAIL\] Passphrase input cannot be empty") {
+        Fail "set_v4_updater_session_credential did not reject empty input (exit=$emptyExitCode, out=$emptyOutput)"
+    }
+
+    # Successful provisioning
+    $setCommand = "`$sec = ConvertTo-SecureString '$testSentinel' -AsPlainText -Force; & '$($repoRoot.Replace('\', '/'))/scripts/set_v4_updater_session_credential.ps1' -TestSecureString `$sec -Target '$testTarget'; exit `$LASTEXITCODE"
+    $setOutput = & pwsh -NoProfile -Command $setCommand 2>&1 | Out-String
+    $setExitCode = $LASTEXITCODE
+    Assert-NoSecretInText -Secret $testSentinel -Text $setOutput -Context "Provisioning script"
+    if ($setExitCode -ne 0 -or $setOutput -notmatch "\[PASS\]") {
+        Fail "set_v4_updater_session_credential did not report PASS (exit=$setExitCode, out=$setOutput)"
+    }
+    if (-not (Test-V4UpdaterProductionCredential -Target $testTarget)) {
+        Fail "Target was not provisioned in Credential Manager. setOutput: $setOutput"
+    }
+    $retrieved = Get-V4UpdaterProductionCredential -Target $testTarget
+    if ($retrieved -ne $testSentinel) {
+        Fail "Provisioned credential value does not match sentinel"
+    }
+
+    # Cleanup script
+    $removeOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+        -File (Join-Path $PSScriptRoot "remove_v4_updater_session_credential.ps1") `
+        -Target $testTarget 2>&1 | Out-String
+    $removeExitCode = $LASTEXITCODE
+    Assert-NoSecretInText -Secret $testSentinel -Text $removeOutput -Context "Cleanup script"
+    if ($removeExitCode -ne 0 -or $removeOutput -notmatch "\[PASS\]") {
+        Fail "remove_v4_updater_session_credential did not report PASS (exit=$removeExitCode, out=$removeOutput)"
+    }
+    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+        Fail "Target was not removed after remove_v4_updater_session_credential"
+    }
+    Write-Host "Test 6: PASS"
+
+    # =========================================================================
+    # Test 7: BuildCandidate integration (shims, env scoping, CLI secrecy, cleanup)
+    # =========================================================================
+    Write-Host "Test 7: BuildCandidate boundary integration with shims..."
+    $fixtureRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-buildcandidate-test-" + [guid]::NewGuid().ToString("N"))
+    $mockLogPath = Join-Path $fixtureRoot "orchestrator-call.log"
+    $mockEnvPath = Join-Path $fixtureRoot "orchestrator-env.log"
+    $mockOrchestratorPath = Join-Path $fixtureRoot "mock_orchestrator.ps1"
+
+    New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+
+    # Mock orchestrator that records its command-line arguments and process environment
+    $mockScript = @"
+param(
+    [string]`$ExpectedSourceSha,
+    [string]`$Version,
+    [string]`$Channel,
+    [string]`$UpdaterPrivateKeyPath,
+    [string]`$UpdaterPasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+)
+Set-StrictMode -Version Latest
+`$ErrorActionPreference = 'Stop'
+
+# Record CLI arguments string
+`$cliArgs = `$MyInvocation.Line
+Set-Content -LiteralPath '$($mockLogPath.Replace('\', '/'))' -Value `$cliArgs -Encoding UTF8
+
+# Record received password env
+`$receivedPassword = [Environment]::GetEnvironmentVariable(`$UpdaterPasswordEnv, 'Process')
+Set-Content -LiteralPath '$($mockEnvPath.Replace('\', '/'))' -Value `$receivedPassword -Encoding UTF8
+
+if (`$env:SKY_MOCK_ORCHESTRATOR_FAIL -eq '1') {
+    exit 42
+}
+exit 0
+"@
+    Set-Content -LiteralPath $mockOrchestratorPath -Value $mockScript -Encoding UTF8
+
+    # Integration test helper mimicking Invoke-BuildCandidate broker wrapper
+    function Invoke-TestBuildCandidateBroker(
+        [string]$Target,
+        [scriptblock]$Action
+    ) {
+        $prevPassword = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+        $credential = $null
+        try {
+            $credential = Get-V4UpdaterProductionCredential -Target $Target
+            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $credential, "Process")
+            & $Action
+        } finally {
+            if ($null -ne $prevPassword) {
+                [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $prevPassword, "Process")
+            } else {
+                [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $null, "Process")
+            }
+            try {
+                Remove-V4UpdaterProductionCredential -Target $Target
+            } catch {
+                Write-Warning "Cleanup returned: $($_.Exception.Message)"
+            }
+            $credential = $null
+            Remove-Variable credential -ErrorAction SilentlyContinue
+        }
+    }
+
+    # Case A: Success path
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+    $priorProcessEnv = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+    if (-not [string]::IsNullOrEmpty($priorProcessEnv)) {
+        Fail "Prior process environment was unexpectedly non-empty"
+    }
+
+    Invoke-TestBuildCandidateBroker -Target $testTarget -Action {
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File $mockOrchestratorPath `
+            -ExpectedSourceSha "0123456789abcdef0123456789abcdef01234567" `
+            -Version "4.0.0-rc.1" `
+            -Channel "beta" `
+            -UpdaterPrivateKeyPath "C:\path\to\key.key"
+        if ($LASTEXITCODE -ne 0) { throw "Mock orchestrator failed" }
+    }
+
+    # Assertions for Case A:
+    $recordedArgs = Get-Content -LiteralPath $mockLogPath -Raw
+    Assert-NoSecretInText -Secret $testSentinel -Text $recordedArgs -Context "Orchestrator CLI arguments"
+    $recordedEnv = Get-Content -LiteralPath $mockEnvPath -Raw
+    if ($recordedEnv.Trim() -ne $testSentinel) {
+        Fail "Mock orchestrator did not receive expected password environment"
+    }
+    $postProcessEnv = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+    if (-not [string]::IsNullOrEmpty($postProcessEnv)) {
+        Fail "TAURI_SIGNING_PRIVATE_KEY_PASSWORD was not cleared after success"
+    }
+    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+        Fail "Session credential was not deleted after success"
+    }
+
+    # Case B: Failure path
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+    $failureObserved = $false
+    try {
+        $env:SKY_MOCK_ORCHESTRATOR_FAIL = '1'
+        Invoke-TestBuildCandidateBroker -Target $testTarget -Action {
+            & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+                -File $mockOrchestratorPath `
+                -ExpectedSourceSha "0123456789abcdef0123456789abcdef01234567" `
+                -Version "4.0.0-rc.1" `
+                -Channel "beta" `
+                -UpdaterPrivateKeyPath "C:\path\to\key.key"
+            if ($LASTEXITCODE -ne 0) { throw "Mock orchestrator failed intentionally" }
+        }
+    } catch {
+        $failureObserved = $true
+    } finally {
+        Remove-Item Env:SKY_MOCK_ORCHESTRATOR_FAIL -ErrorAction SilentlyContinue
+    }
+    if (-not $failureObserved) {
+        Fail "Expected failure was not thrown"
+    }
+    $postFailProcessEnv = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+    if (-not [string]::IsNullOrEmpty($postFailProcessEnv)) {
+        Fail "TAURI_SIGNING_PRIVATE_KEY_PASSWORD was not cleared after failure"
+    }
+    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+        Fail "Session credential was not deleted after failure"
+    }
+
+    # Case C: Ambient environment rejection in v4_release_pipeline.ps1
+    $savedKeyPathEnv = $env:TAURI_SIGNING_PRIVATE_KEY_PATH
+    $savedPassEnv = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+    $dummyKeyPath = Join-Path $fixtureRoot "test.key"
+    New-Item -ItemType File -Path $dummyKeyPath -Force | Out-Null
+    try {
+        $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "ambient-forbidden-value"
+        $pipelineOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot "v4_release_pipeline.ps1") `
+            -State BuildCandidate `
+            -Version "4.0.0-rc.1" `
+            -Channel "beta" `
+            -Tag "v4.0.0-rc.1" `
+            -SourceSha "02d3a973c23ca17ff331563e4f49fe090d3be207" `
+            -WorkflowSha "02d3a973c23ca17ff331563e4f49fe090d3be207" `
+            -StateRoot (Join-Path ([IO.Path]::GetTempPath()) ("state-" + [guid]::NewGuid().ToString("N"))) `
+            -UpdaterPrivateKeyPath $dummyKeyPath 2>&1 | Out-String
+        if ($pipelineOutput -notmatch "ambient updater key or password environment is forbidden") {
+            Fail "v4_release_pipeline did not reject ambient TAURI_SIGNING_PRIVATE_KEY_PASSWORD: $pipelineOutput"
+        }
+    } finally {
+        if ($null -ne $savedPassEnv) {
+            $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $savedPassEnv
+        } else {
+            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+        }
+    }
+
+    Write-Host "Test 7: PASS"
+
+    Write-Host "================================================================="
+    Write-Host " [PASS] All V4 updater credential broker tests passed"
+    Write-Host "================================================================="
+} finally {
+    Remove-V4UpdaterProductionCredential -Target $testTarget
+    if ($null -ne $fixtureRoot -and (Test-Path -LiteralPath $fixtureRoot)) {
+        Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/test_v4_updater_credential_broker.ps1
+++ b/scripts/test_v4_updater_credential_broker.ps1
@@ -36,12 +36,12 @@ try {
     # Test 1: ABSENT fails closed
     # =========================================================================
     Write-Host "Test 1: ABSENT fails closed..."
-    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+    if (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget) {
         Fail "Test target should not exist before test"
     }
     $absentFailedClosed = $false
     try {
-        $null = Get-V4UpdaterProductionCredential -Target $testTarget
+        $null = Get-V4UpdaterProductionCredential -InternalTestTarget $testTarget
     } catch {
         $absentFailedClosed = $true
         if ($_.Exception.Message -notmatch "absent") {
@@ -58,10 +58,10 @@ try {
     # =========================================================================
     Write-Host "Test 2: CRED_PERSIST_SESSION credential is readable..."
     [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
-    if (-not (Test-V4UpdaterProductionCredential -Target $testTarget)) {
+    if (-not (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget)) {
         Fail "Test target should be present after WriteSessionCredential"
     }
-    $readBack = Get-V4UpdaterProductionCredential -Target $testTarget
+    $readBack = Get-V4UpdaterProductionCredential -InternalTestTarget $testTarget
     if ($readBack -ne $testSentinel) {
         Fail "Read credential does not match written sentinel"
     }
@@ -72,12 +72,12 @@ try {
     # =========================================================================
     Write-Host "Test 3: Empty credential blob is rejected..."
     [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteRawCredential($testTarget, [byte[]]@(), 1)
-    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+    if (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget) {
         Fail "Test-V4UpdaterProductionCredential should report false for empty credential blob"
     }
     $emptyFailedClosed = $false
     try {
-        $null = Get-V4UpdaterProductionCredential -Target $testTarget
+        $null = Get-V4UpdaterProductionCredential -InternalTestTarget $testTarget
     } catch {
         $emptyFailedClosed = $true
         if ($_.Exception.Message -notmatch "empty") {
@@ -94,12 +94,12 @@ try {
     # =========================================================================
     Write-Host "Test 4: Deletion works and is idempotent..."
     [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
-    Remove-V4UpdaterProductionCredential -Target $testTarget
-    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+    Remove-V4UpdaterProductionCredential -InternalTestTarget $testTarget
+    if (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget) {
         Fail "Test target should not be present after Remove-V4UpdaterProductionCredential"
     }
     # Second removal should succeed without error (idempotent)
-    Remove-V4UpdaterProductionCredential -Target $testTarget
+    Remove-V4UpdaterProductionCredential -InternalTestTarget $testTarget
     Write-Host "Test 4: PASS"
 
     # =========================================================================
@@ -110,7 +110,7 @@ try {
 
     $readOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
         -File (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1") `
-        -Action Read -BrokerTarget $testTarget 2>&1 | Out-String
+        -Action Read -InternalTestTarget $testTarget 2>&1 | Out-String
     Assert-NoSecretInText -Secret $testSentinel -Text $readOutput -Context "Broker -Action Read"
     if ($readOutput -notmatch "\[PASS\]") {
         Fail "Broker -Action Read did not report sanitized PASS"
@@ -118,7 +118,7 @@ try {
 
     $deleteOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
         -File (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1") `
-        -Action Delete -BrokerTarget $testTarget 2>&1 | Out-String
+        -Action Delete -InternalTestTarget $testTarget 2>&1 | Out-String
     Assert-NoSecretInText -Secret $testSentinel -Text $deleteOutput -Context "Broker -Action Delete"
     if ($deleteOutput -notmatch "\[PASS\]") {
         Fail "Broker -Action Delete did not report sanitized PASS"
@@ -130,7 +130,7 @@ try {
     # =========================================================================
     Write-Host "Test 6: Operator provisioning script contract..."
     # Empty input rejected
-    $emptyCommand = "`$sec = [System.Security.SecureString]::new(); & '$($repoRoot.Replace('\', '/'))/scripts/set_v4_updater_session_credential.ps1' -TestSecureString `$sec -Target '$testTarget'; exit `$LASTEXITCODE"
+    $emptyCommand = "`$sec = [System.Security.SecureString]::new(); & '$($repoRoot.Replace('\', '/'))/scripts/set_v4_updater_session_credential.ps1' -TestSecureString `$sec -InternalTestTarget '$testTarget'; exit `$LASTEXITCODE"
     $emptyOutput = & pwsh -NoProfile -Command $emptyCommand 2>&1 | Out-String
     $emptyExitCode = $LASTEXITCODE
     if ($emptyExitCode -eq 0 -or $emptyOutput -notmatch "\[FAIL\] Passphrase input cannot be empty") {
@@ -138,17 +138,17 @@ try {
     }
 
     # Successful provisioning
-    $setCommand = "`$sec = ConvertTo-SecureString '$testSentinel' -AsPlainText -Force; & '$($repoRoot.Replace('\', '/'))/scripts/set_v4_updater_session_credential.ps1' -TestSecureString `$sec -Target '$testTarget'; exit `$LASTEXITCODE"
+    $setCommand = "`$sec = ConvertTo-SecureString '$testSentinel' -AsPlainText -Force; & '$($repoRoot.Replace('\', '/'))/scripts/set_v4_updater_session_credential.ps1' -TestSecureString `$sec -InternalTestTarget '$testTarget'; exit `$LASTEXITCODE"
     $setOutput = & pwsh -NoProfile -Command $setCommand 2>&1 | Out-String
     $setExitCode = $LASTEXITCODE
     Assert-NoSecretInText -Secret $testSentinel -Text $setOutput -Context "Provisioning script"
     if ($setExitCode -ne 0 -or $setOutput -notmatch "\[PASS\]") {
         Fail "set_v4_updater_session_credential did not report PASS (exit=$setExitCode, out=$setOutput)"
     }
-    if (-not (Test-V4UpdaterProductionCredential -Target $testTarget)) {
+    if (-not (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget)) {
         Fail "Target was not provisioned in Credential Manager. setOutput: $setOutput"
     }
-    $retrieved = Get-V4UpdaterProductionCredential -Target $testTarget
+    $retrieved = Get-V4UpdaterProductionCredential -InternalTestTarget $testTarget
     if ($retrieved -ne $testSentinel) {
         Fail "Provisioned credential value does not match sentinel"
     }
@@ -156,13 +156,13 @@ try {
     # Cleanup script
     $removeOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
         -File (Join-Path $PSScriptRoot "remove_v4_updater_session_credential.ps1") `
-        -Target $testTarget 2>&1 | Out-String
+        -InternalTestTarget $testTarget 2>&1 | Out-String
     $removeExitCode = $LASTEXITCODE
     Assert-NoSecretInText -Secret $testSentinel -Text $removeOutput -Context "Cleanup script"
     if ($removeExitCode -ne 0 -or $removeOutput -notmatch "\[PASS\]") {
         Fail "remove_v4_updater_session_credential did not report PASS (exit=$removeExitCode, out=$removeOutput)"
     }
-    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+    if (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget) {
         Fail "Target was not removed after remove_v4_updater_session_credential"
     }
     Write-Host "Test 6: PASS"
@@ -205,41 +205,17 @@ exit 0
 "@
     Set-Content -LiteralPath $mockOrchestratorPath -Value $mockScript -Encoding UTF8
 
-    # Integration test helper mimicking Invoke-BuildCandidate broker wrapper
-    function Invoke-TestBuildCandidateBroker(
-        [string]$Target,
-        [scriptblock]$Action
-    ) {
-        $prevPassword = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
-        $credential = $null
-        try {
-            $credential = Get-V4UpdaterProductionCredential -Target $Target
-            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $credential, "Process")
-            & $Action
-        } finally {
-            if ($null -ne $prevPassword) {
-                [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $prevPassword, "Process")
-            } else {
-                [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $null, "Process")
-            }
-            try {
-                Remove-V4UpdaterProductionCredential -Target $Target
-            } catch {
-                Write-Warning "Cleanup returned: $($_.Exception.Message)"
-            }
-            $credential = $null
-            Remove-Variable credential -ErrorAction SilentlyContinue
-        }
-    }
-
-    # Case A: Success path
+    # -------------------------------------------------------------------------
+    # Case 7A: Production helper success path (orchestrator success + cleanup success)
+    # -------------------------------------------------------------------------
+    Write-Host "Test 7A: Production helper success path..."
     [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
     $priorProcessEnv = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
     if (-not [string]::IsNullOrEmpty($priorProcessEnv)) {
         Fail "Prior process environment was unexpectedly non-empty"
     }
 
-    Invoke-TestBuildCandidateBroker -Target $testTarget -Action {
+    Invoke-WithV4UpdaterSessionCredential -InternalTestTarget $testTarget -Action {
         & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
             -File $mockOrchestratorPath `
             -ExpectedSourceSha "0123456789abcdef0123456789abcdef01234567" `
@@ -249,7 +225,7 @@ exit 0
         if ($LASTEXITCODE -ne 0) { throw "Mock orchestrator failed" }
     }
 
-    # Assertions for Case A:
+    # Assertions for Case 7A:
     $recordedArgs = Get-Content -LiteralPath $mockLogPath -Raw
     Assert-NoSecretInText -Secret $testSentinel -Text $recordedArgs -Context "Orchestrator CLI arguments"
     $recordedEnv = Get-Content -LiteralPath $mockEnvPath -Raw
@@ -260,16 +236,20 @@ exit 0
     if (-not [string]::IsNullOrEmpty($postProcessEnv)) {
         Fail "TAURI_SIGNING_PRIVATE_KEY_PASSWORD was not cleared after success"
     }
-    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+    if (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget) {
         Fail "Session credential was not deleted after success"
     }
+    Write-Host "Test 7A: PASS"
 
-    # Case B: Failure path
+    # -------------------------------------------------------------------------
+    # Case 7B: Production helper orchestrator failure path (orchestrator failure + cleanup success)
+    # -------------------------------------------------------------------------
+    Write-Host "Test 7B: Production helper orchestrator failure path..."
     [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
     $failureObserved = $false
     try {
         $env:SKY_MOCK_ORCHESTRATOR_FAIL = '1'
-        Invoke-TestBuildCandidateBroker -Target $testTarget -Action {
+        Invoke-WithV4UpdaterSessionCredential -InternalTestTarget $testTarget -Action {
             & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
                 -File $mockOrchestratorPath `
                 -ExpectedSourceSha "0123456789abcdef0123456789abcdef01234567" `
@@ -290,15 +270,96 @@ exit 0
     if (-not [string]::IsNullOrEmpty($postFailProcessEnv)) {
         Fail "TAURI_SIGNING_PRIVATE_KEY_PASSWORD was not cleared after failure"
     }
-    if (Test-V4UpdaterProductionCredential -Target $testTarget) {
+    if (Test-V4UpdaterProductionCredential -InternalTestTarget $testTarget) {
         Fail "Session credential was not deleted after failure"
     }
+    Write-Host "Test 7B: PASS"
 
-    # Case C: Ambient environment rejection in v4_release_pipeline.ps1
+    # -------------------------------------------------------------------------
+    # Case 7C: Orchestrator success + credential deletion failure (FAILS CLOSED)
+    # -------------------------------------------------------------------------
+    Write-Host "Test 7C: Orchestrator success + credential deletion failure (fail closed)..."
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+    $cleanupFailObserved = $false
+    $cleanupFailError = $null
+    try {
+        Invoke-WithV4UpdaterSessionCredential -InternalTestTarget $testTarget -Action {
+            & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+                -File $mockOrchestratorPath `
+                -ExpectedSourceSha "0123456789abcdef0123456789abcdef01234567" `
+                -Version "4.0.0-rc.1" `
+                -Channel "beta" `
+                -UpdaterPrivateKeyPath "C:\path\to\key.key"
+            if ($LASTEXITCODE -ne 0) { throw "Mock orchestrator failed" }
+        } -InternalTestCleanup {
+            throw "Simulated CredDeleteW Win32 access denied"
+        }
+    } catch {
+        $cleanupFailObserved = $true
+        $cleanupFailError = $_.Exception.Message
+    }
+    if (-not $cleanupFailObserved) {
+        Fail "Invoke-WithV4UpdaterSessionCredential did not fail closed on credential deletion failure"
+    }
+    Assert-NoSecretInText -Secret $testSentinel -Text $cleanupFailError -Context "Cleanup failure error"
+    if ($cleanupFailError -notmatch "Simulated CredDeleteW Win32 access denied") {
+        Fail "Error message did not convey cleanup failure: $cleanupFailError"
+    }
+    $postCleanupFailEnv = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+    if (-not [string]::IsNullOrEmpty($postCleanupFailEnv)) {
+        Fail "TAURI_SIGNING_PRIVATE_KEY_PASSWORD was not cleared after deletion failure: $postCleanupFailEnv"
+    }
+    Remove-V4UpdaterProductionCredential -InternalTestTarget $testTarget
+    Write-Host "Test 7C: PASS"
+
+    # -------------------------------------------------------------------------
+    # Case 7D: Orchestrator failure + credential deletion failure (FAILS CLOSED, SURFACES BOTH CAUSES, RESTORES ENV)
+    # -------------------------------------------------------------------------
+    Write-Host "Test 7D: Orchestrator failure + credential deletion failure (both fail, surfaces causes, restores env)..."
+    [SkyAutoPlayer.V4UpdaterCredentialBroker]::WriteSessionCredential($testTarget, $testSentinel)
+    $priorEnvMarker = "BENIGN_PRIOR_ENV_MARKER_" + [guid]::NewGuid().ToString("N")
+    [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $priorEnvMarker, "Process")
+    $bothFailedObserved = $false
+    $bothFailedError = $null
+    $restoredProcessEnv = $null
+    try {
+        Invoke-WithV4UpdaterSessionCredential -InternalTestTarget $testTarget -Action {
+            throw "Mock orchestrator crashed with fatal hardware error"
+        } -InternalTestCleanup {
+            throw "Simulated CredDeleteW device timeout"
+        }
+    } catch {
+        $bothFailedObserved = $true
+        $bothFailedError = $_.Exception.Message
+    } finally {
+        $restoredProcessEnv = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+        [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $null, "Process")
+        Remove-V4UpdaterProductionCredential -InternalTestTarget $testTarget
+    }
+    if (-not $bothFailedObserved) {
+        Fail "Invoke-WithV4UpdaterSessionCredential did not fail closed when both action and deletion failed"
+    }
+    Assert-NoSecretInText -Secret $testSentinel -Text $bothFailedError -Context "Both failed error"
+    if ($bothFailedError -notmatch "Mock orchestrator crashed with fatal hardware error") {
+        Fail "Error message omitted orchestrator failure cause: $bothFailedError"
+    }
+    if ($bothFailedError -notmatch "Simulated CredDeleteW device timeout") {
+        Fail "Error message omitted cleanup failure cause: $bothFailedError"
+    }
+    if ($restoredProcessEnv -ne $priorEnvMarker) {
+        Fail "TAURI_SIGNING_PRIVATE_KEY_PASSWORD was not restored to prior process value: $restoredProcessEnv"
+    }
+    Write-Host "Test 7D: PASS"
+
+    # -------------------------------------------------------------------------
+    # Case 7E: Ambient environment rejection in v4_release_pipeline.ps1
+    # -------------------------------------------------------------------------
+    Write-Host "Test 7E: Ambient environment rejection in v4_release_pipeline.ps1..."
     $savedKeyPathEnv = $env:TAURI_SIGNING_PRIVATE_KEY_PATH
     $savedPassEnv = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
     $dummyKeyPath = Join-Path $fixtureRoot "test.key"
     New-Item -ItemType File -Path $dummyKeyPath -Force | Out-Null
+    $currentHeadSha = (git -C $repoRoot rev-parse HEAD).Trim().ToLowerInvariant()
     try {
         $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "ambient-forbidden-value"
         $pipelineOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
@@ -307,8 +368,8 @@ exit 0
             -Version "4.0.0-rc.1" `
             -Channel "beta" `
             -Tag "v4.0.0-rc.1" `
-            -SourceSha "02d3a973c23ca17ff331563e4f49fe090d3be207" `
-            -WorkflowSha "02d3a973c23ca17ff331563e4f49fe090d3be207" `
+            -SourceSha $currentHeadSha `
+            -WorkflowSha $currentHeadSha `
             -StateRoot (Join-Path ([IO.Path]::GetTempPath()) ("state-" + [guid]::NewGuid().ToString("N"))) `
             -UpdaterPrivateKeyPath $dummyKeyPath 2>&1 | Out-String
         if ($pipelineOutput -notmatch "ambient updater key or password environment is forbidden") {
@@ -321,14 +382,14 @@ exit 0
             Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
         }
     }
-
+    Write-Host "Test 7E: PASS"
     Write-Host "Test 7: PASS"
 
     Write-Host "================================================================="
     Write-Host " [PASS] All V4 updater credential broker tests passed"
     Write-Host "================================================================="
 } finally {
-    Remove-V4UpdaterProductionCredential -Target $testTarget
+    Remove-V4UpdaterProductionCredential -InternalTestTarget $testTarget
     if ($null -ne $fixtureRoot -and (Test-Path -LiteralPath $fixtureRoot)) {
         Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -24,7 +24,6 @@ param(
     [string]$WorkflowSha,
     [string]$StateRoot,
     [string]$UpdaterPrivateKeyPath,
-    [string]$UpdaterPasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
     [string]$ReleaseNotesPath,
     [string]$PublicationDateUtc,
     [string]$AuthorityTokenEnv = "V4_RELEASE_AUTHORITY_TOKEN"
@@ -349,27 +348,48 @@ function Assert-CandidateEvidence([object[]]$Records) {
 function Invoke-BuildCandidate {
     Assert-RequestIdentity
     if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) { Fail "updater private key path is required" }
-    if ([string]::IsNullOrWhiteSpace($UpdaterPasswordEnv)) { Fail "updater password environment variable name is required" }
     $keyPath = (Resolve-Path -LiteralPath $UpdaterPrivateKeyPath -ErrorAction Stop).Path
     $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
     if ($keyPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) { Fail "updater private key must remain outside workspace" }
     if (-not (Test-Path -LiteralPath $keyPath -PathType Leaf)) { Fail "updater private key path is not a file" }
     if (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY) -or
-        -not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
-        Fail "ambient updater key environment is forbidden"
+        -not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH) -or
+        -not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD)) {
+        Fail "ambient updater key or password environment is forbidden"
     }
 
-    # This is the only production candidate build boundary. The orchestrator
-    # owns key verification, stale purge, clean-worktree, NSIS, updater sig,
-    # unsigned-zero-budget, SBOM, and install smoke semantics.
-    & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
-        -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
-        -ExpectedSourceSha $SourceSha `
-        -Version $Version `
-        -Channel $Channel `
-        -UpdaterPrivateKeyPath $keyPath `
-        -UpdaterPasswordEnv $UpdaterPasswordEnv
-    if ($LASTEXITCODE -ne 0) { Fail "production orchestrator failed" }
+    . (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
+
+    $prevPassword = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+    $credential = $null
+    try {
+        $credential = Get-V4UpdaterProductionCredential
+        [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $credential, "Process")
+
+        # This is the only production candidate build boundary. The orchestrator
+        # owns key verification, stale purge, clean-worktree, NSIS, updater sig,
+        # unsigned-zero-budget, SBOM, and install smoke semantics.
+        & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
+            -ExpectedSourceSha $SourceSha `
+            -Version $Version `
+            -Channel $Channel `
+            -UpdaterPrivateKeyPath $keyPath
+        if ($LASTEXITCODE -ne 0) { Fail "production orchestrator failed" }
+    } finally {
+        if ($null -ne $prevPassword) {
+            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $prevPassword, "Process")
+        } else {
+            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $null, "Process")
+        }
+        try {
+            Remove-V4UpdaterProductionCredential
+        } catch {
+            Write-Warning "V4 updater session credential cleanup returned: $($_.Exception.Message)"
+        }
+        $credential = $null
+        Remove-Variable credential -ErrorAction SilentlyContinue
+    }
 
     $records = @(Get-CandidateRecords | ForEach-Object { Get-FileRecord $_ })
     Assert-CandidateEvidence $records

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -360,15 +360,10 @@ function Invoke-BuildCandidate {
 
     . (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
 
-    $prevPassword = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
-    $credential = $null
-    try {
-        $credential = Get-V4UpdaterProductionCredential
-        [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $credential, "Process")
-
-        # This is the only production candidate build boundary. The orchestrator
-        # owns key verification, stale purge, clean-worktree, NSIS, updater sig,
-        # unsigned-zero-budget, SBOM, and install smoke semantics.
+    # This is the only production candidate build boundary. The orchestrator
+    # owns key verification, stale purge, clean-worktree, NSIS, updater sig,
+    # unsigned-zero-budget, SBOM, and install smoke semantics.
+    Invoke-WithV4UpdaterSessionCredential -Action {
         & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
             -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
             -ExpectedSourceSha $SourceSha `
@@ -376,19 +371,6 @@ function Invoke-BuildCandidate {
             -Channel $Channel `
             -UpdaterPrivateKeyPath $keyPath
         if ($LASTEXITCODE -ne 0) { Fail "production orchestrator failed" }
-    } finally {
-        if ($null -ne $prevPassword) {
-            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $prevPassword, "Process")
-        } else {
-            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $null, "Process")
-        }
-        try {
-            Remove-V4UpdaterProductionCredential
-        } catch {
-            Write-Warning "V4 updater session credential cleanup returned: $($_.Exception.Message)"
-        }
-        $credential = $null
-        Remove-Variable credential -ErrorAction SilentlyContinue
     }
 
     $records = @(Get-CandidateRecords | ForEach-Object { Get-FileRecord $_ })

--- a/scripts/v4_updater_credential_broker.ps1
+++ b/scripts/v4_updater_credential_broker.ps1
@@ -1,0 +1,338 @@
+# scripts/v4_updater_credential_broker.ps1
+# Bounded repository helper for Windows Credential Manager generic session credential transport.
+# Governed by docs/v4-release-execution-topology.md, docs/v4-updater-key-custody.md, and SECURITY.md.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet("Read", "Delete", "Test")]
+    [string]$Action,
+
+    [Parameter(Mandatory = $false)]
+    [string]$BrokerTarget
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not [System.OperatingSystem]::IsWindows()) {
+    throw "V4 updater credential broker requires Windows platform"
+}
+
+$script:CanonicalCredentialTarget = "SkyAutoPlayer/V4UpdaterProduction"
+
+if (-not ([System.Management.Automation.PSTypeName]'SkyAutoPlayer.V4UpdaterCredentialBroker').Type) {
+    $csharpSource = @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SkyAutoPlayer
+{
+    public static class V4UpdaterCredentialBroker
+    {
+        private const uint CRED_TYPE_GENERIC = 1;
+        private const uint CRED_PERSIST_SESSION = 1;
+        private const int ERROR_NOT_FOUND = 1168;
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct CREDENTIAL_READ
+        {
+            public uint Flags;
+            public uint Type;
+            public IntPtr TargetName;
+            public IntPtr Comment;
+            public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+            public uint CredentialBlobSize;
+            public IntPtr CredentialBlob;
+            public uint Persist;
+            public uint AttributeCount;
+            public IntPtr Attributes;
+            public IntPtr TargetAlias;
+            public IntPtr UserName;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct CREDENTIAL_WRITE
+        {
+            public uint Flags;
+            public uint Type;
+            public string TargetName;
+            public string Comment;
+            public System.Runtime.InteropServices.ComTypes.FILETIME LastWritten;
+            public uint CredentialBlobSize;
+            public IntPtr CredentialBlob;
+            public uint Persist;
+            public uint AttributeCount;
+            public IntPtr Attributes;
+            public string TargetAlias;
+            public string UserName;
+        }
+
+        [DllImport("Advapi32.dll", EntryPoint = "CredReadW", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CredRead(string target, uint type, uint reservedFlag, out IntPtr credentialPtr);
+
+        [DllImport("Advapi32.dll", EntryPoint = "CredWriteW", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CredWrite(ref CREDENTIAL_WRITE credential, uint flags);
+
+        [DllImport("Advapi32.dll", EntryPoint = "CredDeleteW", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CredDelete(string target, uint type, uint flags);
+
+        [DllImport("Advapi32.dll", SetLastError = true)]
+        private static extern void CredFree(IntPtr buffer);
+
+        public static string ReadCredential(string target)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                throw new ArgumentException("Credential target is required", nameof(target));
+            }
+
+            IntPtr credentialPtr;
+            if (!CredRead(target, CRED_TYPE_GENERIC, 0, out credentialPtr))
+            {
+                int error = Marshal.GetLastWin32Error();
+                if (error == ERROR_NOT_FOUND)
+                {
+                    throw new InvalidOperationException("Credential is absent in Windows Credential Manager");
+                }
+                throw new Win32Exception(error);
+            }
+
+            try
+            {
+                var cred = (CREDENTIAL_READ)Marshal.PtrToStructure(credentialPtr, typeof(CREDENTIAL_READ));
+                if (cred.CredentialBlob == IntPtr.Zero || cred.CredentialBlobSize == 0)
+                {
+                    throw new InvalidOperationException("Credential blob is empty");
+                }
+
+                byte[] blob = new byte[cred.CredentialBlobSize];
+                Marshal.Copy(cred.CredentialBlob, blob, 0, (int)cred.CredentialBlobSize);
+
+                for (int i = 0; i < (int)cred.CredentialBlobSize; i++)
+                {
+                    Marshal.WriteByte(cred.CredentialBlob, i, 0);
+                }
+
+                string result;
+                if (blob.Length >= 2 && blob[1] == 0 && (blob.Length % 2 == 0))
+                {
+                    result = Encoding.Unicode.GetString(blob).TrimEnd('\0');
+                }
+                else
+                {
+                    result = Encoding.UTF8.GetString(blob).TrimEnd('\0');
+                }
+
+                Array.Clear(blob, 0, blob.Length);
+
+                if (string.IsNullOrEmpty(result))
+                {
+                    throw new InvalidOperationException("Credential blob is empty");
+                }
+
+                return result;
+            }
+            finally
+            {
+                CredFree(credentialPtr);
+            }
+        }
+
+        public static bool HasNonEmptyCredential(string target)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                return false;
+            }
+
+            IntPtr credentialPtr;
+            if (!CredRead(target, CRED_TYPE_GENERIC, 0, out credentialPtr))
+            {
+                int error = Marshal.GetLastWin32Error();
+                if (error == ERROR_NOT_FOUND)
+                {
+                    return false;
+                }
+                throw new Win32Exception(error);
+            }
+
+            try
+            {
+                var cred = (CREDENTIAL_READ)Marshal.PtrToStructure(credentialPtr, typeof(CREDENTIAL_READ));
+                return cred.CredentialBlob != IntPtr.Zero && cred.CredentialBlobSize > 0;
+            }
+            finally
+            {
+                CredFree(credentialPtr);
+            }
+        }
+
+        public static bool DeleteCredential(string target)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                return false;
+            }
+
+            if (!CredDelete(target, CRED_TYPE_GENERIC, 0))
+            {
+                int error = Marshal.GetLastWin32Error();
+                if (error == ERROR_NOT_FOUND)
+                {
+                    return false;
+                }
+                throw new Win32Exception(error);
+            }
+
+            return true;
+        }
+
+        public static void WriteSessionCredential(string target, string secret)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                throw new ArgumentException("Credential target is required", nameof(target));
+            }
+            if (string.IsNullOrEmpty(secret))
+            {
+                throw new ArgumentException("Credential secret cannot be empty", nameof(secret));
+            }
+
+            byte[] blob = Encoding.UTF8.GetBytes(secret);
+            WriteRawCredential(target, blob, CRED_PERSIST_SESSION);
+            Array.Clear(blob, 0, blob.Length);
+        }
+
+        public static void WriteRawCredential(string target, byte[] blob, uint persist)
+        {
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                throw new ArgumentException("Credential target is required", nameof(target));
+            }
+
+            IntPtr blobPtr = IntPtr.Zero;
+            int blobLength = (blob != null) ? blob.Length : 0;
+
+            try
+            {
+                if (blobLength > 0)
+                {
+                    blobPtr = Marshal.AllocHGlobal(blobLength);
+                    Marshal.Copy(blob, 0, blobPtr, blobLength);
+                }
+
+                var cred = new CREDENTIAL_WRITE
+                {
+                    Flags = 0,
+                    Type = CRED_TYPE_GENERIC,
+                    TargetName = target,
+                    Comment = "Sky Auto Player V4 Updater Production Session Credential",
+                    CredentialBlobSize = (uint)blobLength,
+                    CredentialBlob = blobPtr,
+                    Persist = persist,
+                    AttributeCount = 0,
+                    Attributes = IntPtr.Zero,
+                    TargetAlias = null,
+                    UserName = "SkyAutoPlayerOperator"
+                };
+
+                if (!CredWrite(ref cred, 0))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                if (blobPtr != IntPtr.Zero)
+                {
+                    for (int i = 0; i < blobLength; i++)
+                    {
+                        Marshal.WriteByte(blobPtr, i, 0);
+                    }
+                    Marshal.FreeHGlobal(blobPtr);
+                }
+            }
+        }
+    }
+}
+'@
+    Add-Type -TypeDefinition $csharpSource -Language CSharp
+}
+
+function Get-V4UpdaterProductionCredential {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Target = $script:CanonicalCredentialTarget
+    )
+
+    if (-not [System.OperatingSystem]::IsWindows()) {
+        throw "V4 updater credential broker requires Windows platform"
+    }
+
+    try {
+        return [SkyAutoPlayer.V4UpdaterCredentialBroker]::ReadCredential($Target)
+    } catch {
+        throw "V4 updater credential broker: failed to read credential for target $Target - $($_.Exception.Message)"
+    }
+}
+
+function Remove-V4UpdaterProductionCredential {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Target = $script:CanonicalCredentialTarget
+    )
+
+    if (-not [System.OperatingSystem]::IsWindows()) {
+        throw "V4 updater credential broker requires Windows platform"
+    }
+
+    try {
+        [void][SkyAutoPlayer.V4UpdaterCredentialBroker]::DeleteCredential($Target)
+    } catch {
+        throw "V4 updater credential broker: failed to delete credential for target $Target - $($_.Exception.Message)"
+    }
+}
+
+function Test-V4UpdaterProductionCredential {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Target = $script:CanonicalCredentialTarget
+    )
+
+    if (-not [System.OperatingSystem]::IsWindows()) {
+        return $false
+    }
+
+    try {
+        return [SkyAutoPlayer.V4UpdaterCredentialBroker]::HasNonEmptyCredential($Target)
+    } catch {
+        return $false
+    }
+}
+
+if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Action")) {
+    $targetToUse = if (-not [string]::IsNullOrWhiteSpace($BrokerTarget)) { $BrokerTarget } else { $script:CanonicalCredentialTarget }
+    switch ($Action) {
+        "Delete" {
+            Remove-V4UpdaterProductionCredential -Target $targetToUse
+            Write-Host "[PASS] V4 updater session credential deleted"
+        }
+        "Test" {
+            if (Test-V4UpdaterProductionCredential -Target $targetToUse) {
+                Write-Host "PRESENT_NONEMPTY"
+            } else {
+                Write-Host "ABSENT"
+            }
+        }
+        "Read" {
+            $null = Get-V4UpdaterProductionCredential -Target $targetToUse
+            Write-Host "[PASS] V4 updater credential read successfully"
+        }
+    }
+}

--- a/scripts/v4_updater_credential_broker.ps1
+++ b/scripts/v4_updater_credential_broker.ps1
@@ -8,8 +8,10 @@ param(
     [ValidateSet("Read", "Delete", "Test")]
     [string]$Action,
 
+    # Internal test seam only: non-production target isolation for regression tests.
+    [Alias("InternalTestTarget")]
     [Parameter(Mandatory = $false)]
-    [string]$BrokerTarget
+    [string]$BrokerInternalTestTarget
 )
 
 Set-StrictMode -Version Latest
@@ -265,73 +267,175 @@ namespace SkyAutoPlayer
 function Get-V4UpdaterProductionCredential {
     [CmdletBinding()]
     param(
+        # Internal test seam only: non-production target isolation for regression tests.
         [Parameter(Mandatory = $false)]
-        [string]$Target = $script:CanonicalCredentialTarget
+        [string]$InternalTestTarget
     )
 
     if (-not [System.OperatingSystem]::IsWindows()) {
         throw "V4 updater credential broker requires Windows platform"
     }
 
+    $target = if (-not [string]::IsNullOrWhiteSpace($InternalTestTarget)) {
+        $InternalTestTarget
+    } else {
+        $script:CanonicalCredentialTarget
+    }
+
     try {
-        return [SkyAutoPlayer.V4UpdaterCredentialBroker]::ReadCredential($Target)
+        return [SkyAutoPlayer.V4UpdaterCredentialBroker]::ReadCredential($target)
     } catch {
-        throw "V4 updater credential broker: failed to read credential for target $Target - $($_.Exception.Message)"
+        throw "V4 updater credential broker: failed to read credential for target $target - $($_.Exception.Message)"
     }
 }
 
 function Remove-V4UpdaterProductionCredential {
     [CmdletBinding()]
     param(
+        # Internal test seam only: non-production target isolation for regression tests.
         [Parameter(Mandatory = $false)]
-        [string]$Target = $script:CanonicalCredentialTarget
+        [string]$InternalTestTarget
     )
 
     if (-not [System.OperatingSystem]::IsWindows()) {
         throw "V4 updater credential broker requires Windows platform"
     }
 
+    $target = if (-not [string]::IsNullOrWhiteSpace($InternalTestTarget)) {
+        $InternalTestTarget
+    } else {
+        $script:CanonicalCredentialTarget
+    }
+
     try {
-        [void][SkyAutoPlayer.V4UpdaterCredentialBroker]::DeleteCredential($Target)
+        [void][SkyAutoPlayer.V4UpdaterCredentialBroker]::DeleteCredential($target)
     } catch {
-        throw "V4 updater credential broker: failed to delete credential for target $Target - $($_.Exception.Message)"
+        throw "V4 updater credential broker: failed to delete credential for target $target - $($_.Exception.Message)"
     }
 }
 
 function Test-V4UpdaterProductionCredential {
     [CmdletBinding()]
     param(
+        # Internal test seam only: non-production target isolation for regression tests.
         [Parameter(Mandatory = $false)]
-        [string]$Target = $script:CanonicalCredentialTarget
+        [string]$InternalTestTarget
     )
 
     if (-not [System.OperatingSystem]::IsWindows()) {
         return $false
     }
 
+    $target = if (-not [string]::IsNullOrWhiteSpace($InternalTestTarget)) {
+        $InternalTestTarget
+    } else {
+        $script:CanonicalCredentialTarget
+    }
+
     try {
-        return [SkyAutoPlayer.V4UpdaterCredentialBroker]::HasNonEmptyCredential($Target)
+        return [SkyAutoPlayer.V4UpdaterCredentialBroker]::HasNonEmptyCredential($target)
     } catch {
         return $false
     }
 }
 
+function Invoke-WithV4UpdaterSessionCredential {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Action,
+
+        # Internal test seam only: non-production target isolation for regression tests.
+        [Parameter(Mandatory = $false)]
+        [string]$InternalTestTarget,
+
+        # Internal test seam only: custom cleanup hook to exercise deletion failures in regression tests.
+        [Parameter(Mandatory = $false)]
+        [scriptblock]$InternalTestCleanup
+    )
+
+    if (-not [System.OperatingSystem]::IsWindows()) {
+        throw "V4 updater credential broker requires Windows platform"
+    }
+
+    $target = if (-not [string]::IsNullOrWhiteSpace($InternalTestTarget)) {
+        $InternalTestTarget
+    } else {
+        $script:CanonicalCredentialTarget
+    }
+
+    $prevPassword = [Environment]::GetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", "Process")
+    $credential = $null
+    $actionException = $null
+    $cleanupException = $null
+    $actionResult = $null
+
+    try {
+        $credential = Get-V4UpdaterProductionCredential -InternalTestTarget $target
+        [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $credential, "Process")
+
+        try {
+            $actionResult = & $Action
+        } catch {
+            $actionException = $_
+        }
+    } finally {
+        # 1. Process environment restoration is deterministic and unconditional
+        if ($null -ne $prevPassword) {
+            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $prevPassword, "Process")
+        } else {
+            [Environment]::SetEnvironmentVariable("TAURI_SIGNING_PRIVATE_KEY_PASSWORD", $null, "Process")
+        }
+
+        # 2. Session credential cleanup must execute even if action threw
+        try {
+            if ($null -ne $InternalTestCleanup) {
+                & $InternalTestCleanup
+            } else {
+                Remove-V4UpdaterProductionCredential -InternalTestTarget $target
+            }
+        } catch {
+            $cleanupException = $_
+        }
+
+        # 3. Clean local secret memory references
+        $credential = $null
+        Remove-Variable credential -ErrorAction SilentlyContinue
+    }
+
+    # 4. Fail closed on either action failure or cleanup failure:
+    if ($null -ne $actionException -and $null -ne $cleanupException) {
+        $cleanMsg = $cleanupException.Exception.Message
+        $actMsg = $actionException.Exception.Message
+        throw "V4 updater credential boundary failure: action failed: $actMsg; session credential cleanup also failed: $cleanMsg"
+    }
+    if ($null -ne $actionException) {
+        throw $actionException
+    }
+    if ($null -ne $cleanupException) {
+        $cleanMsg = $cleanupException.Exception.Message
+        throw "V4 updater credential boundary failure: session credential cleanup failed: $cleanMsg"
+    }
+
+    return $actionResult
+}
+
 if ($PSCmdlet.MyInvocation.BoundParameters.ContainsKey("Action")) {
-    $targetToUse = if (-not [string]::IsNullOrWhiteSpace($BrokerTarget)) { $BrokerTarget } else { $script:CanonicalCredentialTarget }
+    $targetToUse = if (-not [string]::IsNullOrWhiteSpace($BrokerInternalTestTarget)) { $BrokerInternalTestTarget } else { $script:CanonicalCredentialTarget }
     switch ($Action) {
         "Delete" {
-            Remove-V4UpdaterProductionCredential -Target $targetToUse
+            Remove-V4UpdaterProductionCredential -InternalTestTarget $targetToUse
             Write-Host "[PASS] V4 updater session credential deleted"
         }
         "Test" {
-            if (Test-V4UpdaterProductionCredential -Target $targetToUse) {
+            if (Test-V4UpdaterProductionCredential -InternalTestTarget $targetToUse) {
                 Write-Host "PRESENT_NONEMPTY"
             } else {
                 Write-Host "ABSENT"
             }
         }
         "Read" {
-            $null = Get-V4UpdaterProductionCredential -Target $targetToUse
+            $null = Get-V4UpdaterProductionCredential -InternalTestTarget $targetToUse
             Write-Host "[PASS] V4 updater credential read successfully"
         }
     }

--- a/scripts/verify_v4_updater_private_key.ps1
+++ b/scripts/verify_v4_updater_private_key.ps1
@@ -4,7 +4,13 @@ param(
     [string]$KeyPath,
 
     [Parameter(Mandatory = $false)]
-    [string]$PasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD"
+    [string]$PasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$UseCredentialBroker,
+
+    [Parameter(Mandatory = $false)]
+    [string]$CredentialTarget = "SkyAutoPlayer/V4UpdaterProduction"
 )
 
 $ErrorActionPreference = "Stop"
@@ -24,9 +30,12 @@ if (-not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
     throw "Private key file does not exist: $keyFile"
 }
 
-# 2. Resolve password: prefer specified environment variable or secure interactive prompt
+# 2. Resolve password: prefer credential broker if requested, or specified environment variable, or secure interactive prompt
 $envVal = [Environment]::GetEnvironmentVariable($PasswordEnv)
-$passwordValue = if (-not [string]::IsNullOrWhiteSpace($envVal)) {
+$passwordValue = if ($UseCredentialBroker) {
+    . (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
+    Get-V4UpdaterProductionCredential -Target $CredentialTarget
+} elseif (-not [string]::IsNullOrWhiteSpace($envVal)) {
     $envVal
 } elseif ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {
     Write-Host "Enter updater private key passphrase (press Enter if unencrypted): " -NoNewline

--- a/scripts/verify_v4_updater_private_key.ps1
+++ b/scripts/verify_v4_updater_private_key.ps1
@@ -7,10 +7,7 @@ param(
     [string]$PasswordEnv = "TAURI_SIGNING_PRIVATE_KEY_PASSWORD",
 
     [Parameter(Mandatory = $false)]
-    [switch]$UseCredentialBroker,
-
-    [Parameter(Mandatory = $false)]
-    [string]$CredentialTarget = "SkyAutoPlayer/V4UpdaterProduction"
+    [switch]$UseCredentialBroker
 )
 
 $ErrorActionPreference = "Stop"
@@ -34,7 +31,7 @@ if (-not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
 $envVal = [Environment]::GetEnvironmentVariable($PasswordEnv)
 $passwordValue = if ($UseCredentialBroker) {
     . (Join-Path $PSScriptRoot "v4_updater_credential_broker.ps1")
-    Get-V4UpdaterProductionCredential -Target $CredentialTarget
+    Get-V4UpdaterProductionCredential
 } elseif (-not [string]::IsNullOrWhiteSpace($envVal)) {
     $envVal
 } elseif ([Environment]::UserInteractive -and -not [Console]::IsInputRedirected) {


### PR DESCRIPTION
## Summary
Remediation for incident #140: On dedicated runner host `PUMZ`, runner-parent session environment variables (e.g. `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`) do not propagate into child GitHub Actions step processes, leading to bundle signing failures during release candidate builds.

Diagnostic PR #141 confirmed the root cause (parent PowerShell environment PASS, child process FAIL) and remains unmerged evidence.

## Solution Architecture
1. **Windows Credential Manager Generic Session Broker** (`scripts/v4_updater_credential_broker.ps1`):
   - Uses Win32 `Advapi32.dll` (`CredReadW`, `CredWriteW`, `CredDeleteW`, `CredFree`) targeting canonical target `SkyAutoPlayer/V4UpdaterProduction`.
   - Fails closed on missing credentials, empty passwords, or non-Windows OS.
   - Zeroes/frees unmanaged memory allocations and never prints or logs secret contents.
2. **Operator Provisioning & Deletion Helpers**:
   - `scripts/set_v4_updater_session_credential.ps1`: Prompts operator via `Read-Host -AsSecureString` and stores as `CRED_PERSIST_SESSION` (scoped to logon session, automatically discarded on reboot/logoff).
   - `scripts/remove_v4_updater_session_credential.ps1`: Explicit deletion helper.
3. **Pipeline & Workflow Boundary**:
   - `scripts/v4_release_pipeline.ps1`: `Invoke-BuildCandidate` actively rejects ambient `TAURI_SIGNING_PRIVATE_KEY*` environment variables, retrieves credential via broker into process-scoped memory, calls Tauri orchestrator, and guarantees cleanup of both environment variable and session credential in a `finally` block.
   - `.github/workflows/release-v4.yml`: Removed deprecated `updater_password_env` workflow input and job environment binding.
4. **Verification & Audit**:
   - `scripts/verify_v4_updater_private_key.ps1`: Added `-UseCredentialBroker` switch for safe, non-release verification.
   - `rust/xtask/src/checks.rs` & `scripts/test_v4_release_pipeline.ps1`: Mechanically enforced static checks forbidding `updater_password_env` and requiring broker helper existence.
   - Comprehensive test suite in `scripts/test_v4_updater_credential_broker.ps1`.
   - Updated operational documentation in `docs/v4-release-execution-topology.md` and `docs/v4-updater-key-custody.md`.

## Verification
- `cargo xtask check all`: PASS
- `pwsh scripts/test_v4_updater_credential_broker.ps1`: PASS (7/7 suites, 0 failures)
- `pwsh scripts/test_v4_release_pipeline.ps1`: PASS
- `pwsh scripts/test_v4_updater_private_key.ps1`: PASS
- `cargo test --bin xtask`: PASS (69/69 passed)

## Release Safety Notice
- Do NOT merge this PR until QA non-release proof on PUMZ is complete.
- Do NOT trigger or dispatch `release-v4.yml`.
- PR #141 remains unmerged diagnostic evidence.
