### PR TITLE
fix(release): bind Authenticode evidence in canonical production evidence (#143)

### DIFF
--- a/scripts/orchestrate_v4_production_release.ps1
+++ b/scripts/orchestrate_v4_production_release.ps1
@@ -515,34 +515,21 @@ try {
             throw "Emitted qualification evidence failed promote_v4_metadata validation"
         }
 
-        # Comprehensive V4_PRODUCTION_RELEASE_EVIDENCE.json
-        $productionEvidence = [ordered]@{
-            schema_version = 1
-            evidence_type = "v4-production-release-qualification"
-            source_sha = $expectedSha
-            version = $Version
-            channel = $Channel
-            product_name = "Sky Auto Player"
-            identifier = "io.github.pumni.skyautoplayer"
-            target = "nsis"
-            install_mode = "currentUser"
-            installer = $expectedInstallerName
-            installer_size = (Get-Item -LiteralPath $installerPath).Length
-            installer_sha256 = $installerSha256
-            updater_signature = $expectedSignatureName
-            signature_size = (Get-Item -LiteralPath $signaturePath).Length
-            updater_signature_sha256 = $signatureSha256
-            authenticode_mode = "unsigned-zero-budget"
-            authenticode_state = "unsigned"
-            authenticode_provider = "none"
-            approved_signer_thumbprint = $null
-            observed_signer_thumbprint = $observedThumbprint
-            updater_key_id = $canonicalKeyId
-            updater_signature_status = "valid"
-            sbom = "SBOM.spdx.json"
-            sbom_sha256 = $sbomSha256
-            qualification_status = "PASS"
-        }
+        # Comprehensive V4_PRODUCTION_RELEASE_EVIDENCE.json via shared builder contract
+        $productionEvidence = New-V4CanonicalProductionEvidence `
+            -SourceSha $expectedSha `
+            -Version $Version `
+            -Channel $Channel `
+            -InstallerName $expectedInstallerName `
+            -SignatureName $expectedSignatureName `
+            -InstallerSize (Get-Item -LiteralPath $installerPath).Length `
+            -SignatureSize (Get-Item -LiteralPath $signaturePath).Length `
+            -InstallerSha256 $installerSha256 `
+            -SignatureSha256 $signatureSha256 `
+            -AuthenticodeEvidenceSha256 $authEvidenceSha256 `
+            -SbomSha256 $sbomSha256 `
+            -UpdaterKeyId $canonicalKeyId `
+            -ObservedSignerThumbprint $observedThumbprint
         $productionEvidencePath = Join-Path $resolvedEvidenceDir "V4_PRODUCTION_RELEASE_EVIDENCE.json"
         $productionEvidence | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $productionEvidencePath -Encoding utf8
 

--- a/scripts/test_v4_production_orchestrator.ps1
+++ b/scripts/test_v4_production_orchestrator.ps1
@@ -614,6 +614,176 @@ try {
     if ($out16c -notmatch "Qualification evidence type is not the canonical Tauri qualification path") {
         throw "FAILED: Did not reject qualification=skipped-smoke"
     }
+    # Test 17: Canonical production evidence Authenticode binding producer & consumer contract
+    Write-Host "Test 17: Canonical production evidence Authenticode binding producer & consumer contract..."
+    $testSourceSha = "1234567890abcdef1234567890abcdef12345678"
+    $testAuthSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    $testSbomSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    $testInstallerSha = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    $testSigSha = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    $testKeyId = "19AABD2E7838818C"
+
+    function New-TestProductionEvidence {
+        return New-V4CanonicalProductionEvidence `
+            -SourceSha $testSourceSha `
+            -Version $currentVersion `
+            -Channel "stable" `
+            -InstallerName $installerName `
+            -SignatureName $signatureName `
+            -InstallerSize 1234567 `
+            -SignatureSize 512 `
+            -InstallerSha256 $testInstallerSha `
+            -SignatureSha256 $testSigSha `
+            -AuthenticodeEvidenceSha256 $testAuthSha `
+            -SbomSha256 $testSbomSha `
+            -UpdaterKeyId $testKeyId
+    }
+
+    # 17a. Verify builder contract produces exact Authenticode binding properties and values
+    $prodEvObj = New-TestProductionEvidence
+    if (-not $prodEvObj.Contains("authenticode_evidence")) {
+        throw "FAILED: Production evidence builder omitted property 'authenticode_evidence'"
+    }
+    if (-not $prodEvObj.Contains("authenticode_evidence_sha256")) {
+        throw "FAILED: Production evidence builder omitted property 'authenticode_evidence_sha256'"
+    }
+    if ($prodEvObj["authenticode_evidence"] -ne "TAURI_AUTHENTICODE_EVIDENCE.json") {
+        throw "FAILED: Production evidence authenticode_evidence filename is not TAURI_AUTHENTICODE_EVIDENCE.json"
+    }
+    if ($prodEvObj["authenticode_evidence_sha256"] -ne $testAuthSha) {
+        throw "FAILED: Production evidence authenticode_evidence_sha256 does not bind AuthenticodeEvidenceSha256 input"
+    }
+    if ($prodEvObj["authenticode_evidence_sha256"] -eq $prodEvObj["installer_sha256"] -or
+        $prodEvObj["authenticode_evidence_sha256"] -eq $prodEvObj["updater_signature_sha256"] -or
+        $prodEvObj["authenticode_evidence_sha256"] -eq $prodEvObj["sbom_sha256"]) {
+        throw "FAILED: Production evidence authenticode_evidence_sha256 improperly reused another digest"
+    }
+
+    # 17b. Consumer contract: verify Assert-EvidenceIdentity in v4_release_pipeline.ps1 accepts valid production evidence
+    $consumerTestRoot = Join-Path $fixtureRoot "evidence_consumer_test"
+    New-Item -ItemType Directory -Path $consumerTestRoot -Force | Out-Null
+    $prodEvPath = Join-Path $consumerTestRoot "V4_PRODUCTION_RELEASE_EVIDENCE.json"
+    $qualEvPath = Join-Path $consumerTestRoot "V4_QUALIFICATION_EVIDENCE.json"
+    $authEvPath = Join-Path $consumerTestRoot "TAURI_AUTHENTICODE_EVIDENCE.json"
+    $sbomEvPath = Join-Path $consumerTestRoot "SBOM.spdx.json"
+    $instPath = Join-Path $consumerTestRoot $installerName
+    $sigPath = Join-Path $consumerTestRoot $signatureName
+
+    # Write placeholder files to back records
+    Set-Content -LiteralPath $authEvPath -Value "auth" -Encoding utf8
+    Set-Content -LiteralPath $sbomEvPath -Value "sbom" -Encoding utf8
+    Set-Content -LiteralPath $instPath -Value "inst" -Encoding utf8
+    Set-Content -LiteralPath $sigPath -Value "sig" -Encoding utf8
+
+    $records = @(
+        [pscustomobject]@{ name = $installerName; size = [int64]1234567; sha256 = $testInstallerSha },
+        [pscustomobject]@{ name = $signatureName; size = [int64]512; sha256 = $testSigSha },
+        [pscustomobject]@{ name = "V4_PRODUCTION_RELEASE_EVIDENCE.json"; size = [int64]100; sha256 = "1" * 64 },
+        [pscustomobject]@{ name = "V4_QUALIFICATION_EVIDENCE.json"; size = [int64]100; sha256 = "2" * 64 },
+        [pscustomobject]@{ name = "TAURI_AUTHENTICODE_EVIDENCE.json"; size = [int64]100; sha256 = $testAuthSha },
+        [pscustomobject]@{ name = "SBOM.spdx.json"; size = [int64]100; sha256 = $testSbomSha }
+    )
+
+    $validQual = New-V4CanonicalQualificationEvidence `
+        -Version $currentVersion `
+        -InstallerName $installerName `
+        -SignatureName $signatureName `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha
+    $validQual | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $qualEvPath -Encoding utf8
+
+    # Test runner helper for consumer Assert-EvidenceIdentity
+    $pipelineScript = Join-Path $PSScriptRoot "v4_release_pipeline.ps1"
+    function Test-ConsumerAssertion([string]$ProdPath) {
+        $checkScript = @"
+Set-StrictMode -Version Latest
+`$ErrorActionPreference = 'Stop'
+`$SourceSha = '$testSourceSha'
+`$Version = '$currentVersion'
+`$Channel = 'stable'
+`$productionEvidenceName = 'V4_PRODUCTION_RELEASE_EVIDENCE.json'
+`$qualificationEvidenceName = 'V4_QUALIFICATION_EVIDENCE.json'
+`$authenticodeEvidenceName = 'TAURI_AUTHENTICODE_EVIDENCE.json'
+`$sbomName = 'SBOM.spdx.json'
+function Fail([string]`$Message) { throw `$Message }
+function Get-ExpectedInstallerName { return '$installerName' }
+
+`$Records = @(
+    [pscustomobject]@{ name = '$installerName'; size = [int64]1234567; sha256 = '$testInstallerSha' },
+    [pscustomobject]@{ name = '$signatureName'; size = [int64]512; sha256 = '$testSigSha' },
+    [pscustomobject]@{ name = 'V4_PRODUCTION_RELEASE_EVIDENCE.json'; size = [int64]100; sha256 = '$('1' * 64)' },
+    [pscustomobject]@{ name = 'V4_QUALIFICATION_EVIDENCE.json'; size = [int64]100; sha256 = '$('2' * 64)' },
+    [pscustomobject]@{ name = 'TAURI_AUTHENTICODE_EVIDENCE.json'; size = [int64]100; sha256 = '$testAuthSha' },
+    [pscustomobject]@{ name = 'SBOM.spdx.json'; size = [int64]100; sha256 = '$testSbomSha' }
+)
+
+# Extract Assert-EvidenceIdentity body from v4_release_pipeline.ps1
+`$pipelineSource = Get-Content -LiteralPath '$($pipelineScript.Replace('\', '/'))' -Raw
+if (`$pipelineSource -notmatch '(?ms)function Assert-EvidenceIdentity\(\[string\]\`$ProductionPath, \[string\]\`$QualificationPath, \[object\[\]\]\`$Records\) \{(.+?)^\}') {
+    throw 'Could not extract Assert-EvidenceIdentity from v4_release_pipeline.ps1'
+}
+`$body = `$Matches[1]
+`$assertFn = [scriptblock]::Create('param([string]`$ProductionPath, [string]`$QualificationPath, [object[]]`$Records)' + [System.Environment]::NewLine + `$body)
+& `$assertFn '$($ProdPath.Replace('\', '/'))' '$($qualEvPath.Replace('\', '/'))' `$Records
+"@
+        $tempRunner = Join-Path $consumerTestRoot "run_assert_test.ps1"
+        Set-Content -LiteralPath $tempRunner -Value $checkScript -Encoding utf8
+        $res = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $tempRunner 2>&1 | Out-String
+        return @{ ExitCode = $LASTEXITCODE; Output = $res }
+    }
+
+    # Valid production evidence passes consumer assertion
+    $prodEvObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $prodEvPath -Encoding utf8
+    $validConsumerRun = Test-ConsumerAssertion $prodEvPath
+    if ($validConsumerRun.ExitCode -ne 0) {
+        throw "FAILED: Consumer Assert-EvidenceIdentity rejected valid production evidence: $($validConsumerRun.Output)"
+    }
+
+    # 17c. Missing authenticode_evidence fails closed
+    $missingAuthFile = Join-Path $consumerTestRoot "prod_missing_auth.json"
+    $missingAuthEv = New-TestProductionEvidence
+    $missingAuthEv.Remove("authenticode_evidence")
+    $missingAuthEv | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $missingAuthFile -Encoding utf8
+    $missingAuthRun = Test-ConsumerAssertion $missingAuthFile
+    if ($missingAuthRun.ExitCode -eq 0) {
+        throw "FAILED: Consumer Assert-EvidenceIdentity accepted production evidence missing authenticode_evidence"
+    }
+
+    # 17d. Missing authenticode_evidence_sha256 fails closed
+    $missingAuthShaFile = Join-Path $consumerTestRoot "prod_missing_auth_sha.json"
+    $missingAuthShaEv = New-TestProductionEvidence
+    $missingAuthShaEv.Remove("authenticode_evidence_sha256")
+    $missingAuthShaEv | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $missingAuthShaFile -Encoding utf8
+    $missingAuthShaRun = Test-ConsumerAssertion $missingAuthShaFile
+    if ($missingAuthShaRun.ExitCode -eq 0) {
+        throw "FAILED: Consumer Assert-EvidenceIdentity accepted production evidence missing authenticode_evidence_sha256"
+    }
+
+    # 17e. Tampered authenticode_evidence filename fails closed
+    $tamperedNameFile = Join-Path $consumerTestRoot "prod_tampered_name.json"
+    $tamperedNameEv = New-TestProductionEvidence
+    $tamperedNameEv["authenticode_evidence"] = "OTHER_AUTHENTICODE_EVIDENCE.json"
+    $tamperedNameEv | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $tamperedNameFile -Encoding utf8
+    $tamperedNameRun = Test-ConsumerAssertion $tamperedNameFile
+    if ($tamperedNameRun.ExitCode -eq 0) {
+        throw "FAILED: Consumer Assert-EvidenceIdentity accepted production evidence with tampered authenticode_evidence filename"
+    }
+
+    # 17f. Tampered authenticode_evidence_sha256 digest fails closed
+    $tamperedShaFile = Join-Path $consumerTestRoot "prod_tampered_sha.json"
+    $tamperedShaEv = New-TestProductionEvidence
+    $tamperedShaEv["authenticode_evidence_sha256"] = "f" * 64
+    $tamperedShaEv | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $tamperedShaFile -Encoding utf8
+    $tamperedShaRun = Test-ConsumerAssertion $tamperedShaFile
+    if ($tamperedShaRun.ExitCode -eq 0) {
+        throw "FAILED: Consumer Assert-EvidenceIdentity accepted production evidence with tampered authenticode_evidence digest"
+    }
+    Write-Host "Test 17: PASS"
+
     # Regression assertion: Running orchestrator contract suite must not create, delete, or modify production release outputs
     $finalBundleSnapshot = Get-CanonicalBundleSnapshot
     if ($initialBundleSnapshot.Count -ne $finalBundleSnapshot.Count) {

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -284,4 +284,239 @@ if ($mock.BuildCount -ne 1 -or -not $mock.Promoted -or $mock.Draft -or -not $moc
     Fail "mock state machine did not preserve build-once/publication ordering"
 }
 
+# Production evidence Authenticode binding contract regression test
+. (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
+
+$evidenceTestRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-evidence-binding-test-" + [guid]::NewGuid().ToString("N"))
+try {
+    New-Item -ItemType Directory -Path $evidenceTestRoot -Force | Out-Null
+    $testVersion = "4.0.0-rc.1"
+    $testInstaller = "Sky Auto Player_${testVersion}_x64-setup.exe"
+    $testSignature = "$testInstaller.sig"
+    $testSha = "1234567890abcdef1234567890abcdef12345678"
+    $testAuthSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    $testSbomSha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    $testInstallerSha = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    $testSigSha = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    $testKeyId = "19AABD2E7838818C"
+
+    # Verify builder produces required fields with exact values and independent digest
+    $prodObj = New-V4CanonicalProductionEvidence `
+        -SourceSha $testSha `
+        -Version $testVersion `
+        -Channel "stable" `
+        -InstallerName $testInstaller `
+        -SignatureName $testSignature `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha `
+        -UpdaterKeyId $testKeyId
+
+    if (-not $prodObj.Contains("authenticode_evidence") -or -not $prodObj.Contains("authenticode_evidence_sha256")) {
+        Fail "production evidence builder omitted required Authenticode binding property"
+    }
+    if ($prodObj["authenticode_evidence"] -ne "TAURI_AUTHENTICODE_EVIDENCE.json") {
+        Fail "production evidence builder authenticode_evidence filename must be TAURI_AUTHENTICODE_EVIDENCE.json"
+    }
+    if ($prodObj["authenticode_evidence_sha256"] -ne $testAuthSha) {
+        Fail "production evidence builder authenticode_evidence_sha256 must match AuthenticodeEvidenceSha256 input"
+    }
+    if ($prodObj["authenticode_evidence_sha256"] -eq $prodObj["installer_sha256"] -or
+        $prodObj["authenticode_evidence_sha256"] -eq $prodObj["updater_signature_sha256"] -or
+        $prodObj["authenticode_evidence_sha256"] -eq $prodObj["sbom_sha256"]) {
+        Fail "production evidence builder improperly reused another digest for authenticode_evidence_sha256"
+    }
+
+    $qualObj = New-V4CanonicalQualificationEvidence `
+        -Version $testVersion `
+        -InstallerName $testInstaller `
+        -SignatureName $testSignature `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha
+
+    $qualPath = Join-Path $evidenceTestRoot "V4_QUALIFICATION_EVIDENCE.json"
+    $prodPath = Join-Path $evidenceTestRoot "V4_PRODUCTION_RELEASE_EVIDENCE.json"
+    $qualObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $qualPath -Encoding utf8
+
+    $records = @(
+        [pscustomobject]@{ name = $testInstaller; size = [int64]1234567; sha256 = $testInstallerSha },
+        [pscustomobject]@{ name = $testSignature; size = [int64]512; sha256 = $testSigSha },
+        [pscustomobject]@{ name = "V4_PRODUCTION_RELEASE_EVIDENCE.json"; size = [int64]100; sha256 = "1" * 64 },
+        [pscustomobject]@{ name = "V4_QUALIFICATION_EVIDENCE.json"; size = [int64]100; sha256 = "2" * 64 },
+        [pscustomobject]@{ name = "TAURI_AUTHENTICODE_EVIDENCE.json"; size = [int64]100; sha256 = $testAuthSha },
+        [pscustomobject]@{ name = "SBOM.spdx.json"; size = [int64]100; sha256 = $testSbomSha }
+    )
+
+    # Helper to invoke pipeline Assert-EvidenceIdentity in a scoped environment
+    function Invoke-EvidenceIdentityAssertion([string]$TargetProdPath) {
+        $scopedScript = @'
+param(
+    [string]$PipelinePath,
+    [string]$TargetProdPath,
+    [string]$QualPath,
+    [string]$TestSha,
+    [string]$TestVersion,
+    [string]$TestInstaller,
+    [string]$TestInstallerSha,
+    [string]$TestSigSha,
+    [string]$TestAuthSha,
+    [string]$TestSbomSha
+)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$SourceSha = $TestSha
+$Version = $TestVersion
+$Channel = 'stable'
+$productionEvidenceName = 'V4_PRODUCTION_RELEASE_EVIDENCE.json'
+$qualificationEvidenceName = 'V4_QUALIFICATION_EVIDENCE.json'
+$authenticodeEvidenceName = 'TAURI_AUTHENTICODE_EVIDENCE.json'
+$sbomName = 'SBOM.spdx.json'
+function Fail([string]$Message) { throw $Message }
+function Get-ExpectedInstallerName { return $TestInstaller }
+
+$pipelineCode = Get-Content -LiteralPath $PipelinePath -Raw
+$startIdx = $pipelineCode.IndexOf('function Assert-EvidenceIdentity(')
+if ($startIdx -lt 0) { throw 'Could not locate Assert-EvidenceIdentity function start' }
+$openBrace = $pipelineCode.IndexOf('{', $startIdx)
+if ($openBrace -lt 0) { throw 'Could not locate Assert-EvidenceIdentity body start' }
+$closeBrace = $pipelineCode.IndexOf("`n}", $openBrace)
+if ($closeBrace -lt 0) { throw 'Could not locate Assert-EvidenceIdentity body end' }
+$fnBody = $pipelineCode.Substring($openBrace + 1, $closeBrace - $openBrace - 1)
+
+$fn = [scriptblock]::Create("param([string]`$ProductionPath, [string]`$QualificationPath, [object[]]`$Records)`n$fnBody")
+
+$recs = @(
+    [pscustomobject]@{ name = $TestInstaller; size = [int64]1234567; sha256 = $TestInstallerSha },
+    [pscustomobject]@{ name = "$TestInstaller.sig"; size = [int64]512; sha256 = $TestSigSha },
+    [pscustomobject]@{ name = 'V4_PRODUCTION_RELEASE_EVIDENCE.json'; size = [int64]100; sha256 = ('1' * 64) },
+    [pscustomobject]@{ name = 'V4_QUALIFICATION_EVIDENCE.json'; size = [int64]100; sha256 = ('2' * 64) },
+    [pscustomobject]@{ name = 'TAURI_AUTHENTICODE_EVIDENCE.json'; size = [int64]100; sha256 = $TestAuthSha },
+    [pscustomobject]@{ name = 'SBOM.spdx.json'; size = [int64]100; sha256 = $TestSbomSha }
+)
+
+& $fn $TargetProdPath $QualPath $recs
+'@
+        $worker = Join-Path $evidenceTestRoot "assert_worker.ps1"
+        Set-Content -LiteralPath $worker -Value $scopedScript -Encoding utf8
+        $res = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $worker `
+            -PipelinePath $pipelinePath `
+            -TargetProdPath $TargetProdPath `
+            -QualPath $qualPath `
+            -TestSha $testSha `
+            -TestVersion $testVersion `
+            -TestInstaller $testInstaller `
+            -TestInstallerSha $testInstallerSha `
+            -TestSigSha $testSigSha `
+            -TestAuthSha $testAuthSha `
+            -TestSbomSha $testSbomSha 2>&1 | Out-String
+        return @{ ExitCode = $LASTEXITCODE; Output = $res }
+    }
+
+    # 1. Valid production evidence passes consumer Assert-EvidenceIdentity
+    $prodObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $prodPath -Encoding utf8
+    $validRun = Invoke-EvidenceIdentityAssertion $prodPath
+    if ($validRun.ExitCode -ne 0) {
+        Fail "consumer Assert-EvidenceIdentity rejected valid production evidence: $($validRun.Output)"
+    }
+
+    # 2. Missing authenticode_evidence fails closed
+    $missingAuthObj = New-V4CanonicalProductionEvidence `
+        -SourceSha $testSha `
+        -Version $testVersion `
+        -Channel "stable" `
+        -InstallerName $testInstaller `
+        -SignatureName $testSignature `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha `
+        -UpdaterKeyId $testKeyId
+    $missingAuthObj.Remove("authenticode_evidence")
+    $missingAuthPath = Join-Path $evidenceTestRoot "missing_auth.json"
+    $missingAuthObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $missingAuthPath -Encoding utf8
+    $missingAuthRun = Invoke-EvidenceIdentityAssertion $missingAuthPath
+    if ($missingAuthRun.ExitCode -eq 0) {
+        Fail "consumer Assert-EvidenceIdentity accepted production evidence missing authenticode_evidence"
+    }
+
+    # 3. Missing authenticode_evidence_sha256 fails closed
+    $missingShaObj = New-V4CanonicalProductionEvidence `
+        -SourceSha $testSha `
+        -Version $testVersion `
+        -Channel "stable" `
+        -InstallerName $testInstaller `
+        -SignatureName $testSignature `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha `
+        -UpdaterKeyId $testKeyId
+    $missingShaObj.Remove("authenticode_evidence_sha256")
+    $missingShaPath = Join-Path $evidenceTestRoot "missing_sha.json"
+    $missingShaObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $missingShaPath -Encoding utf8
+    $missingShaRun = Invoke-EvidenceIdentityAssertion $missingShaPath
+    if ($missingShaRun.ExitCode -eq 0) {
+        Fail "consumer Assert-EvidenceIdentity accepted production evidence missing authenticode_evidence_sha256"
+    }
+
+    # 4. Tampered filename fails closed
+    $tamperedNameObj = New-V4CanonicalProductionEvidence `
+        -SourceSha $testSha `
+        -Version $testVersion `
+        -Channel "stable" `
+        -InstallerName $testInstaller `
+        -SignatureName $testSignature `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha `
+        -UpdaterKeyId $testKeyId
+    $tamperedNameObj["authenticode_evidence"] = "TAMPERED_AUTHENTICODE_EVIDENCE.json"
+    $tamperedNamePath = Join-Path $evidenceTestRoot "tampered_name.json"
+    $tamperedNameObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $tamperedNamePath -Encoding utf8
+    $tamperedNameRun = Invoke-EvidenceIdentityAssertion $tamperedNamePath
+    if ($tamperedNameRun.ExitCode -eq 0) {
+        Fail "consumer Assert-EvidenceIdentity accepted production evidence with tampered authenticode_evidence filename"
+    }
+
+    # 5. Tampered SHA-256 fails closed
+    $tamperedShaObj = New-V4CanonicalProductionEvidence `
+        -SourceSha $testSha `
+        -Version $testVersion `
+        -Channel "stable" `
+        -InstallerName $testInstaller `
+        -SignatureName $testSignature `
+        -InstallerSize 1234567 `
+        -SignatureSize 512 `
+        -InstallerSha256 $testInstallerSha `
+        -SignatureSha256 $testSigSha `
+        -AuthenticodeEvidenceSha256 $testAuthSha `
+        -SbomSha256 $testSbomSha `
+        -UpdaterKeyId $testKeyId
+    $tamperedShaObj["authenticode_evidence_sha256"] = "f" * 64
+    $tamperedShaPath = Join-Path $evidenceTestRoot "tampered_sha.json"
+    $tamperedShaObj | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $tamperedShaPath -Encoding utf8
+    $tamperedShaRun = Invoke-EvidenceIdentityAssertion $tamperedShaPath
+    if ($tamperedShaRun.ExitCode -eq 0) {
+        Fail "consumer Assert-EvidenceIdentity accepted production evidence with tampered authenticode_evidence_sha256"
+    }
+} finally {
+    if (Test-Path -LiteralPath $evidenceTestRoot) {
+        Remove-Item -LiteralPath $evidenceTestRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
 Write-Host "V4 release pipeline contract/self-test: PASS (mock draft/download/qualify/attest/publish/promote; build count=1)"

--- a/scripts/v4_qualification_evidence.ps1
+++ b/scripts/v4_qualification_evidence.ps1
@@ -50,3 +50,63 @@ function New-V4CanonicalQualificationEvidence {
         sbom_sha256 = $SbomSha256.ToLowerInvariant()
     }
 }
+
+function New-V4CanonicalProductionEvidence {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)] [string]$SourceSha,
+        [Parameter(Mandatory = $true)] [string]$Version,
+        [Parameter(Mandatory = $true)] [string]$Channel,
+        [Parameter(Mandatory = $true)] [string]$InstallerName,
+        [Parameter(Mandatory = $true)] [string]$SignatureName,
+        [Parameter(Mandatory = $true)] [int64]$InstallerSize,
+        [Parameter(Mandatory = $true)] [int64]$SignatureSize,
+        [Parameter(Mandatory = $true)] [string]$InstallerSha256,
+        [Parameter(Mandatory = $true)] [string]$SignatureSha256,
+        [Parameter(Mandatory = $true)] [string]$AuthenticodeEvidenceSha256,
+        [Parameter(Mandatory = $true)] [string]$SbomSha256,
+        [Parameter(Mandatory = $true)] [string]$UpdaterKeyId,
+        $ObservedSignerThumbprint = $null
+    )
+
+    if ($SourceSha -notmatch '^[0-9a-fA-F]{40}$') { throw "SourceSha must be a 40-character commit SHA" }
+    if ($Channel -notin @("stable", "beta")) { throw "Channel must be 'stable' or 'beta'" }
+    if ($InstallerSize -le 0) { throw "InstallerSize must be positive" }
+    if ($SignatureSize -le 0) { throw "SignatureSize must be positive" }
+    if ($InstallerSha256 -notmatch '^[0-9a-fA-F]{64}$') { throw "InstallerSha256 must be a 64-character SHA-256 hex string" }
+    if ($SignatureSha256 -notmatch '^[0-9a-fA-F]{64}$') { throw "SignatureSha256 must be a 64-character SHA-256 hex string" }
+    if ($AuthenticodeEvidenceSha256 -notmatch '^[0-9a-fA-F]{64}$') { throw "AuthenticodeEvidenceSha256 must be a 64-character SHA-256 hex string" }
+    if ($SbomSha256 -notmatch '^[0-9a-fA-F]{64}$') { throw "SbomSha256 must be a 64-character SHA-256 hex string" }
+    if ($UpdaterKeyId -notmatch '^[0-9a-fA-F]{16}$') { throw "UpdaterKeyId must be a 16-character hex string" }
+
+    return [ordered]@{
+        schema_version = 1
+        evidence_type = "v4-production-release-qualification"
+        source_sha = $SourceSha.ToLowerInvariant()
+        version = $Version
+        channel = $Channel
+        product_name = "Sky Auto Player"
+        identifier = "io.github.pumni.skyautoplayer"
+        target = "nsis"
+        install_mode = "currentUser"
+        installer = $InstallerName
+        installer_size = $InstallerSize
+        installer_sha256 = $InstallerSha256.ToLowerInvariant()
+        updater_signature = $SignatureName
+        signature_size = $SignatureSize
+        updater_signature_sha256 = $SignatureSha256.ToLowerInvariant()
+        authenticode_mode = "unsigned-zero-budget"
+        authenticode_state = "unsigned"
+        authenticode_provider = "none"
+        approved_signer_thumbprint = $null
+        observed_signer_thumbprint = if ($null -ne $ObservedSignerThumbprint -and [string]$ObservedSignerThumbprint -ne "") { [string]$ObservedSignerThumbprint } else { $null }
+        authenticode_evidence = "TAURI_AUTHENTICODE_EVIDENCE.json"
+        authenticode_evidence_sha256 = $AuthenticodeEvidenceSha256.ToLowerInvariant()
+        updater_key_id = $UpdaterKeyId.ToUpperInvariant()
+        updater_signature_status = "valid"
+        sbom = "SBOM.spdx.json"
+        sbom_sha256 = $SbomSha256.ToLowerInvariant()
+        qualification_status = "PASS"
+    }
+}
+


### PR DESCRIPTION
## Summary
Closes #143.

Fixes the release candidate build-blocking defect where canonical `V4_PRODUCTION_RELEASE_EVIDENCE.json` produced by `scripts/orchestrate_v4_production_release.ps1` omitted mandatory Authenticode evidence binding fields required by the consumer identity assertion `Assert-EvidenceIdentity` in `scripts/v4_release_pipeline.ps1`:
- `authenticode_evidence = "TAURI_AUTHENTICODE_EVIDENCE.json"`
- `authenticode_evidence_sha256 = <authEvidenceSha256>`

## Changes
1. **Canonical Production Evidence Builder** (`scripts/v4_qualification_evidence.ps1`):
   - Added `New-V4CanonicalProductionEvidence` defining the exact schema and property types for production release qualification evidence, explicitly binding `authenticode_evidence` and `authenticode_evidence_sha256`.
2. **Orchestrator Emission** (`scripts/orchestrate_v4_production_release.ps1`):
   - Replaced inline hashtable construction with `New-V4CanonicalProductionEvidence`, ensuring canonical emission of all required properties.
3. **Consumer & Producer Regression Testing**:
   - `scripts/test_v4_release_pipeline.ps1`: Added unit tests verifying producer outputs and exercising consumer `Assert-EvidenceIdentity` directly against valid, missing, and tampered `authenticode_evidence` and `authenticode_evidence_sha256`.
   - `scripts/test_v4_production_orchestrator.ps1`: Added Test 17 verifying producer contract and consumer assertion fail-closed behavior for missing and tampered fields.

## Verification
- `cargo xtask check static`: PASS
- `pwsh scripts/test_v4_updater_credential_broker.ps1`: PASS (7/7 suites)
- `pwsh scripts/test_v4_release_pipeline.ps1`: PASS
- `pwsh scripts/test_v4_production_orchestrator.ps1`: PASS (Tests 1-17)

## Release Safety Notice
- Do NOT merge until PR CI passes and QA approves.
- Do NOT dispatch production release run #11.
