### PR TITLE
fix: prevent updater key paths in verifier output

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.5"
+version = "4.0.0-rc.6"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.0-rc.6.md
+++ b/docs/releases/v4.0.0-rc.6.md
@@ -1,0 +1,23 @@
+# Sky Auto Player v4.0.0-rc.6
+
+This release candidate is the sixth v4 beta-channel candidate prepared for
+qualification through the dedicated v4 release authority. It supersedes
+v4.0.0-rc.5, which was consumed during authority candidate qualification.
+
+## Distribution and updates
+
+- The canonical Windows distribution is the Tauri NSIS installer.
+- Updates use the official Tauri updater and its Ed25519 signature.
+- v4 release qualification binds the installer, updater signature, SBOM,
+  provenance, and exact source commit.
+- The project production signing policy is `unsigned-zero-budget`; Windows may
+  display Unknown Publisher or SmartScreen warnings because the shipped PE
+  files are Authenticode-unsigned. This does not bypass updater cryptographic
+  trust.
+
+## Qualification scope
+
+Before publication, the release pipeline must qualify the exact draft assets
+after re-download, including fresh current-user installation, update from the
+previous v4 candidate, install/uninstall behavior, external app-data
+preservation, and stable/beta namespace isolation.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.5"
+version = "4.0.0-rc.6"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1364,6 +1364,7 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
     for marker in [
         "V4_TEST_ONLY_PASS_PHRASE_MARKER",
         "verify_v4_updater_private_key.ps1",
+        "Assert-NoKeyPath",
         "Verifier mismatch path",
         "Verifier success path",
         "throwaway.key",
@@ -1384,6 +1385,7 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "UpdaterPrivateKeyPath",
         "ApprovedSignerThumbprint",
         "updater-trust verify-private-key",
+        "Redact-UpdaterVerifierOutput",
         "updater-trust verify-signature",
         "V4_QUALIFICATION_EVIDENCE.json",
         "V4_PRODUCTION_RELEASE_EVIDENCE.json",
@@ -1422,6 +1424,7 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "Channel policy validation fails closed on invalid SemVer / channel",
         "Mutually exclusive provider configuration fails closed",
         "Wrong updater private key fails pre-flight verification before packaging",
+        "Assert-NoThrowawayKeyPath",
         "Secret values are not emitted by expected error paths",
         "Inherited signing key environment fails closed",
         "Stale candidate artifacts and evidence are purged before packaging",

--- a/scripts/orchestrate_v4_production_release.ps1
+++ b/scripts/orchestrate_v4_production_release.ps1
@@ -71,6 +71,30 @@ function Restore-SavedEnvironment {
     }
 }
 
+function Redact-UpdaterVerifierOutput {
+    param(
+        [AllowEmptyString()]
+        [string]$Output,
+        [string]$KeyFile,
+        [string]$Password
+    )
+
+    $redacted = $Output
+    $keyCandidates = @(
+        $KeyFile,
+        [IO.Path]::GetFullPath($KeyFile),
+        ([IO.Path]::GetFullPath($KeyFile) -replace '\\', '/')
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($candidate in $keyCandidates) {
+        $redacted = $redacted -replace [regex]::Escape($candidate), '[REDACTED]'
+    }
+    if (-not [string]::IsNullOrEmpty($Password)) {
+        $redacted = $redacted.Replace($Password, '[REDACTED]')
+    }
+    return $redacted
+}
+
 function Get-CanonicalUpdaterKeyId {
     $tauriConfPath = Join-Path $repoRoot "desktop\src-tauri\tauri.conf.json"
     $tauriConf = Get-Content -LiteralPath $tauriConfPath -Raw | ConvertFrom-Json
@@ -253,8 +277,16 @@ try {
         $prevPwd = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
         $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $passwordValue
         try {
-            & cargo xtask updater-trust verify-private-key --key-file $resolvedKeyPath
-            if ($LASTEXITCODE -ne 0) {
+            $verificationOutput = & cargo xtask updater-trust verify-private-key --key-file $resolvedKeyPath 2>&1 | Out-String
+            $verificationExitCode = $LASTEXITCODE
+            $verificationOutput = Redact-UpdaterVerifierOutput `
+                -Output $verificationOutput `
+                -KeyFile $resolvedKeyPath `
+                -Password $passwordValue
+            if (-not [string]::IsNullOrWhiteSpace($verificationOutput)) {
+                Write-Output $verificationOutput.TrimEnd()
+            }
+            if ($verificationExitCode -ne 0) {
                 throw "Pre-packaging updater key verification failed: private key does not match canonical v4 public root"
             }
         } finally {

--- a/scripts/test_v4_production_orchestrator.ps1
+++ b/scripts/test_v4_production_orchestrator.ps1
@@ -38,6 +38,24 @@ function Restore-SavedEnvironment {
     }
 }
 
+function Assert-NoThrowawayKeyPath {
+    param(
+        [string]$Name,
+        [string]$Output
+    )
+
+    $candidates = @(
+        $throwawayKeyPath,
+        [IO.Path]::GetFullPath($throwawayKeyPath),
+        ([IO.Path]::GetFullPath($throwawayKeyPath) -replace '\\', '/')
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+    foreach ($candidate in $candidates) {
+        if ($Output.IndexOf($candidate, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            throw "FAILED: $Name emitted the throwaway updater key path"
+        }
+    }
+}
+
 try {
     # Ensure runner environment is clean of inherited signing keys before tests run
     Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
@@ -240,6 +258,7 @@ try {
     if ($out6 -notmatch "Pre-packaging updater key verification failed") {
         throw "FAILED: Did not fail closed on updater key pre-flight check. Actual output:`n$out6"
     }
+    Assert-NoThrowawayKeyPath -Name 'Orchestrator mismatch path' -Output $out6
     Write-Host "Test 6: PASS"
 
     # Test 7: Secret values are never emitted by error paths
@@ -263,6 +282,7 @@ try {
     if ($out7.Contains($secretPassword)) {
         throw "FAILED: Secret password was leaked to output/error stream!"
     }
+    Assert-NoThrowawayKeyPath -Name 'Orchestrator secret-error path' -Output $out7
     Write-Host "Test 7: PASS"
 
     # Test 8: Inherited signing key environment fails closed without leaking secret
@@ -356,6 +376,7 @@ try {
     if (-not $out9.Contains($keyFailMarker)) {
         throw "FAILED: Pre-packaging updater key verification failure marker not found. Actual output:`n$out9"
     }
+    Assert-NoThrowawayKeyPath -Name 'Orchestrator purge/key-failure path' -Output $out9
 
     $purgeIndex = $out9.IndexOf($purgeMarker)
     $keyFailIndex = $out9.IndexOf($keyFailMarker)

--- a/scripts/test_v4_updater_private_key.ps1
+++ b/scripts/test_v4_updater_private_key.ps1
@@ -22,6 +22,25 @@ function Assert-NoPasswordMarker {
     }
 }
 
+function Assert-NoKeyPath {
+    param(
+        [string]$Name,
+        [string]$Output,
+        [string]$KeyPath
+    )
+
+    $candidates = @(
+        $KeyPath,
+        [IO.Path]::GetFullPath($KeyPath),
+        ([IO.Path]::GetFullPath($KeyPath) -replace '\\', '/')
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+    foreach ($candidate in $candidates) {
+        if ($Output.IndexOf($candidate, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+            throw "FAILED: $Name emitted the throwaway key path"
+        }
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
 
@@ -50,6 +69,7 @@ try {
         throw 'FAILED: Throwaway updater key unexpectedly passed canonical-root verification'
     }
     Assert-NoPasswordMarker -Name 'Verifier mismatch path' -Output $failureOutput
+    Assert-NoKeyPath -Name 'Verifier mismatch path' -Output $failureOutput -KeyPath $throwawayKeyPath
     if ($failureOutput -notmatch '\[FAIL\]') {
         throw "FAILED: Verifier mismatch path did not report failure. Output:`n$failureOutput"
     }
@@ -72,6 +92,7 @@ exit /b 1
     $successExitCode = $LASTEXITCODE
 
     Assert-NoPasswordMarker -Name 'Verifier success path' -Output $successOutput
+    Assert-NoKeyPath -Name 'Verifier success path' -Output $successOutput -KeyPath $throwawayKeyPath
     if ($successExitCode -ne 0) {
         throw "FAILED: Verifier success path failed with exit code $successExitCode. Output:`n$successOutput"
     }

--- a/scripts/verify_v4_updater_private_key.ps1
+++ b/scripts/verify_v4_updater_private_key.ps1
@@ -14,17 +14,45 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 
+function Redact-UpdaterVerifierOutput {
+    param(
+        [AllowEmptyString()]
+        [string]$Output,
+        [string]$KeyFile,
+        [string]$Password
+    )
+
+    $redacted = $Output
+    $keyCandidates = @(
+        $KeyFile,
+        [IO.Path]::GetFullPath($KeyFile),
+        ([IO.Path]::GetFullPath($KeyFile) -replace '\\', '/')
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+
+    foreach ($candidate in $keyCandidates) {
+        $redacted = $redacted -replace [regex]::Escape($candidate), '[REDACTED]'
+    }
+    if (-not [string]::IsNullOrEmpty($Password)) {
+        $redacted = $redacted.Replace($Password, '[REDACTED]')
+    }
+    return $redacted
+}
+
 # 1. Resolve key path: strictly require a file path (no raw key in env vars or command lines)
-$keyFile = if (-not [string]::IsNullOrWhiteSpace($KeyPath)) {
-    (Resolve-Path -LiteralPath $KeyPath -ErrorAction Stop).Path
-} elseif (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
-    (Resolve-Path -LiteralPath $env:TAURI_SIGNING_PRIVATE_KEY_PATH -ErrorAction Stop).Path
-} else {
-    throw "No updater private key path specified. Provide -KeyPath <path> or set TAURI_SIGNING_PRIVATE_KEY_PATH environment variable."
+try {
+    $keyFile = if (-not [string]::IsNullOrWhiteSpace($KeyPath)) {
+        (Resolve-Path -LiteralPath $KeyPath -ErrorAction Stop).Path
+    } elseif (-not [string]::IsNullOrWhiteSpace($env:TAURI_SIGNING_PRIVATE_KEY_PATH)) {
+        (Resolve-Path -LiteralPath $env:TAURI_SIGNING_PRIVATE_KEY_PATH -ErrorAction Stop).Path
+    } else {
+        throw "No updater private key path specified"
+    }
+} catch {
+    throw "Unable to resolve updater private key file"
 }
 
 if (-not (Test-Path -LiteralPath $keyFile -PathType Leaf)) {
-    throw "Private key file does not exist: $keyFile"
+    throw "Private key file does not exist"
 }
 
 # 2. Resolve password: prefer credential broker if requested, or specified environment variable, or secure interactive prompt
@@ -55,12 +83,10 @@ $prevPwd = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = $passwordValue
 try {
     # The child owns verification and emits only sanitized status. Keep a final
-    # redaction guard around the boundary so this process never forwards a
-    # password if a dependency unexpectedly includes it in diagnostic output.
+    # redaction guard around the boundary so this process never forwards a key
+    # path or password if a dependency unexpectedly includes either in output.
     $verificationOutput = & cargo xtask updater-trust verify-private-key --key-file $keyFile 2>&1 | Out-String
-    if (-not [string]::IsNullOrEmpty($passwordValue)) {
-        $verificationOutput = $verificationOutput.Replace($passwordValue, "[REDACTED]")
-    }
+    $verificationOutput = Redact-UpdaterVerifierOutput -Output $verificationOutput -KeyFile $keyFile -Password $passwordValue
     Write-Output $verificationOutput.TrimEnd()
     if ($LASTEXITCODE -ne 0) {
         Write-Host "[FAIL] Local updater private key does not match canonical production v4 root"
@@ -69,10 +95,7 @@ try {
     Write-Host "[PASS] Local updater private key matches canonical production v4 root"
     exit 0
 } catch {
-    $errorMessage = $_.Exception.Message
-    if (-not [string]::IsNullOrEmpty($passwordValue)) {
-        $errorMessage = $errorMessage.Replace($passwordValue, "[REDACTED]")
-    }
+    $errorMessage = Redact-UpdaterVerifierOutput -Output $_.Exception.Message -KeyFile $keyFile -Password $passwordValue
     Write-Host "[FAIL] Updater private key verification failed: $errorMessage"
     exit 1
 } finally {


### PR DESCRIPTION
Redact updater key paths and passphrases from captured verifier output before stdout or error emission. Apply the same boundary to the production BuildCandidate orchestrator path, add success and failure throwaway-key-path regression assertions, and bump canonical package/notes to RC6. Validation: verifier regression, orchestrator contract suite, release pipeline contract, cargo xtask check static, git diff --check.