### PR TITLE
fix: move RC5 updater key path to runner config

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -20,10 +20,6 @@ on:
         description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
         required: true
         type: string
-      updater_private_key_path:
-        description: "Path to the externally stored updater key on the dedicated runner"
-        required: true
-        type: string
       release_notes_path:
         description: "Bounded release notes file in the checked-out source"
         required: true
@@ -69,12 +65,10 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { throw "GITHUB_RUN_ID is unavailable" }
           "V4_RELEASE_STATE_ROOT=$env:RUNNER_TEMP\sky-v4-release-$env:GITHUB_RUN_ID" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Mask updater key path
-        env:
-          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
+      - name: Verify runner-local updater key configuration
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:V4_UPDATER_PRIVATE_KEY_PATH)) { throw "updater key path input is required" }
-          "::add-mask::$env:V4_UPDATER_PRIVATE_KEY_PATH"
+          if ([string]::IsNullOrWhiteSpace($env:V4_UPDATER_PRIVATE_KEY_PATH)) { throw "runner-local updater key configuration is unavailable" }
+          if (-not (Test-Path -LiteralPath $env:V4_UPDATER_PRIVATE_KEY_PATH -PathType Leaf)) { throw "runner-local updater key configuration does not reference a file" }
 
       - name: Check out the exact requested source SHA
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -114,8 +108,6 @@ jobs:
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
 
       - name: Build and qualify the single production candidate
-        env:
-          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
         run: |
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
             -State BuildCandidate `

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.4"
+version = "4.0.0-rc.5"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.0-rc.5.md
+++ b/docs/releases/v4.0.0-rc.5.md
@@ -1,0 +1,23 @@
+# Sky Auto Player v4.0.0-rc.5
+
+This release candidate is the fifth v4 beta-channel candidate prepared for
+qualification through the dedicated v4 release authority. It supersedes
+v4.0.0-rc.4, which was consumed during authority candidate qualification.
+
+## Distribution and updates
+
+- The canonical Windows distribution is the Tauri NSIS installer.
+- Updates use the official Tauri updater and its Ed25519 signature.
+- v4 release qualification binds the installer, updater signature, SBOM,
+  provenance, and exact source commit.
+- The project production signing policy is `unsigned-zero-budget`; Windows may
+  display Unknown Publisher or SmartScreen warnings because the shipped PE
+  files are Authenticode-unsigned. This does not bypass updater cryptographic
+  trust.
+
+## Qualification scope
+
+Before publication, the release pipeline must qualify the exact draft assets
+after re-download, including fresh current-user installation, update from the
+previous v4 candidate, install/uninstall behavior, external app-data
+preservation, and stable/beta namespace isolation.

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -123,7 +123,9 @@ point. It is manual, runs on the dedicated/single-tenant Windows runner, and
 uses `V4_RELEASE_AUTHORITY_TOKEN` for release/assets/channel metadata writes.
 The source `GITHUB_TOKEN` and OIDC permissions remain separate and are used for
 source-bound attestations. The updater private key is not a GitHub secret: the
-workflow receives only a path to the externally stored key on the runner.
+production workflow does not accept a key-path input and reads
+`V4_UPDATER_PRIVATE_KEY_PATH` only from dedicated runner-local process
+configuration.
 The authority token contract is bounded to the dedicated repository only, with
 the minimum Administration read and Contents read/write capability needed to
 inspect immutable-release policy, create/read/publish release records, upload

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -285,7 +285,9 @@ Step 8: Evidence Emission & Self-Validation
 
 The manual production entry point is `.github/workflows/release-v4.yml`. It
 accepts an explicit version, channel, `v<version>` tag, source SHA, notes path,
-external updater-key path, and UTC publication timestamp. The workflow
+and UTC publication timestamp. The dedicated runner supplies
+`V4_UPDATER_PRIVATE_KEY_PATH` from runner-local process configuration; this is
+not a workflow input. The workflow
 requires the checked-out commit and workflow SHA to equal the requested source
 SHA, then executes these fail-closed states:
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.4"
+version = "4.0.0-rc.5"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -450,8 +450,8 @@ fn v4_release_pipeline_contract_source(
         "attestations: write",
         "V4_RELEASE_AUTHORITY_TOKEN",
         "ref: ${{ inputs.source_sha }}",
-        "updater_private_key_path:",
-        "inputs.updater_private_key_path",
+        "Verify runner-local updater key configuration",
+        "V4_UPDATER_PRIVATE_KEY_PATH",
         "-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH",
         "persist-credentials: false",
         "actions/attest@",
@@ -501,6 +501,10 @@ fn v4_release_pipeline_contract_source(
         "secrets.V4_UPDATER_PASSWORD",
         "updater_password_env",
         "credential_target",
+        "updater_private_key_path:",
+        "inputs.updater_private_key_path",
+        "Mask updater key path",
+        "::add-mask::",
         "Sky-Auto-Player-Updater.exe",
         "MANIFEST.json.sig",
         ".github/workflows/release.yml",
@@ -3212,8 +3216,8 @@ jobs:
   release:
     runs-on: [self-hosted, windows, v4-release, single-tenant]
     ref: ${{ inputs.source_sha }}
-    updater_private_key_path:
-    inputs.updater_private_key_path
+    Verify runner-local updater key configuration
+    V4_UPDATER_PRIVATE_KEY_PATH
     -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
     persist-credentials: false
     env: V4_RELEASE_AUTHORITY_TOKEN

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -56,8 +56,8 @@ if (-not $pipeline.Contains("FixtureTargetDir")) {
     Fail "production qualification must pass an explicit fixture target directory"
 }
 foreach ($marker in @(
-    'updater_private_key_path:',
-    'inputs.updater_private_key_path',
+    'runner-local updater key configuration',
+    'V4_UPDATER_PRIVATE_KEY_PATH',
     '-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH'
 )) {
     if (-not $workflow.Contains($marker)) {
@@ -297,7 +297,7 @@ foreach ($marker in @(
     'actions/attest@',
     '--source-digest $env:GITHUB_SHA',
     'Initialize release state root', 'RUNNER_TEMP', 'GITHUB_RUN_ID', 'GITHUB_ENV',
-    'Mask updater key path', '::add-mask::$env:V4_UPDATER_PRIVATE_KEY_PATH',
+    'Verify runner-local updater key configuration',
     'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
 )) {
     if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }
@@ -308,7 +308,11 @@ foreach ($forbidden in @(
     'secrets.UPDATER_PRIVATE_KEY', 'secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD',
     'secrets.UPDATER_PASSWORD', 'secrets.V4_UPDATER_PASSWORD',
     'updater_password_env', 'credential_target',
-    'V4_RELEASE_STATE_ROOT: ${{ runner.temp }}'
+    'V4_RELEASE_STATE_ROOT: ${{ runner.temp }}',
+    'updater_private_key_path:',
+    'inputs.updater_private_key_path',
+    'Mask updater key path',
+    '::add-mask::'
 )) {
     if ($workflow.Contains($forbidden)) { Fail "forbidden production workflow marker remains: $forbidden" }
 }


### PR DESCRIPTION
## Scope

Move the production updater key-path contract from a workflow dispatch input to the dedicated runner's process environment. The workflow verifies `V4_UPDATER_PRIVATE_KEY_PATH` without echoing it, and BuildCandidate inherits it directly.

This also adds static contract coverage rejecting the old input and mask step, bumps the canonical package and notes to `4.0.0-rc.5`, and updates the active release documentation.

## Validation

- `scripts/test_v4_release_pipeline.ps1` PASS
- `cargo xtask check static` PASS
- PowerShell parse PASS
- `git diff --check` PASS

RC4 remains published, immutable, and unchanged. Do not dispatch production RC5 from this PR; production dispatch requires separate exact-head CI and release authorization.
