### PR TITLE
Prepare v4.0.0 GA release

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.6"
+version = "4.0.0"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -1,0 +1,22 @@
+# Sky Auto Player v4.0.0
+
+Sky Auto Player v4.0.0 is the stable v4 release prepared through the
+dedicated v4 release authority and its governed qualification transaction.
+
+## Distribution and updates
+
+- The canonical Windows distribution is the Tauri NSIS installer.
+- Updates use the official Tauri updater and its Ed25519 signature.
+- The release binds the installer, updater signature, SBOM, provenance, and
+  exact source commit.
+- The project production signing policy is `unsigned-zero-budget`; Windows may
+  display Unknown Publisher or SmartScreen warnings because the shipped PE
+  files are Authenticode-unsigned. This does not bypass updater cryptographic
+  trust.
+
+## Qualification scope
+
+The release transaction qualifies the exact draft assets after re-download,
+including fresh current-user installation, update from the previous v4
+release, install/uninstall behavior, external app-data preservation, and
+stable/beta namespace isolation.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0-rc.6"
+version = "4.0.0"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",

--- a/scripts/test_v4_production_orchestrator.ps1
+++ b/scripts/test_v4_production_orchestrator.ps1
@@ -74,6 +74,7 @@ try {
         throw "Failed to parse Cargo.toml version"
     }
     $currentVersion = $Matches[1].Trim()
+    $currentChannel = if ($currentVersion.Contains("-")) { "beta" } else { "stable" }
 
     . (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
 
@@ -141,7 +142,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha "0000000000000000000000000000000000000000" `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -168,7 +169,7 @@ try {
             -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
             -ExpectedSourceSha $currentSha `
             -Version $currentVersion `
-            -Channel "beta" `
+            -Channel $currentChannel `
             -UpdaterPrivateKeyPath $throwawayKeyPath `
             -AuthenticodeProvider "custom" `
             -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -196,7 +197,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version "9.9.9" `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -206,19 +207,25 @@ try {
         throw "FAILED: Did not fail closed on Cargo.toml version mismatch"
     }
 
-    # 4b. Stable channel rejects prerelease version
+    # 4b. The opposite channel policy rejects the current version
+    $invalidChannel = if ($currentChannel -eq "stable") { "beta" } else { "stable" }
+    $expectedPolicyError = if ($invalidChannel -eq "stable") {
+        "Channel 'stable' rejects prerelease version"
+    } else {
+        "Channel 'beta' requires a prerelease SemVer version"
+    }
     $out4b = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass `
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "stable" `
+        -Channel $invalidChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
         -AuthenticodeProviderScript $dummyProviderScript 2>&1 | Out-String
-    if ($LASTEXITCODE -eq 0) { throw "FAILED: Orchestrator accepted prerelease version on stable channel" }
-    if ($out4b -notmatch "Channel 'stable' rejects prerelease version") {
-        throw "FAILED: Did not fail closed on stable channel with prerelease version"
+    if ($LASTEXITCODE -eq 0) { throw "FAILED: Orchestrator accepted current version on invalid channel" }
+    if ($out4b -notmatch [regex]::Escape($expectedPolicyError)) {
+        throw "FAILED: Did not fail closed on invalid channel policy"
     }
     Write-Host "Test 4: PASS"
 
@@ -228,7 +235,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -247,7 +254,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -270,7 +277,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -UpdaterPasswordEnv "MY_TEST_KEY_PASSWORD" `
         -AuthenticodeProvider "custom" `
@@ -295,7 +302,7 @@ try {
             -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
             -ExpectedSourceSha $currentSha `
             -Version $currentVersion `
-            -Channel "beta" `
+            -Channel $currentChannel `
             -UpdaterPrivateKeyPath $throwawayKeyPath `
             -AuthenticodeProvider "custom" `
             -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -320,7 +327,7 @@ try {
             -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
             -ExpectedSourceSha $currentSha `
             -Version $currentVersion `
-            -Channel "beta" `
+            -Channel $currentChannel `
             -UpdaterPrivateKeyPath $throwawayKeyPath `
             -AuthenticodeProvider "custom" `
             -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -357,7 +364,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -472,7 +479,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -490,7 +497,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint "0123456789ABCDEF0123456789ABCDEF01234567" `
@@ -515,7 +522,7 @@ try {
         -File (Join-Path $PSScriptRoot "orchestrate_v4_production_release.ps1") `
         -ExpectedSourceSha $currentSha `
         -Version $currentVersion `
-        -Channel "beta" `
+        -Channel $currentChannel `
         -UpdaterPrivateKeyPath $throwawayKeyPath `
         -AuthenticodeProvider "custom" `
         -ApprovedSignerThumbprint $testThumbprint `

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -234,12 +234,13 @@ function Invoke-ReleaseNotesValidation([string]$NotesPath) {
     if (-not $versionMatch.Success) { Fail "release notes probe could not read package version" }
     $sourceSha = (& git rev-parse HEAD).Trim()
     try {
+        $probeChannel = if ($versionMatch.Groups[1].Value.Contains("-")) { "beta" } else { "stable" }
         $arguments = @(
             "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
             "-File", $pipelinePath,
             "-State", "ValidateRequest",
             "-Version", $versionMatch.Groups[1].Value,
-            "-Channel", "beta",
+            "-Channel", $probeChannel,
             "-Tag", "v$($versionMatch.Groups[1].Value)",
             "-SourceSha", $sourceSha,
             "-WorkflowSha", $sourceSha,


### PR DESCRIPTION
Prepare the stable v4.0.0 GA transaction from RC6-accepted main.

Changes:
- bump the canonical package and lockfile version to 4.0.0;
- add canonical docs/releases/v4.0.0.md with the exact GA heading;
- keep release notes validation probes valid for both stable finals and beta prereleases.

Validation:
- scripts/test_v4_release_pipeline.ps1
- cargo xtask check static
- git diff --check

The production transaction remains unchanged and will use the exact post-merge main SHA, stable channel, v4.0.0 tag, and canonical notes path.
