### PR TITLE
fix(release): align updater fixture with production topology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,22 +542,16 @@ jobs:
       - name: Exercise non-production updater key rotation fixture
         run: pwsh scripts/test_v4_updater_key_rotation.ps1
 
-      - name: Configure isolated updater fixture target
-        run: |
-          $fixtureTarget = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-updater-fixture-target"
-          New-Item -ItemType Directory -Path $fixtureTarget -Force | Out-Null
-          "CARGO_TARGET_DIR=$fixtureTarget" | Add-Content $env:GITHUB_ENV -Encoding UTF8
-
       - name: Build throwaway signed fixture and qualify packaged Tauri updater rotation
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
         run: |
-          $fixtureTarget = $env:CARGO_TARGET_DIR
-          $fixtureBundle = Join-Path $fixtureTarget "dist/bundle/nsis"
+          $fixtureTarget = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-updater-fixture-target"
+          New-Item -ItemType Directory -Path $fixtureTarget -Force | Out-Null
           # Packaged Tauri updater rotation: ci_tauri_update_e2e.ps1 sets SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS
           # separately for the bridge [old,new] and cutover [new] tauri-update-fixture builds.
           # Its generated configs alone enable dangerousInsecureTransportProtocol on loopback.
-          pwsh scripts/ci_tauri_update_e2e.ps1 -BundleDir $fixtureBundle
+          pwsh scripts/ci_tauri_update_e2e.ps1 -FixtureTargetDir $fixtureTarget
 
       - name: Clean up ephemeral Authenticode test certificate
         if: always()

--- a/.github/workflows/rehearse-v4-production-topology.yml
+++ b/.github/workflows/rehearse-v4-production-topology.yml
@@ -1,0 +1,94 @@
+name: V4 Production Topology Rehearsal
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Canonical v4 SemVer of the candidate to rehearse"
+        required: true
+        type: string
+      channel:
+        description: "v4 metadata channel"
+        required: true
+        type: choice
+        options: [stable, beta]
+      tag:
+        description: "Candidate tag; must be exactly v<version>"
+        required: true
+        type: string
+      source_sha:
+        description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
+        required: true
+        type: string
+      updater_private_key_path:
+        description: "Path to the externally stored updater key on the dedicated runner"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-production-topology-rehearsal-${{ inputs.source_sha }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  rehearsal:
+    name: V4 production-topology rehearsal
+    # This is the same dedicated/single-tenant runner class used by production.
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+    env:
+      V4_REHEARSAL_VERSION: ${{ inputs.version }}
+      V4_REHEARSAL_CHANNEL: ${{ inputs.channel }}
+      V4_REHEARSAL_TAG: ${{ inputs.tag }}
+      V4_REHEARSAL_SOURCE_SHA: ${{ inputs.source_sha }}
+      V4_REHEARSAL_WORKFLOW_SHA: ${{ github.sha }}
+
+    steps:
+      - name: Initialize isolated rehearsal state roots
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { throw "RUNNER_TEMP is unavailable" }
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { throw "GITHUB_RUN_ID is unavailable" }
+          $base = Join-Path $env:RUNNER_TEMP ("sky-v4-production-topology-rehearsal-" + $env:GITHUB_RUN_ID)
+          "V4_REHEARSAL_STATE_ROOT=$base\candidate" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "V4_REHEARSAL_QUALIFICATION_STATE_ROOT=$base\qualification" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Check out the exact requested source SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify dedicated runner tools
+        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
+
+      - name: Build one non-production candidate with the production builder
+        env:
+          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State BuildCandidate `
+            -Version $env:V4_REHEARSAL_VERSION `
+            -Channel $env:V4_REHEARSAL_CHANNEL `
+            -Tag $env:V4_REHEARSAL_TAG `
+            -SourceSha $env:V4_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_REHEARSAL_STATE_ROOT `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
+
+      - name: Execute exact production QualifyDownloaded topology
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_production_topology_rehearsal.ps1 `
+            -CandidateStateRoot $env:V4_REHEARSAL_STATE_ROOT `
+            -StateRoot $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT `
+            -Version $env:V4_REHEARSAL_VERSION `
+            -Channel $env:V4_REHEARSAL_CHANNEL `
+            -Tag $env:V4_REHEARSAL_TAG `
+            -SourceSha $env:V4_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_REHEARSAL_WORKFLOW_SHA `
+            -KeepStateOnFailure

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -20,6 +20,10 @@ on:
         description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
         required: true
         type: string
+      updater_private_key_path:
+        description: "Path to the externally stored updater key on the dedicated runner"
+        required: true
+        type: string
       release_notes_path:
         description: "Bounded release notes file in the checked-out source"
         required: true
@@ -103,6 +107,8 @@ jobs:
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
 
       - name: Build and qualify the single production candidate
+        env:
+          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
         run: |
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
             -State BuildCandidate `
@@ -111,7 +117,8 @@ jobs:
             -Tag $env:V4_RELEASE_TAG `
             -SourceSha $env:V4_RELEASE_SOURCE_SHA `
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
-            -StateRoot $env:V4_RELEASE_STATE_ROOT
+            -StateRoot $env:V4_RELEASE_STATE_ROOT `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
 
       - name: Create exact candidate draft in release authority
         env:

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -20,10 +20,6 @@ on:
         description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
         required: true
         type: string
-      updater_private_key_path:
-        description: "Path to the externally stored updater key on the dedicated runner"
-        required: true
-        type: string
       release_notes_path:
         description: "Bounded release notes file in the checked-out source"
         required: true
@@ -107,8 +103,6 @@ jobs:
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
 
       - name: Build and qualify the single production candidate
-        env:
-          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
         run: |
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
             -State BuildCandidate `
@@ -117,8 +111,7 @@ jobs:
             -Tag $env:V4_RELEASE_TAG `
             -SourceSha $env:V4_RELEASE_SOURCE_SHA `
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
-            -StateRoot $env:V4_RELEASE_STATE_ROOT `
-            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
 
       - name: Create exact candidate draft in release authority
         env:

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -27,6 +27,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=SKY_NATIVE_DIRTY_WORKTREE");
     println!("cargo:rerun-if-env-changed=SKY_NATIVE_SOURCE_FINGERPRINT");
     println!("cargo:rerun-if-env-changed=SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS");
+    println!("cargo:rerun-if-env-changed=SKY_TAURI_UPDATE_FIXTURE_PORT");
     let head = std::env::var("GITHUB_SHA")
         .ok()
         .or_else(|| std::env::var("SKY_NATIVE_BUILD_COMMIT").ok())
@@ -46,6 +47,15 @@ fn main() {
     println!("cargo:rustc-env=SKY_NATIVE_DIRTY_WORKTREE={dirty}");
     println!("cargo:rustc-env=SKY_NATIVE_SOURCE_FINGERPRINT={source_fingerprint}");
     println!("cargo:rustc-env=SKY_RUSTC_VERSION={rustc_version}");
+    if std::env::var_os("CARGO_FEATURE_TAURI_UPDATE_FIXTURE").is_some() {
+        let port = std::env::var("SKY_TAURI_UPDATE_FIXTURE_PORT").unwrap_or_else(|_| {
+            panic!("SKY_TAURI_UPDATE_FIXTURE_PORT must be set for the updater fixture")
+        });
+        if port.parse::<u16>().ok().filter(|port| *port != 0).is_none() {
+            panic!("SKY_TAURI_UPDATE_FIXTURE_PORT must be a non-zero TCP port");
+        }
+        println!("cargo:rustc-env=SKY_TAURI_UPDATE_FIXTURE_PORT={port}");
+    }
     if std::env::var_os("CARGO_FEATURE_TAURI_UPDATE_FIXTURE").is_some()
         && let Ok(keys) = std::env::var("SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS")
     {

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -48,10 +48,11 @@ fn main() {
     println!("cargo:rustc-env=SKY_NATIVE_SOURCE_FINGERPRINT={source_fingerprint}");
     println!("cargo:rustc-env=SKY_RUSTC_VERSION={rustc_version}");
     if std::env::var_os("CARGO_FEATURE_TAURI_UPDATE_FIXTURE").is_some() {
-        let port = std::env::var("SKY_TAURI_UPDATE_FIXTURE_PORT").unwrap_or_else(|_| {
-            panic!("SKY_TAURI_UPDATE_FIXTURE_PORT must be set for the updater fixture")
-        });
-        if port.parse::<u16>().ok().filter(|port| *port != 0).is_none() {
+        let port = std::env::var("SKY_TAURI_UPDATE_FIXTURE_PORT")
+            .unwrap_or_else(|_| "invalid-fixture-port".to_owned());
+        if port != "invalid-fixture-port"
+            && port.parse::<u16>().ok().filter(|port| *port != 0).is_none()
+        {
             panic!("SKY_TAURI_UPDATE_FIXTURE_PORT must be a non-zero TCP port");
         }
         println!("cargo:rustc-env=SKY_TAURI_UPDATE_FIXTURE_PORT={port}");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -98,6 +98,20 @@ pub fn run_gui_smoke() {
 /// candidate-v4 workflow. The entry point is hidden from the product UI and
 /// exists only for deterministic packaged qualification.
 pub fn run_update_smoke() {
+    let update_marker = update_smoke_marker("--selftest-update-marker");
+    let expected_version_file = update_smoke_marker("--selftest-update-expected-version-file");
+    if let (Some(marker), Some(expected_path)) = (update_marker.as_ref(), expected_version_file) {
+        if let Ok(expected_version) = std::fs::read_to_string(expected_path) {
+            let expected_version = expected_version.trim();
+            if expected_version == env!("CARGO_PKG_VERSION") {
+                let _ = std::fs::write(
+                    marker,
+                    format!("update-complete:{}\n", env!("CARGO_PKG_VERSION")),
+                );
+                return;
+            }
+        }
+    }
     run_inner(false, true);
 }
 
@@ -129,6 +143,7 @@ pub fn selftest_update_install_rejection_during_playback() -> i32 {
 fn run_inner(gui_smoke: bool, update_smoke: bool) {
     let update_marker = update_smoke_marker("--selftest-update-marker");
     let update_safety_marker = update_smoke_marker("--selftest-update-safety-marker");
+    let expected_version_file = update_smoke_marker("--selftest-update-expected-version-file");
     if let Some(path) = update_safety_marker {
         let _ = UPDATE_SAFETY_LOG.set(path);
     }
@@ -177,6 +192,15 @@ fn run_inner(gui_smoke: bool, update_smoke: bool) {
                         )
                         .map_err(|error| format!("packaged update check response: {error}"))?;
                         if let Some(target) = check.available_version {
+                            if let Some(expected_path) = expected_version_file.as_ref() {
+                                std::fs::write(expected_path, format!("{target}\n")).map_err(
+                                    |error| {
+                                        format!(
+                                            "packaged update expected-version handoff failed: {error}"
+                                        )
+                                    },
+                                )?;
+                            }
                             let _: commands::UpdateHandoffDto =
                                 serde_json::from_value(native.dispatch(
                                     "update.begin_handoff",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -100,16 +100,16 @@ pub fn run_gui_smoke() {
 pub fn run_update_smoke() {
     let update_marker = update_smoke_marker("--selftest-update-marker");
     let expected_version_file = update_smoke_marker("--selftest-update-expected-version-file");
-    if let (Some(marker), Some(expected_path)) = (update_marker.as_ref(), expected_version_file) {
-        if let Ok(expected_version) = std::fs::read_to_string(expected_path) {
-            let expected_version = expected_version.trim();
-            if expected_version == env!("CARGO_PKG_VERSION") {
-                let _ = std::fs::write(
-                    marker,
-                    format!("update-complete:{}\n", env!("CARGO_PKG_VERSION")),
-                );
-                return;
-            }
+    if let (Some(marker), Some(expected_path)) = (update_marker.as_ref(), expected_version_file)
+        && let Ok(expected_version) = std::fs::read_to_string(expected_path)
+    {
+        let expected_version = expected_version.trim();
+        if expected_version == env!("CARGO_PKG_VERSION") {
+            let _ = std::fs::write(
+                marker,
+                format!("update-complete:{}\n", env!("CARGO_PKG_VERSION")),
+            );
+            return;
         }
     }
     run_inner(false, true);

--- a/desktop/src-tauri/src/native_update.rs
+++ b/desktop/src-tauri/src/native_update.rs
@@ -638,6 +638,37 @@ mod tests {
     }
 
     #[test]
+    fn production_fixture_manifest_is_tauri_consumable() {
+        let manifest = serde_json::json!({
+            "version": "4.0.0-rc.2",
+            "notes": "Deterministic bridge rotation candidate.",
+            "pub_date": "2026-09-04T00:00:00Z",
+            "platforms": {
+                "windows-x86_64": {
+                    "signature": "fixture-signature",
+                    "url": "http://127.0.0.1:40000/candidate/update.exe"
+                }
+            }
+        });
+        let release: tauri_plugin_updater::RemoteRelease =
+            serde_json::from_value(manifest).expect("fixture manifest must match Tauri schema");
+        assert_eq!(release.version.to_string(), "4.0.0-rc.2");
+        assert_eq!(
+            release
+                .download_url("windows-x86_64")
+                .expect("production platform must be present")
+                .as_str(),
+            "http://127.0.0.1:40000/candidate/update.exe"
+        );
+        assert_eq!(
+            release
+                .signature("windows-x86_64")
+                .expect("production signature must be present"),
+            "fixture-signature"
+        );
+    }
+
+    #[test]
     fn update_installation_has_a_distinct_playback_policy_error() {
         let message = update_activity_error(ActivityReservationError::PhysicalPlaybackActive);
         assert_eq!(

--- a/desktop/src-tauri/src/native_update.rs
+++ b/desktop/src-tauri/src/native_update.rs
@@ -34,6 +34,10 @@ const V4_TAURI_UPDATER_PUBLIC_KEYS: &[&str] = &[V4_TAURI_UPDATER_PUBLIC_KEY];
 #[cfg(feature = "tauri-update-fixture")]
 const FIXTURE_TAURI_UPDATER_PUBLIC_KEYS: Option<&str> =
     option_env!("SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS");
+const FIXTURE_TAURI_UPDATER_PORT: &str = match option_env!("SKY_TAURI_UPDATE_FIXTURE_PORT") {
+    Some(port) => port,
+    None => "invalid-fixture-port",
+};
 
 #[derive(Clone, Debug)]
 pub(crate) struct NativeUpdateCandidate {
@@ -460,8 +464,10 @@ fn first_verified_download<T>(
 fn authority_endpoint(channel: UpdateChannel) -> Result<Url, String> {
     let endpoint = if cfg!(feature = "tauri-update-fixture") {
         match channel {
-            UpdateChannel::Stable => "http://127.0.0.1:17845/stable",
-            UpdateChannel::Beta => "http://127.0.0.1:17845/beta",
+            UpdateChannel::Stable => {
+                format!("http://127.0.0.1:{FIXTURE_TAURI_UPDATER_PORT}/stable")
+            }
+            UpdateChannel::Beta => format!("http://127.0.0.1:{FIXTURE_TAURI_UPDATER_PORT}/beta"),
         }
     } else {
         let endpoint = match channel {
@@ -471,9 +477,9 @@ fn authority_endpoint(channel: UpdateChannel) -> Result<Url, String> {
         if !endpoint.contains(V4_RELEASE_AUTHORITY_REPOSITORY) {
             return Err("v4 authority URL is outside the dedicated release repository".into());
         }
-        endpoint
+        endpoint.to_owned()
     };
-    Url::parse(endpoint).map_err(|error| {
+    Url::parse(&endpoint).map_err(|error| {
         if cfg!(feature = "tauri-update-fixture") {
             format!("fixture authority URL invalid: {error}")
         } else {

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -284,8 +284,10 @@ Step 8: Evidence Emission & Self-Validation
 ### 3.3 Dedicated v4 release state machine
 
 The manual production entry point is `.github/workflows/release-v4.yml`. It
-accepts an explicit version, channel, `v<version>` tag, source SHA, external
-updater-key path, notes path, and UTC publication timestamp. The workflow
+accepts an explicit version, channel, `v<version>` tag, source SHA, notes path,
+and UTC publication timestamp. The dedicated runner supplies the external key
+path through its runner-local `V4_UPDATER_PRIVATE_KEY_PATH` process environment;
+the path is not a workflow-dispatch input. The workflow
 requires the checked-out commit and workflow SHA to equal the requested source
 SHA, then executes these fail-closed states:
 
@@ -310,6 +312,20 @@ runs at this post-download boundary: a throwaway previous-v4 bridge consumes
 the exact downloaded installer and `.sig`, while the production candidate is
 never rebuilt. The packaged candidate also proves that update admission is
 rejected while playback is active.
+
+Before creating a new RC, the exact production qualification topology can be
+rehearsed without creating a release-authority draft:
+
+```powershell
+pwsh scripts/test_v4_production_topology_rehearsal.ps1 -CandidateStateRoot $candidateStateRoot -StateRoot (Join-Path $env:RUNNER_TEMP "sky-v4-production-topology-rehearsal") -Version $version -Channel $channel -Tag "v$version" -SourceSha $sourceSha -WorkflowSha $sourceSha
+```
+
+The rehearsal stages the already-qualified candidate bytes under the same
+`downloaded` state layout and invokes
+`v4_release_pipeline.ps1 -State QualifyDownloaded` with the production
+identity parameters. Its throwaway updater bridge builds into a separate
+`FixtureTargetDir\dist\bundle\nsis`; it never searches for a downloaded
+candidate inside that build output.
 
 The same post-download qualification invokes a bounded Windows Defender
 custom scan against the exact downloaded installer and records the artifact

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -285,9 +285,7 @@ Step 8: Evidence Emission & Self-Validation
 
 The manual production entry point is `.github/workflows/release-v4.yml`. It
 accepts an explicit version, channel, `v<version>` tag, source SHA, notes path,
-and UTC publication timestamp. The dedicated runner supplies the external key
-path through its runner-local `V4_UPDATER_PRIVATE_KEY_PATH` process environment;
-the path is not a workflow-dispatch input. The workflow
+external updater-key path, and UTC publication timestamp. The workflow
 requires the checked-out commit and workflow SHA to equal the requested source
 SHA, then executes these fail-closed states:
 
@@ -314,7 +312,12 @@ never rebuilt. The packaged candidate also proves that update admission is
 rejected while playback is active.
 
 Before creating a new RC, the exact production qualification topology can be
-rehearsed without creating a release-authority draft:
+rehearsed without creating a release-authority draft. The manual workflow
+`.github/workflows/rehearse-v4-production-topology.yml` must be dispatched from
+the ref containing the exact requested source SHA. It uses the same dedicated
+runner labels and explicit updater-key path as production, builds one candidate,
+then runs the script below. It has no release-authority token and no authority
+mutation state.
 
 ```powershell
 pwsh scripts/test_v4_production_topology_rehearsal.ps1 -CandidateStateRoot $candidateStateRoot -StateRoot (Join-Path $env:RUNNER_TEMP "sky-v4-production-topology-rehearsal") -Version $version -Channel $channel -Tag "v$version" -SourceSha $sourceSha -WorkflowSha $sourceSha

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -189,8 +189,9 @@ and publishing a new version; existing artifact bytes are never repaired in
 place.
 
 The isolated CI updater qualification runs
-`scripts/ci_tauri_update_e2e.ps1`. It serves the signed candidate from a
-loopback fixture, installs the previous v4 package, and verifies the official
+`scripts/ci_tauri_update_e2e.ps1 -FixtureTargetDir <runner-temp-target>`. The
+script owns the fixture `CARGO_TARGET_DIR` for each throwaway build and serves
+the signed candidate from a loopback fixture, installs the previous v4 package, and verifies the official
 Tauri updater reaches the candidate version after restart. It also verifies
 the bridge `[old,new]` to cutover `[new]` trust transition against real
 packaged clients. The same evidence records the ordered native quiesce,

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -258,5 +258,6 @@ Rotation procedures are validated automatically using:
 
 ```powershell
 pwsh scripts/test_v4_updater_key_rotation.ps1
-pwsh scripts/ci_tauri_update_e2e.ps1 -BundleDir rust/target/dist/bundle/nsis
+$fixtureTarget = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-updater-fixture-target"
+pwsh scripts/ci_tauri_update_e2e.ps1 -FixtureTargetDir $fixtureTarget
 ```

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -742,11 +742,10 @@ fn packaged_ci_contract_source(source: &str) -> Result<()> {
     }
     for marker in [
         "name: Packaged v4 updater fixture qualification",
-        "CARGO_TARGET_DIR",
         "tauri-update-fixture",
         "dangerousInsecureTransportProtocol",
         "scripts/ci_tauri_update_e2e.ps1",
-        "-BundleDir",
+        "FixtureTargetDir",
         "RUNNER_TEMP",
     ] {
         if !fixture.contains(marker) {
@@ -3231,13 +3230,10 @@ class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$Upl
   updater_e2e:
     name: Packaged v4 updater fixture qualification
     needs: [changes, static, release_authority, supply_chain, validate]
-    env:
-      RUNNER_TEMP: runner-temp
-      CARGO_TARGET_DIR: runner-temp
     steps:
       - run: dangerousInsecureTransportProtocol = true
       - run: bun run tauri build --features tauri-update-fixture
-      - run: pwsh scripts/ci_tauri_update_e2e.ps1 -BundleDir runner-temp
+      - run: $fixtureTarget = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-updater-fixture-target"; pwsh scripts/ci_tauri_update_e2e.ps1 -FixtureTargetDir $fixtureTarget
   packaged:
     name: Packaged v4 Tauri NSIS qualification
     needs: [changes, static, release_authority, supply_chain, validate]

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -450,6 +450,9 @@ fn v4_release_pipeline_contract_source(
         "attestations: write",
         "V4_RELEASE_AUTHORITY_TOKEN",
         "ref: ${{ inputs.source_sha }}",
+        "updater_private_key_path:",
+        "inputs.updater_private_key_path",
+        "-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH",
         "persist-credentials: false",
         "actions/attest@",
         "actions/upload-artifact@",
@@ -595,10 +598,12 @@ fn v4_release_pipeline_contract_source(
 
 fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     let workflow_path = root.join(".github/workflows/release-v4.yml");
+    let topology_workflow_path = root.join(".github/workflows/rehearse-v4-production-topology.yml");
     let pipeline_path = root.join("scripts/v4_release_pipeline.ps1");
     let regression_path = root.join("scripts/test_v4_release_pipeline.ps1");
     let pipeline = fs::read_to_string(&pipeline_path)?;
     let regression = fs::read_to_string(&regression_path)?;
+    let topology_workflow = fs::read_to_string(&topology_workflow_path)?;
     v4_release_pipeline_contract_source(
         &fs::read_to_string(&workflow_path)?,
         &pipeline,
@@ -607,6 +612,43 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     .map_err(|error| -> Box<dyn std::error::Error + Send + Sync> {
         format!("v4 release pipeline contract: {error}").into()
     })?;
+    for marker in [
+        "name: V4 Production Topology Rehearsal",
+        "workflow_dispatch:",
+        "runs-on: [self-hosted, windows, v4-release, single-tenant]",
+        "ref: ${{ inputs.source_sha }}",
+        "persist-credentials: false",
+        "updater_private_key_path:",
+        "BuildCandidate",
+        "test_v4_production_topology_rehearsal.ps1",
+        "-CandidateStateRoot $env:V4_REHEARSAL_STATE_ROOT",
+        "-StateRoot $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT",
+        "-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH",
+    ] {
+        if !topology_workflow.contains(marker) {
+            return Err(format!(
+                "production-topology rehearsal workflow is missing its required marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "V4_RELEASE_AUTHORITY_TOKEN",
+        "ValidateAuthority",
+        "CreateDraft",
+        "PublishDraft",
+        "PromoteMetadata",
+        "FinalVerify",
+        "gh release",
+        "softprops/action-gh-release",
+    ] {
+        if topology_workflow.contains(forbidden) {
+            return Err(format!(
+                "production-topology rehearsal workflow contains an authority mutation marker: {forbidden}"
+            )
+            .into());
+        }
+    }
     for script_name in [
         "scripts/v4_updater_credential_broker.ps1",
         "scripts/set_v4_updater_session_credential.ps1",
@@ -3170,6 +3212,9 @@ jobs:
   release:
     runs-on: [self-hosted, windows, v4-release, single-tenant]
     ref: ${{ inputs.source_sha }}
+    updater_private_key_path:
+    inputs.updater_private_key_path
+    -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
     persist-credentials: false
     env: V4_RELEASE_AUTHORITY_TOKEN
     -State ValidateRequest

--- a/scripts/ci_tauri_update_e2e.ps1
+++ b/scripts/ci_tauri_update_e2e.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)]
-  [string]$BundleDir,
+  [string]$FixtureTargetDir,
   [string]$CandidateInstallerPath,
   [string]$CandidateSignaturePath,
   [string]$CandidateVersion,
@@ -58,7 +58,7 @@ if ((Convert-FixtureCargoVersion -Source $syntheticCargo -Version $previousVersi
 & (Join-Path $PSScriptRoot 'test_v4_updater_fixture_server.ps1')
 
 
-$invokeArgs = @{ BundleDir = $BundleDir }
+$invokeArgs = @{ FixtureTargetDir = $FixtureTargetDir }
 foreach ($name in @('CandidateInstallerPath', 'CandidateSignaturePath', 'CandidateVersion', 'CandidatePublicKeyPath')) {
   if ($PSBoundParameters.ContainsKey($name)) {
     $invokeArgs[$name] = Get-Variable -Name $name -ValueOnly

--- a/scripts/ci_tauri_update_e2e.ps1
+++ b/scripts/ci_tauri_update_e2e.ps1
@@ -6,6 +6,7 @@ param(
   [string]$CandidateSignaturePath,
   [string]$CandidateVersion,
   [string]$CandidatePublicKeyPath,
+  [string]$EvidencePath,
   [switch]$KeepFixtureOnFailure
 )
 
@@ -63,6 +64,9 @@ foreach ($name in @('CandidateInstallerPath', 'CandidateSignaturePath', 'Candida
   if ($PSBoundParameters.ContainsKey($name)) {
     $invokeArgs[$name] = Get-Variable -Name $name -ValueOnly
   }
+}
+if ($PSBoundParameters.ContainsKey('EvidencePath')) {
+  $invokeArgs['EvidencePath'] = $EvidencePath
 }
 if ($KeepFixtureOnFailure) {
   $invokeArgs['KeepFixtureOnFailure'] = $true

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
   [Parameter(Mandatory = $true)]
-  [string]$BundleDir,
+  [string]$FixtureTargetDir,
   [string]$CandidateInstallerPath,
   [string]$CandidateSignaturePath,
   [string]$CandidateVersion,
@@ -25,6 +25,13 @@ $summaryPath = if ([string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
   $env:GITHUB_STEP_SUMMARY
 }
 $fixtureRoot = Join-Path $runnerTemp ('sky-auto-player-tauri-update-' + [guid]::NewGuid().ToString('N'))
+$fixtureTargetRoot = [IO.Path]::GetFullPath($FixtureTargetDir)
+$repoPrefix = $repoRoot.TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+if ($fixtureTargetRoot.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) -or
+  $fixtureTargetRoot.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+  throw 'Updater fixture target directory must be outside the repository workspace'
+}
+$fixtureBundleRoot = Join-Path $fixtureTargetRoot 'dist/bundle/nsis'
 $installRoot = Join-Path $fixtureRoot 'installed'
 $markerPath = Join-Path $fixtureRoot 'completion.txt'
 $cutoverMarkerPath = Join-Path $fixtureRoot 'cutover.txt'
@@ -104,7 +111,9 @@ function Invoke-FixtureBuild {
   $env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS = $PublicRoots
   $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
   $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ''
+  $oldCargoTargetDir = [Environment]::GetEnvironmentVariable('CARGO_TARGET_DIR', 'Process')
   try {
+    [Environment]::SetEnvironmentVariable('CARGO_TARGET_DIR', $fixtureTargetRoot, 'Process')
     Push-Location $desktopRoot
     try {
       & bun run tauri build --ci --config $ConfigPath -- --profile dist --features tauri-update-fixture
@@ -113,6 +122,11 @@ function Invoke-FixtureBuild {
       Pop-Location
     }
   } finally {
+    if ($null -eq $oldCargoTargetDir) {
+      [Environment]::SetEnvironmentVariable('CARGO_TARGET_DIR', $null, 'Process')
+    } else {
+      [Environment]::SetEnvironmentVariable('CARGO_TARGET_DIR', $oldCargoTargetDir, 'Process')
+    }
     Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
     Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
     Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
@@ -121,8 +135,18 @@ function Invoke-FixtureBuild {
 
 try {
   New-Item -ItemType Directory -Path $fixtureRoot, $installRoot -Force | Out-Null
-  New-Item -ItemType Directory -Path $BundleDir -Force | Out-Null
-  $bundleRoot = (Resolve-Path -LiteralPath $BundleDir -ErrorAction Stop).Path
+  New-Item -ItemType Directory -Path $fixtureBundleRoot -Force | Out-Null
+  $fixtureBundleRoot = (Resolve-Path -LiteralPath $fixtureBundleRoot -ErrorAction Stop).Path
+
+  foreach ($candidatePath in @($CandidateInstallerPath, $CandidateSignaturePath)) {
+    if (-not [string]::IsNullOrWhiteSpace($candidatePath)) {
+      $resolvedCandidatePath = [IO.Path]::GetFullPath($candidatePath)
+      $fixturePrefix = $fixtureTargetRoot.TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+      if ($resolvedCandidatePath.StartsWith($fixturePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw 'Downloaded candidate paths must remain outside the throwaway fixture target directory'
+      }
+    }
+  }
 
   Push-Location $desktopRoot
   try {
@@ -155,7 +179,7 @@ try {
   # qualification the candidate below is the exact installer and signature
   # downloaded from the release draft; it is never rebuilt by this fixture.
   Invoke-FixtureBuild $bridgeConfigPath $oldKeyPath "$oldPublicKey|$newPublicKey"
-  $previousInstallers = @(Get-ChildItem -LiteralPath $bundleRoot -Filter '*4.0.0-alpha.1_x64-setup.exe' -File)
+  $previousInstallers = @(Get-ChildItem -LiteralPath $fixtureBundleRoot -Filter '*4.0.0-alpha.1_x64-setup.exe' -File)
   if ($previousInstallers.Count -ne 1) {
     throw "Expected exactly one bridge-v4 installer, found $($previousInstallers.Count)"
   }
@@ -181,7 +205,7 @@ try {
     [IO.File]::WriteAllText($lockPath, $lockCandidate, [Text.UTF8Encoding]::new($false))
     Invoke-FixtureBuild $cutoverConfigPath $newKeyPath $newPublicKey
 
-    $candidateArchives = @(Get-ChildItem -LiteralPath $bundleRoot -Filter "*${candidateVersion}*-setup.exe" -File)
+    $candidateArchives = @(Get-ChildItem -LiteralPath $fixtureBundleRoot -Filter ("*" + $candidateVersion + "*-setup.exe") -File)
     if ($candidateArchives.Count -ne 1) {
       throw "Expected exactly one new-root candidate installer, found $($candidateArchives.Count)"
     }

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -6,6 +6,7 @@ param(
   [string]$CandidateSignaturePath,
   [string]$CandidateVersion,
   [string]$CandidatePublicKeyPath,
+  [string]$EvidencePath,
   [switch]$KeepFixtureOnFailure
 )
 
@@ -62,7 +63,16 @@ if ($providedCandidate) {
 }
 $candidateVersion = if ($providedCandidate) { $CandidateVersion } else { '4.0.0-alpha.2' }
 $cutoverVersion = '4.0.0-alpha.3'
-$port = 17845
+$requestLogPath = Join-Path $fixtureRoot 'http-requests.jsonl'
+$httpEvidencePath = if ([string]::IsNullOrWhiteSpace($EvidencePath)) {
+  Join-Path $fixtureRoot 'fixture-http-evidence.json'
+} else {
+  [IO.Path]::GetFullPath($EvidencePath)
+}
+$manifestContract = [ordered]@{ status = 'not-checked' }
+$candidateContract = [ordered]@{ status = 'not-checked' }
+$fixtureStatus = 'FAIL'
+$port = 0
 $serverJob = $null
 $previousInstallerCopy = Join-Path $fixtureRoot 'previous-v4-setup.exe'
 $candidateArchive = $null
@@ -71,6 +81,114 @@ $candidateCargoPath = Join-Path $desktopRoot 'src-tauri/Cargo.toml'
 $lockPath = Join-Path $repoRoot 'rust/Cargo.lock'
 $cargoSource = [IO.File]::ReadAllText($candidateCargoPath)
 $lockSource = [IO.File]::ReadAllText($lockPath)
+
+function Get-DisposableLoopbackPort {
+  $probe = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Loopback, 0)
+  try {
+    $probe.Start()
+    return ([Net.IPEndPoint]$probe.LocalEndpoint).Port
+  } finally {
+    $probe.Stop()
+  }
+}
+
+function Get-ByteSha256([byte[]]$Bytes) {
+  return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($Bytes)).ToLowerInvariant()
+}
+
+function Invoke-LoopbackHttpBytes([string]$Uri) {
+  $handler = [Net.Http.HttpClientHandler]::new()
+  $handler.UseProxy = $false
+  $client = [Net.Http.HttpClient]::new($handler)
+  try {
+    $response = $client.GetAsync($Uri).GetAwaiter().GetResult()
+    try {
+      $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+      $contentType = if ($null -ne $response.Content.Headers.ContentType) {
+        [string]$response.Content.Headers.ContentType.MediaType
+      } else {
+        ''
+      }
+      $contentLength = $response.Content.Headers.ContentLength
+      return [pscustomobject]@{
+        status_code = [int]$response.StatusCode
+        content_type = $contentType
+        content_length = if ($null -eq $contentLength) { [int64]$bytes.Length } else { [int64]$contentLength }
+        body_length = [int64]$bytes.Length
+        body_sha256 = Get-ByteSha256 $bytes
+        body = $bytes
+      }
+    } finally {
+      $response.Dispose()
+    }
+  } finally {
+    $client.Dispose()
+    $handler.Dispose()
+  }
+}
+
+function Assert-ExactHttpResponse {
+  param(
+    [Parameter(Mandatory = $true)] [object]$Response,
+    [Parameter(Mandatory = $true)] [byte[]]$ExpectedBytes,
+    [Parameter(Mandatory = $true)] [string]$ExpectedContentType,
+    [Parameter(Mandatory = $true)] [string]$Name
+  )
+  $expectedHash = Get-ByteSha256 $ExpectedBytes
+  if ($Response.status_code -ne 200 -or
+    $Response.content_type -ne $ExpectedContentType -or
+    [int64]$Response.content_length -ne [int64]$ExpectedBytes.Length -or
+    [int64]$Response.body_length -ne [int64]$ExpectedBytes.Length -or
+    [string]$Response.body_sha256 -ne $expectedHash) {
+    throw "$Name HTTP response failed exact contract (status=$($Response.status_code); content_type=$($Response.content_type); content_length=$($Response.content_length); body_length=$($Response.body_length); body_sha256=$($Response.body_sha256))"
+  }
+  return [ordered]@{
+    status = 'PASS'
+    status_code = [int]$Response.status_code
+    content_type = [string]$Response.content_type
+    content_length = [int64]$Response.content_length
+    body_length = [int64]$Response.body_length
+    body_sha256 = [string]$Response.body_sha256
+  }
+}
+
+function Write-HttpEvidence([string]$Status) {
+  try {
+    $requests = @()
+    if (Test-Path -LiteralPath $requestLogPath -PathType Leaf) {
+      $requests = @(Get-Content -LiteralPath $requestLogPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | ForEach-Object { $_ | ConvertFrom-Json })
+    }
+    $proxy = [ordered]@{
+      http_proxy_set = @('HTTP_PROXY', 'http_proxy') | Where-Object {
+        -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+      } | Select-Object -First 1 | ForEach-Object { $true }
+      https_proxy_set = @('HTTPS_PROXY', 'https_proxy') | Where-Object {
+        -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+      } | Select-Object -First 1 | ForEach-Object { $true }
+      no_proxy_set = @('NO_PROXY', 'no_proxy') | Where-Object {
+        -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+      } | Select-Object -First 1 | ForEach-Object { $true }
+      loopback_client_proxy_disabled = $true
+    }
+    foreach ($proxyName in @('http_proxy_set', 'https_proxy_set', 'no_proxy_set')) {
+      if ($null -eq $proxy[$proxyName]) { $proxy[$proxyName] = $false }
+    }
+    $evidence = [ordered]@{
+      schema_version = 1
+      status = $Status
+      port = [int]$port
+      proxy_environment = $proxy
+      manifest = $manifestContract
+      candidate = $candidateContract
+      requests = $requests
+    }
+    $parent = Split-Path -Parent $httpEvidencePath
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    [IO.File]::WriteAllText($httpEvidencePath, ($evidence | ConvertTo-Json -Depth 12) + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+  } catch {
+    Write-Warning 'Could not persist sanitized fixture HTTP evidence'
+  }
+}
 
 function Wait-ForPath {
   param([string]$Path, [int]$TimeoutSeconds = 180)
@@ -112,8 +230,10 @@ function Invoke-FixtureBuild {
   $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
   $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ''
   $oldCargoTargetDir = [Environment]::GetEnvironmentVariable('CARGO_TARGET_DIR', 'Process')
+  $oldFixturePort = [Environment]::GetEnvironmentVariable('SKY_TAURI_UPDATE_FIXTURE_PORT', 'Process')
   try {
     [Environment]::SetEnvironmentVariable('CARGO_TARGET_DIR', $fixtureTargetRoot, 'Process')
+    [Environment]::SetEnvironmentVariable('SKY_TAURI_UPDATE_FIXTURE_PORT', [string]$port, 'Process')
     Push-Location $desktopRoot
     try {
       & bun run tauri build --ci --config $ConfigPath -- --profile dist --features tauri-update-fixture
@@ -127,6 +247,11 @@ function Invoke-FixtureBuild {
     } else {
       [Environment]::SetEnvironmentVariable('CARGO_TARGET_DIR', $oldCargoTargetDir, 'Process')
     }
+    if ($null -eq $oldFixturePort) {
+      [Environment]::SetEnvironmentVariable('SKY_TAURI_UPDATE_FIXTURE_PORT', $null, 'Process')
+    } else {
+      [Environment]::SetEnvironmentVariable('SKY_TAURI_UPDATE_FIXTURE_PORT', $oldFixturePort, 'Process')
+    }
     Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
     Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
     Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
@@ -134,7 +259,9 @@ function Invoke-FixtureBuild {
 }
 
 try {
+  $port = Get-DisposableLoopbackPort
   New-Item -ItemType Directory -Path $fixtureRoot, $installRoot -Force | Out-Null
+  New-Item -ItemType File -Path $requestLogPath -Force | Out-Null
   New-Item -ItemType Directory -Path $fixtureBundleRoot -Force | Out-Null
   $fixtureBundleRoot = (Resolve-Path -LiteralPath $fixtureBundleRoot -ErrorAction Stop).Path
 
@@ -150,8 +277,8 @@ try {
 
   Push-Location $desktopRoot
   try {
-    bun run tauri signer generate --ci --password '' --force -w $oldKeyPath | Out-Null
-    bun run tauri signer generate --ci --password '' --force -w $newKeyPath | Out-Null
+    bun run tauri signer generate --ci --password '' --force -w $oldKeyPath *> $null
+    bun run tauri signer generate --ci --password '' --force -w $newKeyPath *> $null
   } finally {
     Pop-Location
   }
@@ -222,7 +349,7 @@ try {
     Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
     Push-Location $desktopRoot
     try {
-      bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath | Out-Null
+      bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath *> $null
     } finally {
       Pop-Location
     }
@@ -260,7 +387,7 @@ try {
 
   $archivePath = $candidateArchive.FullName
   $serverJob = Start-Job -ScriptBlock {
-    param($Port, $ManifestPath, $ArchivePath, $StopPath)
+    param($Port, $ManifestPath, $ArchivePath, $StopPath, $RequestLogPath)
     $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Parse('127.0.0.1'), $Port)
     $listener.Start()
     try {
@@ -275,7 +402,10 @@ try {
           $requestBytes = [byte[]]::new(8192)
           $read = $stream.Read($requestBytes, 0, $requestBytes.Length)
           $request = [Text.Encoding]::ASCII.GetString($requestBytes, 0, $read)
-          $path = ($request -split "`r?`n", 2)[0].Split(' ')[1].Split('?')[0]
+          $requestLine = ($request -split "`r?`n", 2)[0]
+          $requestParts = $requestLine.Split(' ')
+          $method = if ($requestParts.Count -gt 0) { $requestParts[0] } else { '' }
+          $path = if ($requestParts.Count -gt 1) { $requestParts[1].Split('?')[0] } else { '' }
           if ($path -eq '/stable' -or $path -eq '/beta') {
             $bytes = [IO.File]::ReadAllBytes($ManifestPath)
             $contentType = 'application/json'
@@ -289,6 +419,15 @@ try {
             $contentType = 'text/plain'
             $status = '404 Not Found'
           }
+          $requestEvidence = [ordered]@{
+            method = $method
+            path = $path
+            status_code = [int]$status.Split(' ')[0]
+            content_type = $contentType
+            content_length = [int64]$bytes.Length
+            body_sha256 = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+          }
+          [IO.File]::AppendAllText($RequestLogPath, (($requestEvidence | ConvertTo-Json -Compress) + [Environment]::NewLine), [Text.UTF8Encoding]::new($false))
           $header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 $status`r`nContent-Type: $contentType`r`nContent-Length: $($bytes.Length)`r`nConnection: close`r`n`r`n")
           $stream.Write($header, 0, $header.Length)
           $stream.Write($bytes, 0, $bytes.Length)
@@ -301,7 +440,7 @@ try {
     } finally {
       $listener.Stop()
     }
-  } -ArgumentList $port, $manifestPath, $archivePath, $stopPath
+  } -ArgumentList $port, $manifestPath, $archivePath, $stopPath, $requestLogPath
 
   $serverReady = $false
   $serverDeadline = [DateTime]::UtcNow.AddSeconds(30)
@@ -316,6 +455,36 @@ try {
     $serverOutput = Receive-Job -Job $serverJob -Keep | Out-String
     throw "Local signed updater fixture did not become ready. Server job output: $serverOutput"
   }
+
+  $manifestBytes = [IO.File]::ReadAllBytes($manifestPath)
+  $manifestDocument = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+  $manifestPlatform = $manifestDocument.platforms.'windows-x86_64-nsis'
+  $expectedCandidateUrl = "http://127.0.0.1:$port/candidate/update.exe"
+  if ($null -eq $manifestPlatform -or
+    [string]$manifestDocument.version -ne $candidateVersion -or
+    [string]$manifestPlatform.url -ne $expectedCandidateUrl -or
+    [string]::IsNullOrWhiteSpace([string]$manifestPlatform.signature)) {
+    throw 'Fixture release manifest failed the Tauri-compatible schema contract'
+  }
+  $manifestResponse = Invoke-LoopbackHttpBytes "http://127.0.0.1:$port/stable"
+  $manifestHttp = Assert-ExactHttpResponse $manifestResponse $manifestBytes 'application/json' 'fixture release manifest'
+  $manifestContract = [ordered]@{
+    status = 'PASS'
+    schema_status = 'PASS'
+    version = [string]$manifestDocument.version
+    platform = 'windows-x86_64-nsis'
+    candidate_url = [string]$manifestPlatform.url
+    signature_present = $true
+    http = $manifestHttp
+  }
+  $candidateBytes = [IO.File]::ReadAllBytes($candidateArchive.FullName)
+  $candidateResponse = Invoke-LoopbackHttpBytes $expectedCandidateUrl
+  $candidateContract = [ordered]@{
+    status = 'PASS'
+    http = Assert-ExactHttpResponse $candidateResponse $candidateBytes 'application/octet-stream' 'fixture candidate artifact'
+  }
+  Write-Host "Fixture HTTP manifest contract: PASS (status=200; content-type=application/json; content-length=$($manifestHttp.content_length); body-sha256=$($manifestHttp.body_sha256))"
+  Write-Host "Fixture HTTP candidate contract: PASS (status=200; content-type=application/octet-stream; content-length=$($candidateContract.http.content_length); body-sha256=$($candidateContract.http.body_sha256))"
 
   $installerRun = Start-Process -FilePath $previousInstallerCopy -ArgumentList @('/S', "/D=$installRoot") -WindowStyle Hidden -Wait -PassThru
   if ($installerRun.ExitCode -ne 0) { throw "Bridge-v4 installer exited with $($installerRun.ExitCode)" }
@@ -368,6 +537,7 @@ try {
     "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; cutover [new] rejected old-root-only $cutoverVersion; safety phases=$($requiredPhases -join ', '))" |
       Add-Content $summaryPath -Encoding UTF8
   }
+  $fixtureStatus = 'PASS'
 } finally {
   if ($null -ne $serverJob) {
     New-Item -ItemType File -Path $stopPath -Force | Out-Null
@@ -379,6 +549,7 @@ try {
   Remove-Item Env:SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS -ErrorAction SilentlyContinue
   Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
   Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+  Write-HttpEvidence $fixtureStatus
   if (-not $KeepFixtureOnFailure -and (Test-Path -LiteralPath $fixtureRoot)) {
     Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
   }

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -363,7 +363,10 @@ try {
     notes = 'Deterministic bridge rotation candidate.'
     pub_date = '2026-09-04T00:00:00Z'
     platforms = [ordered]@{
-      'windows-x86_64-nsis' = [ordered]@{
+      # Match the production release-authority manifest exactly. Tauri's
+      # updater accepts this platform key and falls back from the bundle
+      # specific target when the packaged runtime does not expose it.
+      'windows-x86_64' = [ordered]@{
         signature = $signatureText
         url = "http://127.0.0.1:$port/candidate/update.exe"
       }
@@ -376,7 +379,7 @@ try {
       notes = 'Old-root rejection candidate.'
       pub_date = '2026-09-04T00:00:00Z'
       platforms = [ordered]@{
-        'windows-x86_64-nsis' = [ordered]@{
+        'windows-x86_64' = [ordered]@{
           signature = $oldSignatureText
           url = "http://127.0.0.1:$port/candidate/update.exe"
         }
@@ -458,7 +461,7 @@ try {
 
   $manifestBytes = [IO.File]::ReadAllBytes($manifestPath)
   $manifestDocument = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
-  $manifestPlatform = $manifestDocument.platforms.'windows-x86_64-nsis'
+  $manifestPlatform = $manifestDocument.platforms.'windows-x86_64'
   $expectedCandidateUrl = "http://127.0.0.1:$port/candidate/update.exe"
   if ($null -eq $manifestPlatform -or
     [string]$manifestDocument.version -ne $candidateVersion -or
@@ -472,7 +475,7 @@ try {
     status = 'PASS'
     schema_status = 'PASS'
     version = [string]$manifestDocument.version
-    platform = 'windows-x86_64-nsis'
+    platform = 'windows-x86_64'
     candidate_url = [string]$manifestPlatform.url
     signature_present = $true
     http = $manifestHttp

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -35,6 +35,7 @@ if ($fixtureTargetRoot.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) 
 $fixtureBundleRoot = Join-Path $fixtureTargetRoot 'dist/bundle/nsis'
 $installRoot = Join-Path $fixtureRoot 'installed'
 $markerPath = Join-Path $fixtureRoot 'completion.txt'
+$expectedVersionPath = Join-Path $fixtureRoot 'expected-installed-version.txt'
 $cutoverMarkerPath = Join-Path $fixtureRoot 'cutover.txt'
 $safetyPath = Join-Path $fixtureRoot 'safety.txt'
 $stopPath = Join-Path $fixtureRoot 'stop-server'
@@ -499,6 +500,7 @@ try {
   $appProcess = Start-Process -FilePath $appPath -ArgumentList @(
     '--selftest-desktop-update',
     '--selftest-update-marker', $markerPath,
+    '--selftest-update-expected-version-file', $expectedVersionPath,
     '--selftest-update-safety-marker', $safetyPath
   ) -WindowStyle Hidden -PassThru
   Wait-Process -Id $appProcess.Id -Timeout 180

--- a/scripts/test_v4_production_topology_rehearsal.ps1
+++ b/scripts/test_v4_production_topology_rehearsal.ps1
@@ -1,0 +1,187 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CandidateStateRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("stable", "beta")]
+    [string]$Channel,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Tag,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SourceSha,
+
+    [string]$WorkflowSha,
+    [string]$StateRoot,
+    [switch]$KeepStateOnFailure
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$pipelinePath = Join-Path $PSScriptRoot "v4_release_pipeline.ps1"
+$candidateRoot = [IO.Path]::GetFullPath($CandidateStateRoot)
+$candidateManifestPath = Join-Path $candidateRoot "candidate-manifest.json"
+$canonicalBundleDir = Join-Path $repoRoot "rust/target/dist/bundle/nsis"
+$canonicalEvidenceDir = Join-Path $repoRoot "rust/target/dist"
+. (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
+
+function Fail([string]$Message) {
+    throw "V4 production-topology rehearsal failed closed: $Message"
+}
+
+function Resolve-ExternalDirectory([string]$Path, [string]$Name) {
+    if ([string]::IsNullOrWhiteSpace($Path)) { Fail "$Name is required" }
+    $full = [IO.Path]::GetFullPath($Path)
+    $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if ($full.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "$Name must be outside the repository workspace"
+    }
+    return $full
+}
+
+function Write-JsonFile([string]$Path, [object]$Value) {
+    $parent = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $json = $Value | ConvertTo-Json -Depth 20
+    [IO.File]::WriteAllText($Path, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+}
+
+function Get-SourceAssetPath([object]$Record) {
+    $sourceName = if ($null -ne $Record.PSObject.Properties["source_name"]) {
+        [string]$Record.source_name
+    } else {
+        [string]$Record.name
+    }
+    $role = [string]$Record.role
+    if ($role -in @("installer", "updater-signature")) {
+        return Join-Path $canonicalBundleDir $sourceName
+    }
+    return Join-Path $canonicalEvidenceDir $sourceName
+}
+
+if ($SourceSha -notmatch "^[0-9a-fA-F]{40}$") { Fail "source SHA must be an exact 40-character commit SHA" }
+if ($Tag -ne "v$Version") { Fail "tag must exactly equal v<version>" }
+
+$candidateRoot = Resolve-ExternalDirectory $candidateRoot "CandidateStateRoot"
+if (-not (Test-Path -LiteralPath $candidateManifestPath -PathType Leaf)) {
+    Fail "BuildCandidate manifest is missing: $candidateManifestPath"
+}
+
+$effectiveWorkflowSha = if ([string]::IsNullOrWhiteSpace($WorkflowSha)) { $SourceSha } else { $WorkflowSha }
+$effectiveStateRoot = if ([string]::IsNullOrWhiteSpace($StateRoot)) {
+    Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-production-topology-" + [guid]::NewGuid().ToString("N"))
+} else {
+    $StateRoot
+}
+$effectiveStateRoot = Resolve-ExternalDirectory $effectiveStateRoot "StateRoot"
+if ($effectiveStateRoot.Equals($candidateRoot, [StringComparison]::OrdinalIgnoreCase)) {
+    Fail "StateRoot must be separate from CandidateStateRoot"
+}
+if (Test-Path -LiteralPath $effectiveStateRoot -PathType Leaf) {
+    Fail "StateRoot must be a directory"
+}
+$stateRootExisted = Test-Path -LiteralPath $effectiveStateRoot -PathType Container
+if ($stateRootExisted -and @(Get-ChildItem -LiteralPath $effectiveStateRoot -Force).Count -ne 0) {
+    Fail "StateRoot must be empty for a disposable topology rehearsal"
+}
+New-Item -ItemType Directory -Path $effectiveStateRoot -Force | Out-Null
+
+$manifest = Get-Content -LiteralPath $candidateManifestPath -Raw | ConvertFrom-Json
+if ([string]$manifest.source_sha -ne $SourceSha.ToLowerInvariant() -or
+    [string]$manifest.version -ne $Version -or
+    [string]$manifest.channel -ne $Channel) {
+    Fail "candidate manifest identity does not match the rehearsal request"
+}
+
+$records = @($manifest.assets)
+if ($records.Count -eq 0) { Fail "candidate manifest contains no assets" }
+$downloaded = Join-Path $effectiveStateRoot "downloaded"
+New-Item -ItemType Directory -Path $downloaded -Force | Out-Null
+
+try {
+    foreach ($record in $records) {
+        $sourceName = if ($null -ne $record.PSObject.Properties["source_name"]) {
+            [string]$record.source_name
+        } else {
+            [string]$record.name
+        }
+        $authorityName = if ($null -ne $record.PSObject.Properties["authority_name"]) {
+            [string]$record.authority_name
+        } else {
+            Get-V4SafeAuthorityAssetName $sourceName
+        }
+        $sourcePath = Get-SourceAssetPath $record
+        if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+            Fail "candidate asset is missing from the BuildCandidate output: $sourcePath"
+        }
+        $sourceItem = Get-Item -LiteralPath $sourcePath
+        $sourceHash = (Get-FileHash -LiteralPath $sourcePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ([int64]$sourceItem.Length -ne [int64]$record.size -or
+            $sourceHash -ne [string]$record.sha256) {
+            Fail "candidate asset changed after BuildCandidate: $sourceName"
+        }
+        $destination = Join-Path $downloaded $authorityName
+        Copy-Item -LiteralPath $sourcePath -Destination $destination -Force
+        $downloadedItem = Get-Item -LiteralPath $destination
+        $downloadedHash = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ([int64]$downloadedItem.Length -ne [int64]$record.size -or
+            $downloadedHash -ne [string]$record.sha256) {
+            Fail "staged rehearsal asset is not byte-identical: $sourceName"
+        }
+    }
+
+    $releaseState = [ordered]@{
+        schema_version = 1
+        source_sha = $SourceSha.ToLowerInvariant()
+        version = $Version
+        channel = $Channel
+        tag = $Tag
+        release_id = 0
+        draft = $true
+        published = $false
+        immutable = $false
+        attested = $false
+        qualified_after_download = $false
+        assets = $records
+    }
+    Write-JsonFile (Join-Path $effectiveStateRoot "release-state.json") $releaseState
+    Write-JsonFile (Join-Path $effectiveStateRoot "downloaded-manifest.json") ([ordered]@{
+        schema_version = 1
+        source_sha = $SourceSha.ToLowerInvariant()
+        version = $Version
+        channel = $Channel
+        assets = $records
+    })
+
+    $pipelineArguments = @(
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $pipelinePath,
+        "-State", "QualifyDownloaded",
+        "-Version", $Version,
+        "-Channel", $Channel,
+        "-Tag", $Tag,
+        "-SourceSha", $SourceSha,
+        "-WorkflowSha", $effectiveWorkflowSha,
+        "-StateRoot", $effectiveStateRoot
+    )
+    & pwsh @pipelineArguments
+    if ($LASTEXITCODE -ne 0) {
+        Fail "the production QualifyDownloaded entrypoint returned exit code $LASTEXITCODE"
+    }
+    Write-Host "V4 production-topology rehearsal: PASS (v4_release_pipeline.ps1 -State QualifyDownloaded; exact candidate bytes; isolated fixture target)"
+}
+finally {
+    if (-not $KeepStateOnFailure -and -not $stateRootExisted -and (Test-Path -LiteralPath $effectiveStateRoot)) {
+        Remove-Item -LiteralPath $effectiveStateRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -7,14 +7,50 @@ $ErrorActionPreference = "Stop"
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $pipelinePath = Join-Path $PSScriptRoot "v4_release_pipeline.ps1"
 $rehearsalPath = Join-Path $PSScriptRoot "test_v4_release_authority_rehearsal.ps1"
+$topologyRehearsalPath = Join-Path $PSScriptRoot "test_v4_production_topology_rehearsal.ps1"
+$fixtureWrapperPath = Join-Path $PSScriptRoot "ci_tauri_update_e2e.ps1"
+$fixtureCorePath = Join-Path $PSScriptRoot "ci_tauri_update_e2e_core.ps1"
 $uploadHelperPath = Join-Path $PSScriptRoot "v4_release_authority_upload.ps1"
 $workflowPath = Join-Path $repoRoot ".github/workflows/release-v4.yml"
 $pipeline = Get-Content -LiteralPath $pipelinePath -Raw
 $rehearsal = Get-Content -LiteralPath $rehearsalPath -Raw
+$topologyRehearsal = Get-Content -LiteralPath $topologyRehearsalPath -Raw
+$fixtureWrapper = Get-Content -LiteralPath $fixtureWrapperPath -Raw
+$fixtureCore = Get-Content -LiteralPath $fixtureCorePath -Raw
 $uploadHelper = Get-Content -LiteralPath $uploadHelperPath -Raw
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
 
 function Fail([string]$Message) { throw "FAILED: $Message" }
+
+if ($fixtureWrapper.Contains("BundleDir") -or $fixtureCore.Contains("BundleDir")) {
+    Fail "updater fixture must not use the ambiguous BundleDir contract"
+}
+foreach ($marker in @(
+    "FixtureTargetDir",
+    "CARGO_TARGET_DIR",
+    "dist/bundle/nsis",
+    "Downloaded candidate paths must remain outside the throwaway fixture target directory"
+)) {
+    if (-not $fixtureCore.Contains($marker)) {
+        Fail "updater fixture topology marker is missing: $marker"
+    }
+}
+foreach ($marker in @(
+    '"-State", "QualifyDownloaded"',
+    '"-StateRoot", $effectiveStateRoot'
+)) {
+    if (-not $topologyRehearsal.Contains($marker)) {
+        Fail "production-topology rehearsal marker is missing: $marker"
+    }
+}
+if (-not $pipeline.Contains("FixtureTargetDir")) {
+    Fail "production qualification must pass an explicit fixture target directory"
+}
+if ($workflow.Contains("updater_private_key_path") -or
+    $workflow.Contains("inputs.updater_private_key_path") -or
+    $workflow.Contains("CARGO_TARGET_DIR=")) {
+    Fail "production workflow still carries a dispatch key path or ambient fixture target contract"
+}
 
 foreach ($script in @(
     [pscustomobject]@{ Name = "production release pipeline"; Source = $pipeline },

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -12,6 +12,7 @@ $fixtureWrapperPath = Join-Path $PSScriptRoot "ci_tauri_update_e2e.ps1"
 $fixtureCorePath = Join-Path $PSScriptRoot "ci_tauri_update_e2e_core.ps1"
 $uploadHelperPath = Join-Path $PSScriptRoot "v4_release_authority_upload.ps1"
 $workflowPath = Join-Path $repoRoot ".github/workflows/release-v4.yml"
+$topologyWorkflowPath = Join-Path $repoRoot ".github/workflows/rehearse-v4-production-topology.yml"
 $pipeline = Get-Content -LiteralPath $pipelinePath -Raw
 $rehearsal = Get-Content -LiteralPath $rehearsalPath -Raw
 $topologyRehearsal = Get-Content -LiteralPath $topologyRehearsalPath -Raw
@@ -19,6 +20,7 @@ $fixtureWrapper = Get-Content -LiteralPath $fixtureWrapperPath -Raw
 $fixtureCore = Get-Content -LiteralPath $fixtureCorePath -Raw
 $uploadHelper = Get-Content -LiteralPath $uploadHelperPath -Raw
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
+$topologyWorkflow = Get-Content -LiteralPath $topologyWorkflowPath -Raw
 
 function Fail([string]$Message) { throw "FAILED: $Message" }
 
@@ -46,10 +48,17 @@ foreach ($marker in @(
 if (-not $pipeline.Contains("FixtureTargetDir")) {
     Fail "production qualification must pass an explicit fixture target directory"
 }
-if ($workflow.Contains("updater_private_key_path") -or
-    $workflow.Contains("inputs.updater_private_key_path") -or
-    $workflow.Contains("CARGO_TARGET_DIR=")) {
-    Fail "production workflow still carries a dispatch key path or ambient fixture target contract"
+foreach ($marker in @(
+    'updater_private_key_path:',
+    'inputs.updater_private_key_path',
+    '-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH'
+)) {
+    if (-not $workflow.Contains($marker)) {
+        Fail "production workflow key-path transport marker is missing: $marker"
+    }
+}
+if ($workflow.Contains("CARGO_TARGET_DIR=")) {
+    Fail "production workflow still carries an ambient fixture target contract"
 }
 
 foreach ($script in @(
@@ -244,6 +253,39 @@ foreach ($forbidden in @(
     'V4_RELEASE_STATE_ROOT: ${{ runner.temp }}'
 )) {
     if ($workflow.Contains($forbidden)) { Fail "forbidden production workflow marker remains: $forbidden" }
+}
+
+foreach ($marker in @(
+    'name: V4 Production Topology Rehearsal',
+    'workflow_dispatch:',
+    'runs-on: [self-hosted, windows, v4-release, single-tenant]',
+    'ref: ${{ inputs.source_sha }}',
+    'persist-credentials: false',
+    'updater_private_key_path:',
+    'BuildCandidate',
+    'test_v4_production_topology_rehearsal.ps1',
+    '-CandidateStateRoot $env:V4_REHEARSAL_STATE_ROOT',
+    'Execute exact production QualifyDownloaded topology',
+    '-StateRoot $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT',
+    '-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH'
+)) {
+    if (-not $topologyWorkflow.Contains($marker)) {
+        Fail "production-topology rehearsal workflow marker is missing: $marker"
+    }
+}
+foreach ($forbidden in @(
+    'V4_RELEASE_AUTHORITY_TOKEN',
+    'ValidateAuthority',
+    'CreateDraft',
+    'PublishDraft',
+    'PromoteMetadata',
+    'FinalVerify',
+    'gh release',
+    'softprops/action-gh-release'
+)) {
+    if ($topologyWorkflow.Contains($forbidden)) {
+        Fail "production-topology rehearsal workflow contains an authority mutation marker: $forbidden"
+    }
 }
 $stateRootInit = $workflow.IndexOf('- name: Initialize release state root', [StringComparison]::Ordinal)
 $checkout = $workflow.IndexOf('- name: Check out the exact requested source SHA', [StringComparison]::Ordinal)

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -37,7 +37,7 @@ foreach ($marker in @(
     "Assert-ExactHttpResponse",
     "fixture-http-evidence.json",
     "body_sha256",
-    "windows-x86_64-nsis",
+    "windows-x86_64",
     "/candidate/update.exe"
 )) {
     if (-not $fixtureCore.Contains($marker)) {

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -31,7 +31,14 @@ foreach ($marker in @(
     "FixtureTargetDir",
     "CARGO_TARGET_DIR",
     "dist/bundle/nsis",
-    "Downloaded candidate paths must remain outside the throwaway fixture target directory"
+    "Downloaded candidate paths must remain outside the throwaway fixture target directory",
+    "Get-DisposableLoopbackPort",
+    "SKY_TAURI_UPDATE_FIXTURE_PORT",
+    "Assert-ExactHttpResponse",
+    "fixture-http-evidence.json",
+    "body_sha256",
+    "windows-x86_64-nsis",
+    "/candidate/update.exe"
 )) {
     if (-not $fixtureCore.Contains($marker)) {
         Fail "updater fixture topology marker is missing: $marker"

--- a/scripts/test_v4_updater_credential_broker.ps1
+++ b/scripts/test_v4_updater_credential_broker.ps1
@@ -360,14 +360,19 @@ exit 0
     $dummyKeyPath = Join-Path $fixtureRoot "test.key"
     New-Item -ItemType File -Path $dummyKeyPath -Force | Out-Null
     $currentHeadSha = (git -C $repoRoot rev-parse HEAD).Trim().ToLowerInvariant()
+    $cargoSource = Get-Content -LiteralPath (Join-Path $repoRoot "desktop/src-tauri/Cargo.toml") -Raw
+    if ($cargoSource -notmatch '(?m)^version\s*=\s*"([^"]+)"') {
+        Fail "Could not determine the current desktop package version for the ambient environment test"
+    }
+    $currentVersion = $Matches[1]
     try {
         $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = "ambient-forbidden-value"
         $pipelineOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
             -File (Join-Path $PSScriptRoot "v4_release_pipeline.ps1") `
             -State BuildCandidate `
-            -Version "4.0.0-rc.1" `
+            -Version $currentVersion `
             -Channel "beta" `
-            -Tag "v4.0.0-rc.1" `
+            -Tag "v$currentVersion" `
             -SourceSha $currentHeadSha `
             -WorkflowSha $currentHeadSha `
             -StateRoot (Join-Path ([IO.Path]::GetTempPath()) ("state-" + [guid]::NewGuid().ToString("N"))) `

--- a/scripts/test_v4_updater_fixture_server.ps1
+++ b/scripts/test_v4_updater_fixture_server.ps1
@@ -24,7 +24,7 @@ foreach ($marker in @(
         'fixture-http-evidence.json',
         'Content-Length',
         'body_sha256',
-        'windows-x86_64-nsis',
+        'windows-x86_64',
         '/candidate/update.exe'
     )) {
     if ($coreContent -notlike "*$marker*") {
@@ -63,7 +63,7 @@ $manifestText = [ordered]@{
     notes = 'Fixture manifest contract test.'
     pub_date = '2026-09-08T00:00:00Z'
     platforms = [ordered]@{
-        'windows-x86_64-nsis' = [ordered]@{
+        'windows-x86_64' = [ordered]@{
             signature = 'fixture-signature'
             url = "http://127.0.0.1:$testPort/candidate/update.exe"
         }
@@ -150,7 +150,7 @@ try {
                 [string]$response.Content.Headers.ContentType.MediaType
             }
             $servedDocument = [Text.Encoding]::UTF8.GetString($servedBytes) | ConvertFrom-Json
-            $servedPlatform = $servedDocument.platforms.'windows-x86_64-nsis'
+            $servedPlatform = $servedDocument.platforms.'windows-x86_64'
             $servedHash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($servedBytes)).ToLowerInvariant()
             $expectedHash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
             if ([int]$response.StatusCode -ne 200 -or

--- a/scripts/test_v4_updater_fixture_server.ps1
+++ b/scripts/test_v4_updater_fixture_server.ps1
@@ -24,6 +24,7 @@ foreach ($marker in @(
         'fixture-http-evidence.json',
         'Content-Length',
         'body_sha256',
+        'selftest-update-expected-version-file',
         'windows-x86_64',
         '/candidate/update.exe'
     )) {

--- a/scripts/test_v4_updater_fixture_server.ps1
+++ b/scripts/test_v4_updater_fixture_server.ps1
@@ -17,6 +17,20 @@ $coreContent = Get-Content -LiteralPath $coreScriptPath -Raw
 if ($coreContent -match '(?i)\$listener\s*\.\s*Close\s*\(') {
     throw "FAILED: ci_tauri_update_e2e_core.ps1 still contains unsupported `$listener.Close() call"
 }
+foreach ($marker in @(
+        'Get-DisposableLoopbackPort',
+        'SKY_TAURI_UPDATE_FIXTURE_PORT',
+        'Assert-ExactHttpResponse',
+        'fixture-http-evidence.json',
+        'Content-Length',
+        'body_sha256',
+        'windows-x86_64-nsis',
+        '/candidate/update.exe'
+    )) {
+    if ($coreContent -notlike "*$marker*") {
+        throw "FAILED: fixture HTTP contract is missing required marker: $marker"
+    }
+}
 Write-Host "Test 1: PASS"
 
 # Test 2: Runtime platform contract - verify [System.Net.Sockets.TcpListener] does not expose Close()
@@ -35,13 +49,35 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 
 $stopPath = Join-Path $tempDir "stop.signal"
 $manifestPath = Join-Path $tempDir "manifest.json"
-Set-Content -LiteralPath $manifestPath -Value '{"version":"4.0.0-test"}' -Encoding utf8
+$candidatePath = Join-Path $tempDir "candidate-update.exe"
+$testPort = $null
+$probe = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+try {
+    $probe.Start()
+    $testPort = ([System.Net.IPEndPoint]$probe.LocalEndpoint).Port
+} finally {
+    $probe.Stop()
+}
+$manifestText = [ordered]@{
+    version = '4.0.0-test'
+    notes = 'Fixture manifest contract test.'
+    pub_date = '2026-09-08T00:00:00Z'
+    platforms = [ordered]@{
+        'windows-x86_64-nsis' = [ordered]@{
+            signature = 'fixture-signature'
+            url = "http://127.0.0.1:$testPort/candidate/update.exe"
+        }
+    }
+} | ConvertTo-Json -Depth 8 -Compress
+$manifestBytes = [Text.UTF8Encoding]::new($false).GetBytes($manifestText + "`n")
+[IO.File]::WriteAllBytes($manifestPath, $manifestBytes)
+$candidateBytes = [Text.Encoding]::ASCII.GetBytes('fixture candidate bytes')
+[IO.File]::WriteAllBytes($candidatePath, $candidateBytes)
 
-$testPort = 39182
 $serverJob = $null
 try {
     $serverJob = Start-Job -ScriptBlock {
-        param($Port, $ManifestPath, $StopPath)
+        param($Port, $ManifestPath, $CandidatePath, $StopPath)
         $listener = [Net.Sockets.TcpListener]::new([Net.IPAddress]::Parse('127.0.0.1'), $Port)
         $listener.Start()
         try {
@@ -59,12 +95,18 @@ try {
                     $path = ($request -split "`r?`n", 2)[0].Split(' ')[1].Split('?')[0]
                     if ($path -eq '/stable') {
                         $bytes = [IO.File]::ReadAllBytes($ManifestPath)
+                        $contentType = 'application/json'
+                        $status = '200 OK'
+                    } elseif ($path -eq '/candidate/update.exe') {
+                        $bytes = [IO.File]::ReadAllBytes($CandidatePath)
+                        $contentType = 'application/octet-stream'
                         $status = '200 OK'
                     } else {
                         $bytes = [Text.Encoding]::UTF8.GetBytes('not found')
+                        $contentType = 'text/plain'
                         $status = '404 Not Found'
                     }
-                    $header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 $status`r`nContent-Type: application/json`r`nContent-Length: $($bytes.Length)`r`nConnection: close`r`n`r`n")
+                    $header = [Text.Encoding]::ASCII.GetBytes("HTTP/1.1 $status`r`nContent-Type: $contentType`r`nContent-Length: $($bytes.Length)`r`nConnection: close`r`n`r`n")
                     $stream.Write($header, 0, $header.Length)
                     $stream.Write($bytes, 0, $bytes.Length)
                     $stream.Flush()
@@ -76,7 +118,7 @@ try {
         } finally {
             $listener.Stop()
         }
-    } -ArgumentList $testPort, $manifestPath, $stopPath
+    } -ArgumentList $testPort, $manifestPath, $candidatePath, $stopPath
 
     # Wait for server to become ready
     $ready = $false
@@ -94,6 +136,42 @@ try {
     if (-not $ready) {
         throw "Test fixture server did not become ready within deadline"
     }
+
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.UseProxy = $false
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    try {
+        $response = $client.GetAsync("http://127.0.0.1:$testPort/stable").GetAwaiter().GetResult()
+        try {
+            $servedBytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+            $servedContentType = if ($null -eq $response.Content.Headers.ContentType) {
+                ''
+            } else {
+                [string]$response.Content.Headers.ContentType.MediaType
+            }
+            $servedDocument = [Text.Encoding]::UTF8.GetString($servedBytes) | ConvertFrom-Json
+            $servedPlatform = $servedDocument.platforms.'windows-x86_64-nsis'
+            $servedHash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($servedBytes)).ToLowerInvariant()
+            $expectedHash = [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
+            if ([int]$response.StatusCode -ne 200 -or
+                $servedContentType -ne 'application/json' -or
+                [int64]$response.Content.Headers.ContentLength -ne [int64]$manifestBytes.Length -or
+                -not [System.Linq.Enumerable]::SequenceEqual($servedBytes, $manifestBytes) -or
+                $servedHash -ne $expectedHash -or
+                [string]$servedDocument.version -ne '4.0.0-test' -or
+                $null -eq $servedPlatform -or
+                [string]$servedPlatform.url -ne "http://127.0.0.1:$testPort/candidate/update.exe" -or
+                [string]::IsNullOrWhiteSpace([string]$servedPlatform.signature)) {
+                throw "Tauri-compatible manifest contract failed (status=$([int]$response.StatusCode); content_type=$servedContentType; content_length=$($response.Content.Headers.ContentLength); body_sha256=$servedHash)"
+            }
+        } finally {
+            $response.Dispose()
+        }
+    } finally {
+        $client.Dispose()
+        $handler.Dispose()
+    }
+    Write-Host "Test 3: PASS (exact Tauri-compatible manifest bytes/schema served)"
 
     # Signal server to stop
     New-Item -ItemType File -Path $stopPath -Force | Out-Null
@@ -122,7 +200,13 @@ Write-Host "Test 4: Regression proof that TcpListener.Close() fails closed..."
 $tempDir4 = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-listener-neg-" + [guid]::NewGuid().ToString("N"))
 New-Item -ItemType Directory -Path $tempDir4 -Force | Out-Null
 $stopPath4 = Join-Path $tempDir4 "stop.signal"
-$negPort = 39183
+$probe4 = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+try {
+    $probe4.Start()
+    $negPort = ([System.Net.IPEndPoint]$probe4.LocalEndpoint).Port
+} finally {
+    $probe4.Stop()
+}
 $negJob = $null
 try {
     $negJob = Start-Job -ScriptBlock {

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -604,7 +604,8 @@ function Invoke-QualifyDownloaded {
         "-CandidateInstallerPath", (Join-Path $bundle $sourceInstaller),
         "-CandidateSignaturePath", (Join-Path $bundle $sourceSignature),
         "-CandidateVersion", $Version,
-        "-CandidatePublicKeyPath", $canonicalPublicKey
+        "-CandidatePublicKeyPath", $canonicalPublicKey,
+        "-EvidencePath", (Join-Path $root "fixture-http-evidence.json")
     ) "exact downloaded previous-v4 to candidate-v4 updater qualification failed"
 
     # Production policy requires a deterministic exact-artifact Defender

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -365,15 +365,8 @@ function Assert-CandidateEvidence([object[]]$Records) {
 
 function Invoke-BuildCandidate {
     Assert-RequestIdentity
-    $runnerKeyPath = if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) {
-        [Environment]::GetEnvironmentVariable("V4_UPDATER_PRIVATE_KEY_PATH", "Process")
-    } else {
-        $UpdaterPrivateKeyPath
-    }
-    if ([string]::IsNullOrWhiteSpace($runnerKeyPath)) {
-        Fail "updater private key path is unavailable; configure V4_UPDATER_PRIVATE_KEY_PATH on the dedicated release runner"
-    }
-    $keyPath = (Resolve-Path -LiteralPath $runnerKeyPath -ErrorAction Stop).Path
+    if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) { Fail "updater private key path is required" }
+    $keyPath = (Resolve-Path -LiteralPath $UpdaterPrivateKeyPath -ErrorAction Stop).Path
     $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
     if ($keyPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) { Fail "updater private key must remain outside workspace" }
     if (-not (Test-Path -LiteralPath $keyPath -PathType Leaf)) { Fail "updater private key path is not a file" }

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -365,8 +365,15 @@ function Assert-CandidateEvidence([object[]]$Records) {
 
 function Invoke-BuildCandidate {
     Assert-RequestIdentity
-    if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) { Fail "updater private key path is required" }
-    $keyPath = (Resolve-Path -LiteralPath $UpdaterPrivateKeyPath -ErrorAction Stop).Path
+    $runnerKeyPath = if ([string]::IsNullOrWhiteSpace($UpdaterPrivateKeyPath)) {
+        [Environment]::GetEnvironmentVariable("V4_UPDATER_PRIVATE_KEY_PATH", "Process")
+    } else {
+        $UpdaterPrivateKeyPath
+    }
+    if ([string]::IsNullOrWhiteSpace($runnerKeyPath)) {
+        Fail "updater private key path is unavailable; configure V4_UPDATER_PRIVATE_KEY_PATH on the dedicated release runner"
+    }
+    $keyPath = (Resolve-Path -LiteralPath $runnerKeyPath -ErrorAction Stop).Path
     $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
     if ($keyPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) { Fail "updater private key must remain outside workspace" }
     if (-not (Test-Path -LiteralPath $keyPath -PathType Leaf)) { Fail "updater private key path is not a file" }
@@ -596,11 +603,11 @@ function Invoke-QualifyDownloaded {
     Invoke-Checked "cargo" @(
         "xtask", "updater-trust", "export-public-key", "--output", $canonicalPublicKey
     ) "canonical updater public-root export failed"
-    $fixtureBundle = Join-Path $root "previous-v4-fixture"
+    $fixtureTargetDir = Join-Path $root "previous-v4-fixture-target"
     Invoke-Checked "pwsh" @(
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", (Join-Path $PSScriptRoot "ci_tauri_update_e2e.ps1"),
-        "-BundleDir", $fixtureBundle,
+        "-FixtureTargetDir", $fixtureTargetDir,
         "-CandidateInstallerPath", (Join-Path $bundle $sourceInstaller),
         "-CandidateSignaturePath", (Join-Path $bundle $sourceSignature),
         "-CandidateVersion", $Version,


### PR DESCRIPTION
Refs #151 and #109.

QA context: production run #12 consumed RC2 after BuildCandidate/CreateDraft/DownloadDraft succeeded and QualifyDownloaded failed because the updater fixture used incompatible BundleDir semantics between CI and production.

This PR is opened to obtain exact-head CI and review evidence. Production remains HOLD.

Acceptance before merge:
- explicit fixture build target is separate from exact downloaded candidate inputs;
- real `v4_release_pipeline.ps1 -State QualifyDownloaded` production-topology rehearsal must actually execute and PASS on this exact head using production-like StateRoot layout (static marker checks alone are insufficient);
- full exact-head CI must pass, including packaged updater fixture + packaged NSIS + release authority + required gate;
- key-path custody change must not reintroduce parent-shell inheritance or expose key path through workflow inputs;
- no production release dispatch.

RC2 remains consumed/audit-only; do not mutate its draft/assets/tag.