### PR TITLE
chore(release): prepare v4.0.0-rc.2

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.1"
+version = "4.0.0-rc.2"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.0-rc.2.md
+++ b/docs/releases/v4.0.0-rc.2.md
@@ -1,0 +1,23 @@
+# Sky Auto Player v4.0.0-rc.2
+
+This release candidate is the second v4 beta-channel candidate prepared for
+qualification through the dedicated v4 release authority. It supersedes
+v4.0.0-rc.1, which was consumed during authority candidate qualification.
+
+## Distribution and updates
+
+- The canonical Windows distribution is the Tauri NSIS installer.
+- Updates use the official Tauri updater and its Ed25519 signature.
+- v4 release qualification binds the installer, updater signature, SBOM,
+  provenance, and exact source commit.
+- The project production signing policy is `unsigned-zero-budget`; Windows may
+  display Unknown Publisher or SmartScreen warnings because the shipped PE
+  files are Authenticode-unsigned. This does not bypass updater cryptographic
+  trust.
+
+## Qualification scope
+
+Before publication, the release pipeline must qualify the exact draft assets
+after re-download, including fresh current-user installation, update from the
+previous v4 candidate, install/uninstall behavior, external app-data
+preservation, and stable/beta namespace isolation.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.1"
+version = "4.0.0-rc.2"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",


### PR DESCRIPTION
## Summary

Prepares the version bump and release notes for **V4 RC2**, superseding the consumed RC1 release candidate per Issue #149.

- Bump \desktop/src-tauri/Cargo.toml\ package version to \4.0.0-rc.2\.
- Update \ust/Cargo.lock\ to reflect the matching version for \sky_desktop_shell\ (\4.0.0-rc.2\).
- Add \docs/releases/v4.0.0-rc.2.md\ detailing distribution, updates, and qualification scope for RC2 while noting it supersedes consumed RC1.

Refs #149