### PR TITLE
fix(release): use safe authority asset names to prevent GitHub release asset normalization

### DIFF
--- a/rust/xtask/src/release_authority.rs
+++ b/rust/xtask/src/release_authority.rs
@@ -68,10 +68,14 @@ pub fn canonical_installer_name(version: &str) -> String {
     format!("{PRODUCT_NAME}_{version}_{WINDOWS_ARCH}-setup.exe")
 }
 
+pub fn canonical_authority_installer_name(version: &str) -> String {
+    canonical_installer_name(version).replace(' ', ".")
+}
+
 pub fn canonical_asset_url(version: &str) -> String {
     format!(
         "https://github.com/{AUTHORITY_REPOSITORY}/releases/download/v{version}/{}",
-        canonical_installer_name(version).replace(' ', "%20")
+        canonical_authority_installer_name(version)
     )
 }
 
@@ -312,7 +316,7 @@ mod tests {
         let url = canonical_asset_url("4.0.0-beta.1");
         assert_eq!(
             url,
-            "https://github.com/pumni/Sky-Auto-Player-Releases/releases/download/v4.0.0-beta.1/Sky%20Auto%20Player_4.0.0-beta.1_x64-setup.exe"
+            "https://github.com/pumni/Sky-Auto-Player-Releases/releases/download/v4.0.0-beta.1/Sky.Auto.Player_4.0.0-beta.1_x64-setup.exe"
         );
         let first = serde_json::to_string_pretty(&metadata("4.0.0-beta.1", &url)).unwrap();
         let second = serde_json::to_string_pretty(&metadata("4.0.0-beta.1", &url)).unwrap();
@@ -367,7 +371,7 @@ mod tests {
             valid.replace(AUTHORITY_REPOSITORY, SOURCE_REPOSITORY),
             valid.replace("https://", "http://"),
             valid.replace("_x64-setup.exe", "_x64-setup.exe?channel=beta"),
-            valid.replace("Sky%20Auto%20Player", "Sky-Auto-Player-v4"),
+            valid.replace("Sky.Auto.Player", "Sky-Auto-Player-v4"),
         ] {
             assert!(
                 validate_metadata(&metadata("4.0.0", &url), Channel::Stable).is_err(),

--- a/scripts/promote_v4_metadata.ps1
+++ b/scripts/promote_v4_metadata.ps1
@@ -31,6 +31,7 @@ $installerNameSuffix = "_x64-setup.exe"
 $evidenceType = "tauri-nsis-qualified-release"
 $evidenceSchemaVersion = 1
 $productionAuthenticodeMode = "unsigned-zero-budget"
+. (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
 
 function Get-GitHubJson([string]$Path) {
     $payload = & gh api $Path --header "Accept: application/vnd.github+json"
@@ -195,7 +196,9 @@ function Invoke-PromotionSelfTest {
     $version = "4.0.0"
     $installer = "$productName`_$version$installerNameSuffix"
     $signature = "$installer.sig"
-    $url = Get-CanonicalReleaseAssetUrl $version $installer
+    $authorityInstaller = Get-V4SafeAuthorityAssetName $installer
+    $authoritySignature = Get-V4SafeAuthorityAssetName $signature
+    $url = Get-CanonicalReleaseAssetUrl $version $authorityInstaller
     $evidence = [pscustomobject]@{
         schema_version = 1
         evidence_type = $evidenceType
@@ -220,14 +223,14 @@ function Invoke-PromotionSelfTest {
     }
     $digests = Assert-QualificationEvidence $evidence $version $installer $signature
     $differentBytes = [pscustomobject]@{
-        name = $installer
+        name = $authorityInstaller
         browser_download_url = $url
         size = [int64]10
         digest = "sha256:" + ("b" * 64)
     }
     $rejected = $false
     try {
-        Assert-PublishedAsset $differentBytes $installer $url $digests.InstallerSize $digests.InstallerSha256 "installer"
+        Assert-PublishedAsset $differentBytes $authorityInstaller $url $digests.InstallerSize $digests.InstallerSha256 "installer"
     } catch {
         if ($_.Exception.Message -notmatch "SHA-256 mismatch") { throw }
         $rejected = $true
@@ -278,6 +281,8 @@ if ($null -eq $platformJson) { throw "Metadata has no $platform entry" }
 $version = [string]$metadataJson.version
 $expectedInstaller = "$productName`_$version$installerNameSuffix"
 $expectedSignature = "$expectedInstaller.sig"
+$expectedAuthorityInstaller = Get-V4SafeAuthorityAssetName $expectedInstaller
+$expectedAuthoritySignature = Get-V4SafeAuthorityAssetName $expectedSignature
 $evidence = Get-Content -LiteralPath $QualificationEvidence -Raw | ConvertFrom-Json
 $evidenceDigests = $null
 
@@ -297,19 +302,19 @@ if ($Channel -eq "stable" -and $release.prerelease) {
     throw "Stable metadata cannot point at a prerelease: v$version"
 }
 
-$asset = @($release.assets | Where-Object { $_.name -eq $expectedInstaller })
-$signatureAsset = @($release.assets | Where-Object { $_.name -eq $expectedSignature })
+$asset = @($release.assets | Where-Object { $_.name -eq $expectedAuthorityInstaller })
+$signatureAsset = @($release.assets | Where-Object { $_.name -eq $expectedAuthoritySignature })
 if ($asset.Count -ne 1 -or $signatureAsset.Count -ne 1) {
     throw "Published release is missing the exact Tauri installer/signature pair"
 }
-$expectedInstallerUrl = Get-CanonicalReleaseAssetUrl $version $expectedInstaller
-$expectedSignatureUrl = Get-CanonicalReleaseAssetUrl $version $expectedSignature
+$expectedInstallerUrl = Get-CanonicalReleaseAssetUrl $version $expectedAuthorityInstaller
+$expectedSignatureUrl = Get-CanonicalReleaseAssetUrl $version $expectedAuthoritySignature
 if ([string]$platformJson.url -ne $expectedInstallerUrl) {
     throw "Metadata URL is not the exact published Tauri asset URL"
 }
-Assert-PublishedAsset $asset[0] $expectedInstaller $expectedInstallerUrl `
+Assert-PublishedAsset $asset[0] $expectedAuthorityInstaller $expectedInstallerUrl `
     $evidenceDigests.InstallerSize $evidenceDigests.InstallerSha256 "installer"
-Assert-PublishedAsset $signatureAsset[0] $expectedSignature $expectedSignatureUrl `
+Assert-PublishedAsset $signatureAsset[0] $expectedAuthoritySignature $expectedSignatureUrl `
     $evidenceDigests.SignatureSize $evidenceDigests.SignatureSha256 "signature"
 
 $publishedSignature = & gh api $signatureAsset[0].url --header "Accept: application/octet-stream"

--- a/scripts/test_v4_release_authority_rehearsal.ps1
+++ b/scripts/test_v4_release_authority_rehearsal.ps1
@@ -20,8 +20,10 @@ if ([string]::IsNullOrWhiteSpace($token)) {
 }
 
 $rehearsalRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-authority-rehearsal-" + [guid]::NewGuid().ToString("N"))
-$artifactName = "v4-authority-upload-rehearsal-" + [guid]::NewGuid().ToString("N") + ".txt"
-$artifactPath = Join-Path $rehearsalRoot $artifactName
+. (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
+$sourceArtifactName = "v4 authority upload rehearsal " + [guid]::NewGuid().ToString("N") + ".txt"
+$safeAuthorityName = Get-V4SafeAuthorityAssetName $sourceArtifactName
+$artifactPath = Join-Path $rehearsalRoot $sourceArtifactName
 $downloadPath = Join-Path $rehearsalRoot "downloaded.txt"
 $errorPath = Join-Path $rehearsalRoot "gh-error.log"
 $tag = "v4-authority-rehearsal-" + [guid]::NewGuid().ToString("N")
@@ -164,10 +166,10 @@ try {
     $phase = "upload-asset"
     $uploaded = Invoke-V4ReleaseAuthorityAssetUpload `
         -UploadUrl $uploadUrl `
-        -AssetName $artifactName `
+        -AssetName $safeAuthorityName `
         -FilePath $artifactPath `
         -Token $token
-    if ([string]$uploaded.name -ne $artifactName -or [int64]$uploaded.size -ne [int64]$expectedSize) {
+    if ([string]$uploaded.name -ne $safeAuthorityName -or [int64]$uploaded.size -ne [int64]$expectedSize) {
         throw "authority rehearsal upload response did not preserve the exact asset identity"
     }
 
@@ -175,7 +177,7 @@ try {
     $rehearsed = Invoke-AuthorityApi -Arguments @(
         "api", "repos/$authorityRepository/releases/$releaseId"
     )
-    $asset = @($rehearsed.assets | Where-Object { [string]$_.name -eq $artifactName })
+    $asset = @($rehearsed.assets | Where-Object { [string]$_.name -eq $safeAuthorityName })
     if ($asset.Count -ne 1) { throw "authority rehearsal draft asset was not found" }
 
     $phase = "download-asset"

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -519,4 +519,117 @@ $recs = @(
     }
 }
 
+# Safe authority asset name contract regression tests
+function Test-SafeAuthorityAssetNameContract {
+    # 1. Source installer name with spaces maps to deterministic safe authority name
+    $sourceInstaller = "Sky Auto Player_4.0.0-rc.1_x64-setup.exe"
+    $safeInstaller = Get-V4SafeAuthorityAssetName $sourceInstaller
+    if ($safeInstaller -ne "Sky.Auto.Player_4.0.0-rc.1_x64-setup.exe") {
+        Fail "Get-V4SafeAuthorityAssetName did not map source installer spaces to dots"
+    }
+    $sourceSig = "$sourceInstaller.sig"
+    $safeSig = Get-V4SafeAuthorityAssetName $sourceSig
+    if ($safeSig -ne "Sky.Auto.Player_4.0.0-rc.1_x64-setup.exe.sig") {
+        Fail "Get-V4SafeAuthorityAssetName did not map signature name spaces to dots"
+    }
+
+    # 2. Source and authority records keep identical SHA and size
+    $tempDir = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-record-test-" + [guid]::NewGuid().ToString("N"))
+    try {
+        New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+        $filePath = Join-Path $tempDir $sourceInstaller
+        $testBytes = [byte[]](0x4D, 0x5A, 0x90, 0x00, 0x03)
+        [IO.File]::WriteAllBytes($filePath, $testBytes)
+        $fileSha = (Get-FileHash -LiteralPath $filePath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+        $rec = [pscustomobject]@{
+            name = $safeInstaller
+            source_name = $sourceInstaller
+            authority_name = $safeInstaller
+            role = "installer"
+            size = [int64]$testBytes.Length
+            sha256 = $fileSha
+        }
+        if ($rec.size -ne [int64]$testBytes.Length -or $rec.sha256 -ne $fileSha) {
+            Fail "source and authority record sizes or SHA-256 digests do not match"
+        }
+        if ($rec.source_name -ne $sourceInstaller -or $rec.authority_name -ne $safeInstaller) {
+            Fail "record does not cleanly separate source_name from authority_name"
+        }
+    } finally {
+        if (Test-Path -LiteralPath $tempDir) {
+            Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # 3. Upload response exact-name matching remains mandatory
+    if ($pipeline -notmatch '\[string\]\$uploaded\.name\s+-ne\s+\$authorityName') {
+        Fail "pipeline must enforce uploaded.name -eq authorityName exact response match"
+    }
+
+    # 4. Unsafe name fails before CreateDraft
+    foreach ($unsafe in @(
+        "", "   ", "path/separator", "path\separator", ".leadingdot", "-leadinghyphen",
+        ".", "..", "invalid*char", "invalid?char", "invalid:char", "invalid|char"
+    )) {
+        $failedClosed = $false
+        try {
+            $null = Get-V4SafeAuthorityAssetName $unsafe
+        } catch {
+            $failedClosed = $true
+        }
+        if (-not $failedClosed) {
+            Fail "Get-V4SafeAuthorityAssetName accepted unsafe name: '$unsafe'"
+        }
+    }
+
+    # 5. Authority-name collision fails before CreateDraft
+    if ($pipeline -notmatch 'authority asset name collision detected') {
+        Fail "pipeline must contain authority asset name collision check before CreateDraft"
+    }
+
+    # 6. Downloaded safe-name asset qualifies against source-name evidence without byte mutation
+    $qualTestDir = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-download-qual-test-" + [guid]::NewGuid().ToString("N"))
+    try {
+        New-Item -ItemType Directory -Path $qualTestDir -Force | Out-Null
+        $dlDir = Join-Path $qualTestDir "downloaded"
+        $bundleDir = Join-Path $qualTestDir "bundle"
+        New-Item -ItemType Directory -Path $dlDir -Force | Out-Null
+        New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
+        $dlFile = Join-Path $dlDir $safeInstaller
+        $fixtureBytes = [byte[]](0xDE, 0xAD, 0xBE, 0xEF, 0x42)
+        [IO.File]::WriteAllBytes($dlFile, $fixtureBytes)
+        $dlHash = (Get-FileHash -LiteralPath $dlFile -Algorithm SHA256).Hash.ToLowerInvariant()
+        # Stage to bundle under source name
+        $stagedFile = Join-Path $bundleDir $sourceInstaller
+        Copy-Item -LiteralPath $dlFile -Destination $stagedFile
+        $stagedHash = (Get-FileHash -LiteralPath $stagedFile -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($stagedHash -ne $dlHash) {
+            Fail "staging safe authority name into source bundle mutated file bytes"
+        }
+        if ((Get-Item -LiteralPath $stagedFile).Name -ne $sourceInstaller) {
+            Fail "staged file name does not match expected source installer name"
+        }
+    } finally {
+        if (Test-Path -LiteralPath $qualTestDir) {
+            Remove-Item -LiteralPath $qualTestDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    # 7. Authority rehearsal exercises a filename that would normalize and proves sending already-safe name
+    if ($rehearsal -notmatch 'sourceArtifactName\s*=\s*"v4 authority upload rehearsal ') {
+        Fail "authority rehearsal must exercise a source artifact name containing spaces"
+    }
+    if ($rehearsal -notmatch 'safeAuthorityName\s*=\s*Get-V4SafeAuthorityAssetName') {
+        Fail "authority rehearsal must map source name via Get-V4SafeAuthorityAssetName"
+    }
+    if ($rehearsal -notmatch '-AssetName\s+\$safeAuthorityName') {
+        Fail "authority rehearsal must upload asset with safeAuthorityName"
+    }
+
+    Write-Host "V4 safe authority asset name contract: PASS (deterministic dot mapping; collision check; exact response check; safe staging)"
+}
+
+Test-SafeAuthorityAssetNameContract
+
 Write-Host "V4 release pipeline contract/self-test: PASS (mock draft/download/qualify/attest/publish/promote; build count=1)"

--- a/scripts/v4_qualification_evidence.ps1
+++ b/scripts/v4_qualification_evidence.ps1
@@ -110,3 +110,30 @@ function New-V4CanonicalProductionEvidence {
     }
 }
 
+function Get-V4SafeAuthorityAssetName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)] [string]$Name
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "Asset name must not be null or whitespace"
+    }
+    if ($Name.Contains('/') -or $Name.Contains('\')) {
+        throw "Asset name must not contain path separators: $Name"
+    }
+    if ($Name -eq '.' -or $Name -eq '..') {
+        throw "Asset name must not be '.' or '..': $Name"
+    }
+    if ($Name.StartsWith('.') -or $Name.StartsWith('-')) {
+        throw "Asset name must not start with '.' or '-': $Name"
+    }
+
+    $safeName = $Name.Replace(' ', '.')
+    if ($safeName -notmatch '^[A-Za-z0-9._-]+$') {
+        throw "Asset name '$Name' (normalized to '$safeName') contains invalid characters; must match '^[A-Za-z0-9._-]+$'"
+    }
+
+    return $safeName
+}
+

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -43,6 +43,7 @@ $installedAuthenticodeEvidenceName = "INSTALLED_AUTHENTICODE_EVIDENCE.json"
 $summaryName = "TAURI_ARTIFACT_SUMMARY.json"
 $sbomName = "SBOM.spdx.json"
 . (Join-Path $PSScriptRoot "v4_release_authority_upload.ps1")
+. (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
 
 function Fail([string]$Message) {
     throw "V4 release pipeline failed closed: $Message"
@@ -287,9 +288,13 @@ function Get-FileRecord([object]$Candidate) {
     if (-not (Test-Path -LiteralPath $Candidate.path -PathType Leaf)) { Fail "qualified candidate file is missing: $($Candidate.name)" }
     $item = Get-Item -LiteralPath $Candidate.path
     if ($item.Length -le 0) { Fail "qualified candidate file is empty: $($Candidate.name)" }
+    $sourceName = [string]$Candidate.name
+    $authorityName = Get-V4SafeAuthorityAssetName $sourceName
     return [pscustomobject]@{
-        name = $Candidate.name
-        role = $Candidate.role
+        name = $authorityName
+        source_name = $sourceName
+        authority_name = $authorityName
+        role = [string]$Candidate.role
         size = [int64]$item.Length
         sha256 = (Get-FileHash -LiteralPath $Candidate.path -Algorithm SHA256).Hash.ToLowerInvariant()
     }
@@ -297,7 +302,15 @@ function Get-FileRecord([object]$Candidate) {
 
 function Assert-EvidenceIdentity([string]$ProductionPath, [string]$QualificationPath, [object[]]$Records) {
     $recordsByName = @{}
-    foreach ($record in @($Records)) { $recordsByName[[string]$record.name] = $record }
+    foreach ($record in @($Records)) {
+        $recordsByName[[string]$record.name] = $record
+        if ($null -ne $record.PSObject.Properties['source_name'] -and -not [string]::IsNullOrWhiteSpace([string]$record.source_name)) {
+            $recordsByName[[string]$record.source_name] = $record
+        }
+        if ($null -ne $record.PSObject.Properties['authority_name'] -and -not [string]::IsNullOrWhiteSpace([string]$record.authority_name)) {
+            $recordsByName[[string]$record.authority_name] = $record
+        }
+    }
     foreach ($requiredName in @($productionEvidenceName, $qualificationEvidenceName, $authenticodeEvidenceName, $sbomName)) {
         if (-not $recordsByName.ContainsKey($requiredName)) { Fail "candidate manifest is missing required identity record: $requiredName" }
     }
@@ -315,23 +328,28 @@ function Assert-EvidenceIdentity([string]$ProductionPath, [string]$Qualification
     if ([string]$evidence.updater_signature_status -ne "valid" -or [string]$evidence.qualification_status -ne "PASS") {
         Fail "production evidence omitted a mandatory updater or qualification result"
     }
+    $instRec = $recordsByName[(Get-ExpectedInstallerName)]
+    $sigRec = $recordsByName["$((Get-ExpectedInstallerName)).sig"]
+    $instSourceName = if ($null -ne $instRec.PSObject.Properties['source_name']) { [string]$instRec.source_name } else { [string]$instRec.name }
+    $sigSourceName = if ($null -ne $sigRec.PSObject.Properties['source_name']) { [string]$sigRec.source_name } else { [string]$sigRec.name }
+
     if ([string]$evidence.installer -ne (Get-ExpectedInstallerName) -or
         [string]$evidence.updater_signature -ne "$(Get-ExpectedInstallerName).sig" -or
         [string]$evidence.authenticode_evidence -ne $authenticodeEvidenceName -or
         [string]$evidence.sbom -ne $sbomName -or
-        [string]$evidence.installer -ne [string]$recordsByName[(Get-ExpectedInstallerName)].name -or
-        [int64]$evidence.installer_size -ne [int64]$recordsByName[(Get-ExpectedInstallerName)].size -or
-        [string]$evidence.installer_sha256 -ne [string]$recordsByName[(Get-ExpectedInstallerName)].sha256 -or
-        [int64]$evidence.signature_size -ne [int64]$recordsByName["$((Get-ExpectedInstallerName)).sig"].size -or
-        [string]$evidence.updater_signature_sha256 -ne [string]$recordsByName["$((Get-ExpectedInstallerName)).sig"].sha256 -or
+        [string]$evidence.installer -ne $instSourceName -or
+        [int64]$evidence.installer_size -ne [int64]$instRec.size -or
+        [string]$evidence.installer_sha256 -ne [string]$instRec.sha256 -or
+        [int64]$evidence.signature_size -ne [int64]$sigRec.size -or
+        [string]$evidence.updater_signature_sha256 -ne [string]$sigRec.sha256 -or
         [string]$evidence.authenticode_evidence_sha256 -ne [string]$recordsByName[$authenticodeEvidenceName].sha256 -or
         [string]$evidence.sbom_sha256 -ne [string]$recordsByName[$sbomName].sha256) {
         Fail "production evidence digests or sizes do not match the candidate manifest"
     }
     if ([string]$qualification.installer -ne (Get-ExpectedInstallerName) -or
         [string]$qualification.updater_signature -ne "$(Get-ExpectedInstallerName).sig" -or
-        [string]$qualification.installer_sha256 -ne [string]$recordsByName[(Get-ExpectedInstallerName)].sha256 -or
-        [string]$qualification.updater_signature_sha256 -ne [string]$recordsByName["$((Get-ExpectedInstallerName)).sig"].sha256 -or
+        [string]$qualification.installer_sha256 -ne [string]$instRec.sha256 -or
+        [string]$qualification.updater_signature_sha256 -ne [string]$sigRec.sha256 -or
         [string]$qualification.authenticode_mode -ne "unsigned-zero-budget" -or
         [string]$qualification.sbom_sha256 -ne [string]$recordsByName[$sbomName].sha256) {
         Fail "qualification evidence does not bind the exact candidate manifest"
@@ -374,6 +392,14 @@ function Invoke-BuildCandidate {
     }
 
     $records = @(Get-CandidateRecords | ForEach-Object { Get-FileRecord $_ })
+    $authorityNames = @{}
+    foreach ($record in $records) {
+        $authName = [string]$record.authority_name
+        if ($authorityNames.ContainsKey($authName)) {
+            Fail "authority asset name collision detected: '$authName' from source '$($record.source_name)' and '$($authorityNames[$authName])'"
+        }
+        $authorityNames[$authName] = [string]$record.source_name
+    }
     Assert-CandidateEvidence $records
     $manifest = [ordered]@{
         schema_version = 1
@@ -430,20 +456,22 @@ function Invoke-CreateDraft {
     }
 
     foreach ($record in $manifest.assets) {
-        $candidate = (Get-CandidateRecords | Where-Object { $_.name -eq [string]$record.name })
-        if ($null -eq $candidate) { Fail "candidate manifest contains an unknown asset" }
+        $sourceName = if ($null -ne $record.PSObject.Properties['source_name']) { [string]$record.source_name } else { [string]$record.name }
+        $authorityName = if ($null -ne $record.PSObject.Properties['authority_name']) { [string]$record.authority_name } else { Get-V4SafeAuthorityAssetName $sourceName }
+        $candidate = (Get-CandidateRecords | Where-Object { $_.name -eq $sourceName })
+        if ($null -eq $candidate) { Fail "candidate manifest contains an unknown asset: $sourceName" }
         # GitHub's release-specific upload_url is deliberately used here. The
         # endpoint rejects duplicate names; this path never deletes or
         # replaces an asset after a failed upload.
         $uploaded = Invoke-V4ReleaseAuthorityAssetUpload `
             -UploadUrl $uploadUrl `
-            -AssetName ([string]$record.name) `
+            -AssetName $authorityName `
             -FilePath ([string]$candidate.path) `
             -Token (Get-AuthorityToken)
-        if ([string]$uploaded.name -ne [string]$record.name -or
+        if ([string]$uploaded.name -ne $authorityName -or
             [int64]$uploaded.size -ne [int64]$record.size -or
             [string]$uploaded.state -ne "uploaded") {
-            Fail "authority upload did not return the exact uploaded asset: $($record.name)"
+            Fail "authority upload did not return the exact uploaded asset: $authorityName"
         }
     }
     $state = [ordered]@{
@@ -466,7 +494,9 @@ function Invoke-CreateDraft {
 
 function Assert-ExactAssetSet([object]$Release, [object[]]$Expected) {
     $actual = @($Release.assets | ForEach-Object { [string]$_.name } | Sort-Object)
-    $expectedNames = @($Expected | ForEach-Object { [string]$_.name } | Sort-Object)
+    $expectedNames = @($Expected | ForEach-Object {
+        if ($null -ne $_.PSObject.Properties['authority_name']) { [string]$_.authority_name } else { [string]$_.name }
+    } | Sort-Object)
     if (($actual -join "`n") -ne ($expectedNames -join "`n")) { Fail "authority release asset set differs from the qualified candidate set" }
 }
 
@@ -486,14 +516,15 @@ function Invoke-DownloadDraft {
     if (Test-Path -LiteralPath $downloaded) { Remove-Item -LiteralPath $downloaded -Recurse -Force }
     New-Item -ItemType Directory -Path $downloaded -Force | Out-Null
     foreach ($expected in $state.assets) {
-        $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })
-        if ($asset.Count -ne 1) { Fail "expected authority asset is missing" }
-        $destination = Join-Path $downloaded ([IO.Path]::GetFileName([string]$expected.name))
+        $expectedAuthorityName = if ($null -ne $expected.PSObject.Properties['authority_name']) { [string]$expected.authority_name } else { [string]$expected.name }
+        $asset = @($release.assets | Where-Object { [string]$_.name -eq $expectedAuthorityName })
+        if ($asset.Count -ne 1) { Fail "expected authority asset is missing: $expectedAuthorityName" }
+        $destination = Join-Path $downloaded ([IO.Path]::GetFileName($expectedAuthorityName))
         Invoke-AuthorityApi -Arguments @("api", [string]$asset[0].url, "--header", "Accept: application/octet-stream") -BinaryOutput -OutputPath $destination
         $item = Get-Item -LiteralPath $destination
         $hash = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash.ToLowerInvariant()
         if ([int64]$item.Length -ne [int64]$expected.size -or $hash -ne [string]$expected.sha256) {
-            Fail "downloaded authority asset differs in size or SHA-256: $($expected.name)"
+            Fail "downloaded authority asset differs in size or SHA-256: $expectedAuthorityName"
         }
     }
     Write-JsonFile (Join-Path (Get-EffectiveStateRoot) "downloaded-manifest.json") ([ordered]@{
@@ -525,19 +556,22 @@ function Invoke-QualifyDownloaded {
     $bundle = Join-Path $root "downloaded-bundle"
     if (Test-Path -LiteralPath $bundle) { Remove-Item -LiteralPath $bundle -Recurse -Force }
     New-Item -ItemType Directory -Path $bundle -Force | Out-Null
-    $installer = Get-ExpectedInstallerName
-    Copy-Item -LiteralPath (Join-Path $downloaded $installer) -Destination (Join-Path $bundle $installer)
-    Copy-Item -LiteralPath (Join-Path $downloaded "$installer.sig") -Destination (Join-Path $bundle "$installer.sig")
+    $sourceInstaller = Get-ExpectedInstallerName
+    $sourceSignature = "$sourceInstaller.sig"
+    $authorityInstaller = Get-V4SafeAuthorityAssetName $sourceInstaller
+    $authoritySignature = Get-V4SafeAuthorityAssetName $sourceSignature
+    Copy-Item -LiteralPath (Join-Path $downloaded $authorityInstaller) -Destination (Join-Path $bundle $sourceInstaller)
+    Copy-Item -LiteralPath (Join-Path $downloaded $authoritySignature) -Destination (Join-Path $bundle $sourceSignature)
 
     Invoke-Checked "pwsh" @(
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", (Join-Path $PSScriptRoot "verify_v4_authenticode.ps1"),
-        "-Mode", "unsigned-zero-budget", "-Artifact", (Join-Path $downloaded $installer),
+        "-Mode", "unsigned-zero-budget", "-Artifact", (Join-Path $bundle $sourceInstaller),
         "-Evidence", (Join-Path $root "downloaded-authenticode-verification.json")
     ) "downloaded candidate Authenticode state is not unsigned-zero-budget"
     Invoke-Checked "cargo" @(
-        "xtask", "updater-trust", "verify-signature", "--installer", (Join-Path $downloaded $installer),
-        "--signature", (Join-Path $downloaded "$installer.sig")
+        "xtask", "updater-trust", "verify-signature", "--installer", (Join-Path $bundle $sourceInstaller),
+        "--signature", (Join-Path $bundle $sourceSignature)
     ) "downloaded candidate Tauri updater signature verification failed"
     Invoke-Checked "cargo" @(
         "xtask", "sbom", "verify", "--artifact-dir", $bundle, "--sbom", (Join-Path $downloaded $sbomName)
@@ -567,8 +601,8 @@ function Invoke-QualifyDownloaded {
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", (Join-Path $PSScriptRoot "ci_tauri_update_e2e.ps1"),
         "-BundleDir", $fixtureBundle,
-        "-CandidateInstallerPath", (Join-Path $downloaded $installer),
-        "-CandidateSignaturePath", (Join-Path $downloaded "$installer.sig"),
+        "-CandidateInstallerPath", (Join-Path $bundle $sourceInstaller),
+        "-CandidateSignaturePath", (Join-Path $bundle $sourceSignature),
         "-CandidateVersion", $Version,
         "-CandidatePublicKeyPath", $canonicalPublicKey
     ) "exact downloaded previous-v4 to candidate-v4 updater qualification failed"
@@ -581,11 +615,14 @@ function Invoke-QualifyDownloaded {
     Invoke-Checked "pwsh" @(
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", (Join-Path $PSScriptRoot "scan_v4_defender_exact.ps1"),
-        "-Artifact", (Join-Path $downloaded $installer),
+        "-Artifact", (Join-Path $bundle $sourceInstaller),
         "-Evidence", $defenderEvidencePath
     ) "exact downloaded installer Defender scan failed"
     $defenderEvidence = Read-JsonFile $defenderEvidencePath
-    $installerRecord = @($state.assets | Where-Object { [string]$_.name -eq $installer })
+    $installerRecord = @($state.assets | Where-Object {
+        [string]$_.name -eq $authorityInstaller -or
+        ($null -ne $_.PSObject.Properties['source_name'] -and [string]$_.source_name -eq $sourceInstaller)
+    })
     if (-not [bool]$defenderEvidence.scan_performed -or
         [string]$defenderEvidence.detection_result -ne "none" -or
         $installerRecord.Count -ne 1 -or
@@ -607,7 +644,7 @@ function Invoke-QualifyDownloaded {
     New-Item -ItemType Directory -Path $preservationRoot -Force | Out-Null
     [IO.File]::WriteAllText($preservationMarker, "external-user-data-marker`n", [Text.UTF8Encoding]::new($false))
     try {
-        $install = Start-Process -FilePath (Join-Path $downloaded $installer) -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
+        $install = Start-Process -FilePath (Join-Path $bundle $sourceInstaller) -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
         if ($install.ExitCode -ne 0) { Fail "downloaded candidate current-user installer failed" }
         if (-not (Test-Path -LiteralPath $app) -or -not (Test-Path -LiteralPath $uninstaller)) { Fail "downloaded candidate install omitted app or uninstaller" }
         $installedPe = @(Get-ChildItem -LiteralPath $installRoot -File -Recurse | Where-Object {
@@ -628,7 +665,7 @@ function Invoke-QualifyDownloaded {
         $uninstall = Start-Process -FilePath $uninstaller -ArgumentList @("/S") -WindowStyle Hidden -Wait -PassThru
         if ($uninstall.ExitCode -ne 0) { Fail "downloaded candidate uninstall failed" }
         if (-not (Test-Path -LiteralPath $preservationMarker -PathType Leaf)) { Fail "uninstall removed external app/user data" }
-        $reinstall = Start-Process -FilePath (Join-Path $downloaded $installer) -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
+        $reinstall = Start-Process -FilePath (Join-Path $bundle $sourceInstaller) -ArgumentList @("/S", "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
         if ($reinstall.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $app)) { Fail "downloaded candidate reinstall failed" }
         if (-not (Test-Path -LiteralPath $preservationMarker -PathType Leaf)) { Fail "reinstall did not preserve external app/user data" }
         $finalUninstall = Start-Process -FilePath (Join-Path $installRoot "uninstall.exe") -ArgumentList @("/S") -WindowStyle Hidden -Wait -PassThru
@@ -674,11 +711,12 @@ function Invoke-PublishDraft {
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "draft is missing or has changed before publication" }
     Assert-ExactAssetSet $release $state.assets
     foreach ($expected in $state.assets) {
-        $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })
-        if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "draft asset changed before publication" }
-        $downloadedPath = Join-Path (Get-EffectiveStateRoot) "downloaded/$($expected.name)"
+        $expectedAuthorityName = if ($null -ne $expected.PSObject.Properties['authority_name']) { [string]$expected.authority_name } else { [string]$expected.name }
+        $asset = @($release.assets | Where-Object { [string]$_.name -eq $expectedAuthorityName })
+        if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "draft asset changed before publication: $expectedAuthorityName" }
+        $downloadedPath = Join-Path (Get-EffectiveStateRoot) "downloaded/$expectedAuthorityName"
         $downloadedHash = (Get-FileHash -LiteralPath $downloadedPath -Algorithm SHA256).Hash.ToLowerInvariant()
-        if ($downloadedHash -ne [string]$expected.sha256) { Fail "qualified downloaded digest changed before publication" }
+        if ($downloadedHash -ne [string]$expected.sha256) { Fail "qualified downloaded digest changed before publication: $expectedAuthorityName" }
     }
     $patchPath = Join-Path (Get-EffectiveStateRoot) "publish-release.json"
     Write-JsonFile $patchPath ([ordered]@{ draft = $false })
@@ -718,8 +756,11 @@ function Invoke-PromoteMetadata {
     if (-not (Test-Path -LiteralPath (Join-Path $authorityCheckout ".git") -PathType Container)) { Fail "authority checkout main was not obtained" }
     $metadata = Join-Path $root "latest.json"
     $notesPath = Assert-ReleaseNotes
-    $signature = Join-Path $downloaded "$((Get-ExpectedInstallerName)).sig"
-    $assetUrl = "https://github.com/$authorityRepository/releases/download/$Tag/$((Get-ExpectedInstallerName).Replace(' ', '%20'))"
+    $sourceInstaller = Get-ExpectedInstallerName
+    $authorityInstaller = Get-V4SafeAuthorityAssetName $sourceInstaller
+    $authoritySignature = Get-V4SafeAuthorityAssetName "$sourceInstaller.sig"
+    $signature = Join-Path $downloaded $authoritySignature
+    $assetUrl = "https://github.com/$authorityRepository/releases/download/$Tag/$authorityInstaller"
     Invoke-Checked "cargo" @(
         "xtask", "release-authority", "generate", "--channel", $Channel, "--version", $Version,
         "--notes-file", $notesPath, "--pub-date", $PublicationDateUtc, "--platform", "windows-x86_64",
@@ -758,12 +799,13 @@ function Invoke-FinalVerify {
     Assert-ImmutableRelease $release
     Assert-ExactAssetSet $release $state.assets
     foreach ($expected in $state.assets) {
-        $asset = @($release.assets | Where-Object { [string]$_.name -eq [string]$expected.name })
-        if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "final public asset identity changed" }
-        $finalPath = Join-Path (Get-EffectiveStateRoot) "final-$($expected.name)"
+        $expectedAuthorityName = if ($null -ne $expected.PSObject.Properties['authority_name']) { [string]$expected.authority_name } else { [string]$expected.name }
+        $asset = @($release.assets | Where-Object { [string]$_.name -eq $expectedAuthorityName })
+        if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "final public asset identity changed: $expectedAuthorityName" }
+        $finalPath = Join-Path (Get-EffectiveStateRoot) "final-$expectedAuthorityName"
         Invoke-AuthorityApi -Arguments @("api", [string]$asset[0].url, "--header", "Accept: application/octet-stream") -BinaryOutput -OutputPath $finalPath
         $hash = (Get-FileHash -LiteralPath $finalPath -Algorithm SHA256).Hash.ToLowerInvariant()
-        if ($hash -ne [string]$expected.sha256) { Fail "final public asset digest differs from qualified bytes" }
+        if ($hash -ne [string]$expected.sha256) { Fail "final public asset digest differs from qualified bytes: $expectedAuthorityName" }
     }
     $metadataResponse = Invoke-AuthorityApi -Arguments @("api", "repos/$authorityRepository/contents/channels/$Channel/latest.json?ref=main")
     $metadataPath = Join-Path (Get-EffectiveStateRoot) "final-metadata.json"
@@ -771,11 +813,14 @@ function Invoke-FinalVerify {
     [IO.File]::WriteAllBytes($metadataPath, [Convert]::FromBase64String($metadataBase64))
     Invoke-Checked "cargo" @("xtask", "release-authority", "validate", "--channel", $Channel, "--metadata", $metadataPath) "final public metadata failed deterministic validation"
     $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
-    $expectedUrl = "https://github.com/$authorityRepository/releases/download/$Tag/$((Get-ExpectedInstallerName).Replace(' ', '%20'))"
+    $sourceInstaller = Get-ExpectedInstallerName
+    $authorityInstaller = Get-V4SafeAuthorityAssetName $sourceInstaller
+    $authoritySignature = Get-V4SafeAuthorityAssetName "$sourceInstaller.sig"
+    $expectedUrl = "https://github.com/$authorityRepository/releases/download/$Tag/$authorityInstaller"
     if ([string]$metadata.version -ne $Version -or [string]$metadata.platforms.'windows-x86_64'.url -ne $expectedUrl) {
         Fail "final metadata does not reference the exact immutable public asset"
     }
-    $finalSignature = Get-Content -LiteralPath (Join-Path (Get-EffectiveStateRoot) "final-$((Get-ExpectedInstallerName)).sig") -Raw
+    $finalSignature = Get-Content -LiteralPath (Join-Path (Get-EffectiveStateRoot) "final-$authoritySignature") -Raw
     $metadataSignature = [string]$metadata.platforms.'windows-x86_64'.signature
     if ($finalSignature.Trim() -ne $metadataSignature.Trim()) {
         Fail "final metadata signature does not match the exact public Tauri signature asset"


### PR DESCRIPTION
## Description

Resolves #147.

### Problem
In production release run #11 (`34082494988`), `BuildCandidate` passed and generated valid release candidate assets. However, `CreateDraft` uploaded `"Sky Auto Player_4.0.0-rc.1_x64-setup.exe"`, which GitHub Release Assets API normalized by replacing spaces with dots (`"Sky.Auto.Player_4.0.0-rc.1_x64-setup.exe"`). The fail-closed exact check `uploaded.name == manifest.name` failed. Authority draft `383828519` was created with the uploaded asset, consuming `v4.0.0-rc.1` per WO-07 policy.

### Solution
Cleanly separate source-qualified filename identity (`Sky Auto Player_...`) from release-authority filename identity (`Sky.Auto.Player_...`) across candidate manifest, draft upload/download, qualification staging, and metadata promotion:

1. **`scripts/v4_qualification_evidence.ps1`**:
   - Added `Get-V4SafeAuthorityAssetName` that deterministically maps spaces to dots (`$Name.Replace(' ', '.')`), validates against `^[A-Za-z0-9._-]+$`, and rejects path separators, leading `.` or `-`, reserved `.`/`..`, and invalid characters.

2. **`rust/xtask/src/release_authority.rs`**:
   - Added `canonical_authority_installer_name` (`canonical_installer_name(version).replace(' ', ".")`).
   - Updated `canonical_asset_url` to use `canonical_authority_installer_name` directly without URL percent-encoding.
   - Updated tests and validation checks.

3. **`scripts/v4_release_pipeline.ps1`**:
   - `Get-FileRecord`: Records `source_name`, `authority_name`, `role`, `size`, `sha256`, and sets `name = $authority_name`.
   - `Invoke-BuildCandidate`: Detects and fails closed on any `authority_name` collisions before writing `candidate-manifest.json`.
   - `Assert-EvidenceIdentity`: Strict-mode safe indexing and comparison by `source_name` and `authority_name`.
   - `Invoke-CreateDraft`: Uploads with `-AssetName $authorityName` and enforces `uploaded.name == $authorityName`, `uploaded.size == $record.size`, `uploaded.state == "uploaded"`.
   - `Assert-ExactAssetSet`: Compares exact authority names on GitHub releases.
   - `Invoke-DownloadDraft`: Downloads assets by `authority_name` and byte-verifies exact size and SHA-256.
   - `Invoke-QualifyDownloaded`: Stages downloaded authority files into temporary `$bundle` under their `source_name`, so SPDX SBOM, Tauri bundle verifier, Defender scan, and install smoke test verify against expected source filenames without byte mutation.
   - `Invoke-PublishDraft`, `Invoke-PromoteMetadata`, `Invoke-FinalVerify`: Reference exact public authority asset names.

4. **`scripts/promote_v4_metadata.ps1`**:
   - Dot-sources `v4_qualification_evidence.ps1`.
   - Uses `Get-V4SafeAuthorityAssetName` to check published release assets and canonical metadata URL while validating source qualification evidence.
   - Updated `Invoke-PromotionSelfTest`.

5. **`scripts/test_v4_release_authority_rehearsal.ps1`**:
   - Exercises a source artifact filename containing spaces, maps it via `Get-V4SafeAuthorityAssetName`, uploads using the safe authority name, and confirms exact upload/download identity.

6. **`scripts/test_v4_release_pipeline.ps1`**:
   - Added `Test-SafeAuthorityAssetNameContract` testing all 7 required points:
     1. Source installer name with spaces maps to deterministic safe authority name.
     2. Source and authority records keep identical SHA and size.
     3. Upload response exact-name matching remains mandatory.
     4. Unsafe name fails before CreateDraft.
     5. Authority-name collision fails before CreateDraft.
     6. Downloaded safe-name asset qualifies against source-name evidence without byte mutation.
     7. Authority rehearsal exercises space-containing filename and proves sending already-safe name.

### Policy Compliance
- Candidate version bump to `4.0.0-rc.2` is intentionally NOT in this PR (reserved for subsequent commit/PR after merge).
- Production remains on HOLD. No production dispatch until merged and authorized.
