### PR TITLE
chore(release): prepare v4.0.0-rc.3

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.2"
+version = "4.0.0-rc.3"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.2"
+version = "4.0.0-rc.3"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",


### PR DESCRIPTION
Prepare the v4.0.0-rc.3 product version from main@b009649d1b61e057e458f30168f7e1745802f32a.\n\nChanges are limited to the canonical desktop Cargo package version and matching workspace lockfile entry.