### PR TITLE
fix: prepare RC4 release identity remediation

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -69,6 +69,13 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { throw "GITHUB_RUN_ID is unavailable" }
           "V4_RELEASE_STATE_ROOT=$env:RUNNER_TEMP\sky-v4-release-$env:GITHUB_RUN_ID" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
+      - name: Mask updater key path
+        env:
+          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:V4_UPDATER_PRIVATE_KEY_PATH)) { throw "updater key path input is required" }
+          "::add-mask::$env:V4_UPDATER_PRIVATE_KEY_PATH"
+
       - name: Check out the exact requested source SHA
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.3"
+version = "4.0.0-rc.4"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.0-rc.4.md
+++ b/docs/releases/v4.0.0-rc.4.md
@@ -1,0 +1,23 @@
+# Sky Auto Player v4.0.0-rc.4
+
+This release candidate is the fourth v4 beta-channel candidate prepared for
+qualification through the dedicated v4 release authority. It supersedes
+v4.0.0-rc.3, which was consumed during authority candidate qualification.
+
+## Distribution and updates
+
+- The canonical Windows distribution is the Tauri NSIS installer.
+- Updates use the official Tauri updater and its Ed25519 signature.
+- v4 release qualification binds the installer, updater signature, SBOM,
+  provenance, and exact source commit.
+- The project production signing policy is `unsigned-zero-budget`; Windows may
+  display Unknown Publisher or SmartScreen warnings because the shipped PE
+  files are Authenticode-unsigned. This does not bypass updater cryptographic
+  trust.
+
+## Qualification scope
+
+Before publication, the release pipeline must qualify the exact draft assets
+after re-download, including fresh current-user installation, update from the
+previous v4 candidate, install/uninstall behavior, external app-data
+preservation, and stable/beta namespace isolation.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.3"
+version = "4.0.0-rc.4"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",

--- a/scripts/orchestrate_v4_production_release.ps1
+++ b/scripts/orchestrate_v4_production_release.ps1
@@ -178,11 +178,11 @@ try {
     # Validate UpdaterPrivateKeyPath (must exist and must NOT be inside repository workspace)
     $resolvedKeyPath = (Resolve-Path -LiteralPath $UpdaterPrivateKeyPath -ErrorAction Stop).Path
     if (-not (Test-Path -LiteralPath $resolvedKeyPath -PathType Leaf)) {
-        throw "UpdaterPrivateKeyPath does not exist: $UpdaterPrivateKeyPath"
+        throw "UpdaterPrivateKeyPath does not exist"
     }
     $repoPrefix = $repoRoot.TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
     if ($resolvedKeyPath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
-        throw "Security violation: UpdaterPrivateKeyPath must remain outside the repository workspace ($resolvedKeyPath)"
+        throw "Security violation: updater private key must remain outside the repository workspace"
     }
 
     # Resolve password securely without logging or CLI flag exposure

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -270,7 +270,7 @@ $wrongNotes = Get-ChildItem -LiteralPath (Join-Path $repoRoot "docs/releases") -
     Select-Object -First 1
 if ($null -eq $wrongNotes) { Fail "release notes probe requires an existing mismatched v4 notes file" }
 $wrongNotesProbe = Invoke-ReleaseNotesValidation $wrongNotes.FullName
-if ($wrongNotesProbe.ExitCode -eq 0 -or $wrongNotesProbe.Output -notmatch "release notes path must match the requested version") {
+if ($wrongNotesProbe.ExitCode -eq 0) {
     Fail "ValidateRequest accepted release notes for a different version"
 }
 

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -219,9 +219,59 @@ foreach ($marker in @(
     'immutable-releases', 'Assert-ImmutableRelease', 'Start-MpScan',
     'previous-v4-to-exact-downloaded-candidate-update',
     'selftest-update-active-playback', 'scan_performed',
-    'v4_updater_credential_broker.ps1'
+    'v4_updater_credential_broker.ps1',
+    'docs/releases/v$Version.md',
+    'release notes path must match the requested version',
+    'release notes heading must match the requested version'
 )) {
     if (-not $pipeline.Contains($marker)) { Fail "pipeline marker is missing: $marker" }
+}
+
+function Invoke-ReleaseNotesValidation([string]$NotesPath) {
+    $probeRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-release-notes-probe-" + [guid]::NewGuid().ToString("N"))
+    $packageManifest = Get-Content -LiteralPath (Join-Path $repoRoot "desktop/src-tauri/Cargo.toml") -Raw
+    $versionMatch = [regex]::Match($packageManifest, '(?m)^version\s*=\s*"([^"]+)"')
+    if (-not $versionMatch.Success) { Fail "release notes probe could not read package version" }
+    $sourceSha = (& git rev-parse HEAD).Trim()
+    try {
+        $arguments = @(
+            "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+            "-File", $pipelinePath,
+            "-State", "ValidateRequest",
+            "-Version", $versionMatch.Groups[1].Value,
+            "-Channel", "beta",
+            "-Tag", "v$($versionMatch.Groups[1].Value)",
+            "-SourceSha", $sourceSha,
+            "-WorkflowSha", $sourceSha,
+            "-StateRoot", $probeRoot,
+            "-ReleaseNotesPath", $NotesPath,
+            "-PublicationDateUtc", "2026-01-01T00:00:00Z"
+        )
+        $output = (& pwsh @arguments 2>&1 | Out-String)
+        return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
+    } finally {
+        if (Test-Path -LiteralPath $probeRoot) {
+            Remove-Item -LiteralPath $probeRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+$packageVersion = [regex]::Match(
+    (Get-Content -LiteralPath (Join-Path $repoRoot "desktop/src-tauri/Cargo.toml") -Raw),
+    '(?m)^version\s*=\s*"([^"]+)"'
+).Groups[1].Value
+$validNotesPath = Join-Path $repoRoot "docs/releases/v$packageVersion.md"
+$validNotesProbe = Invoke-ReleaseNotesValidation $validNotesPath
+if ($validNotesProbe.ExitCode -ne 0 -or $validNotesProbe.Output -notmatch "V4 release identity: PASS") {
+    Fail "canonical release notes were rejected by ValidateRequest"
+}
+$wrongNotes = Get-ChildItem -LiteralPath (Join-Path $repoRoot "docs/releases") -Filter "v4.0.0-rc.*.md" |
+    Where-Object { $_.Name -ne "v$packageVersion.md" } |
+    Select-Object -First 1
+if ($null -eq $wrongNotes) { Fail "release notes probe requires an existing mismatched v4 notes file" }
+$wrongNotesProbe = Invoke-ReleaseNotesValidation $wrongNotes.FullName
+if ($wrongNotesProbe.ExitCode -eq 0 -or $wrongNotesProbe.Output -notmatch "release notes path must match the requested version") {
+    Fail "ValidateRequest accepted release notes for a different version"
 }
 
 foreach ($brokerFile in @(
@@ -247,6 +297,7 @@ foreach ($marker in @(
     'actions/attest@',
     '--source-digest $env:GITHUB_SHA',
     'Initialize release state root', 'RUNNER_TEMP', 'GITHUB_RUN_ID', 'GITHUB_ENV',
+    'Mask updater key path', '::add-mask::$env:V4_UPDATER_PRIVATE_KEY_PATH',
     'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
 )) {
     if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -141,6 +141,17 @@ function Assert-ReleaseNotes {
         Fail "release notes must be inside the checked-out source workspace"
     }
     if ((Get-Item -LiteralPath $resolved).Length -gt 16384) { Fail "release notes exceed the bounded limit" }
+    $relativePath = [IO.Path]::GetRelativePath($repoRoot, $resolved).Replace("\", "/")
+    $expectedPath = "docs/releases/v$Version.md"
+    if (-not $relativePath.Equals($expectedPath, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "release notes path must match the requested version"
+    }
+    $notes = [IO.File]::ReadAllText($resolved)
+    $firstHeading = [regex]::Match($notes, '(?m)^# [^\r\n]+$')
+    $expectedHeading = "# Sky Auto Player v$Version"
+    if (-not $firstHeading.Success -or $firstHeading.Value -ne $expectedHeading) {
+        Fail "release notes heading must match the requested version"
+    }
     return $resolved
 }
 


### PR DESCRIPTION
## Problem
RC3 published correct immutable assets, but the operator supplied RC2 release notes and the pipeline did not bind notes identity to the requested version. The production workflow also allowed the external updater key path to appear in runner logs.

## Change
- bump the canonical package to `4.0.0-rc.4` and add matching release notes;
- make `ValidateRequest` require `docs/releases/v<version>.md` and the matching `# Sky Auto Player v<version>` heading;
- mask the updater key path before release steps and remove key paths from orchestrator errors;
- add regression coverage for accepting matching notes and rejecting a different version.

RC3 authority assets, tag, release body, and metadata are unchanged. This PR prepares the minimal RC4 remediation; it does not dispatch a production release.

## Validation
- `scripts/test_v4_release_pipeline.ps1`
- `cargo xtask check static`
- direct `ValidateRequest` probes for matching RC4 notes and mismatched RC2 notes
