### PR TITLE
security(release): harden signing runner trust boundary

### DIFF
--- a/.github/workflows/rehearse-v4-production-topology.yml
+++ b/.github/workflows/rehearse-v4-production-topology.yml
@@ -20,11 +20,6 @@ on:
         description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
         required: true
         type: string
-      updater_private_key_path:
-        description: "Path to the externally stored updater key on the dedicated runner"
-        required: true
-        type: string
-
 permissions:
   contents: read
 
@@ -37,10 +32,33 @@ defaults:
     shell: pwsh
 
 jobs:
+  rehearsal-dispatch-boundary:
+    name: Validate canonical rehearsal dispatch context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fail closed outside the canonical default branch
+        shell: bash
+        env:
+          EXPECTED_REPOSITORY: pumni/Sky-Auto-Player
+          EXPECTED_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = "workflow_dispatch" || { echo "rehearsal requires workflow_dispatch" >&2; exit 1; }
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_REPOSITORY" || { echo "rehearsal repository is not canonical" >&2; exit 1; }
+          test "$GITHUB_REF" = "refs/heads/main" || { echo "rehearsal must be dispatched from refs/heads/main" >&2; exit 1; }
+          test "$EXPECTED_DEFAULT_BRANCH" = "main" || { echo "canonical repository default branch must be main" >&2; exit 1; }
+
   rehearsal:
     name: V4 production-topology rehearsal
+    needs: rehearsal-dispatch-boundary
+    if: needs.rehearsal-dispatch-boundary.result == 'success'
     # This is the same dedicated/single-tenant runner class used by production.
     runs-on: [self-hosted, windows, v4-release, single-tenant]
+    environment: v4-production-release
+    permissions:
+      contents: read
     env:
       V4_REHEARSAL_VERSION: ${{ inputs.version }}
       V4_REHEARSAL_CHANNEL: ${{ inputs.channel }}
@@ -64,12 +82,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Verify isolated rehearsal runner boundary
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/verify_v4_release_runner.ps1 `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH `
+            -StateRoot $env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT
+
       - name: Verify dedicated runner tools
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
 
       - name: Build one non-production candidate with the production builder
-        env:
-          V4_UPDATER_PRIVATE_KEY_PATH: ${{ inputs.updater_private_key_path }}
         run: |
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
             -State BuildCandidate `
@@ -90,5 +112,21 @@ jobs:
             -Channel $env:V4_REHEARSAL_CHANNEL `
             -Tag $env:V4_REHEARSAL_TAG `
             -SourceSha $env:V4_REHEARSAL_SOURCE_SHA `
-            -WorkflowSha $env:V4_REHEARSAL_WORKFLOW_SHA `
-            -KeepStateOnFailure
+            -WorkflowSha $env:V4_REHEARSAL_WORKFLOW_SHA
+
+      - name: Preserve bounded rehearsal evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v4-production-topology-rehearsal-${{ github.run_id }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}\sky-v4-production-topology-rehearsal-${{ github.run_id }}\candidate\*.json
+            ${{ runner.temp }}\sky-v4-production-topology-rehearsal-${{ github.run_id }}\qualification\*.json
+
+      - name: Clean runner-local rehearsal state
+        if: always()
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/cleanup_v4_release_state.ps1 `
+            -StateRoot $env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -41,8 +41,28 @@ defaults:
     shell: pwsh
 
 jobs:
+  release-dispatch-boundary:
+    name: Validate canonical production dispatch context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fail closed outside the canonical default branch
+        shell: bash
+        env:
+          EXPECTED_REPOSITORY: pumni/Sky-Auto-Player
+          EXPECTED_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = "workflow_dispatch" || { echo "release requires workflow_dispatch" >&2; exit 1; }
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_REPOSITORY" || { echo "release repository is not canonical" >&2; exit 1; }
+          test "$GITHUB_REF" = "refs/heads/main" || { echo "release must be dispatched from refs/heads/main" >&2; exit 1; }
+          test "$EXPECTED_DEFAULT_BRANCH" = "main" || { echo "canonical repository default branch must be main" >&2; exit 1; }
+
   release:
     name: V4 production release state machine
+    needs: release-dispatch-boundary
+    if: needs.release-dispatch-boundary.result == 'success'
     # This label set is intentionally narrower than a general Windows pool.
     # It identifies the accepted dedicated/single-tenant release runner.
     runs-on: [self-hosted, windows, v4-release, single-tenant]
@@ -67,17 +87,18 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { throw "GITHUB_RUN_ID is unavailable" }
           "V4_RELEASE_STATE_ROOT=$env:RUNNER_TEMP\sky-v4-release-$env:GITHUB_RUN_ID" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Verify runner-local updater key configuration
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:V4_UPDATER_PRIVATE_KEY_PATH)) { throw "runner-local updater key configuration is unavailable" }
-          if (-not (Test-Path -LiteralPath $env:V4_UPDATER_PRIVATE_KEY_PATH -PathType Leaf)) { throw "runner-local updater key configuration does not reference a file" }
-
       - name: Check out the exact requested source SHA
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.source_sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify isolated production runner boundary
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/verify_v4_release_runner.ps1 `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
 
       - name: Validate exact v4 release request
         run: |
@@ -249,4 +270,10 @@ jobs:
             -Tag $env:V4_RELEASE_TAG `
             -SourceSha $env:V4_RELEASE_SOURCE_SHA `
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
+            -StateRoot $env:V4_RELEASE_STATE_ROOT
+
+      - name: Clean runner-local release state
+        if: always()
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/cleanup_v4_release_state.ps1 `
             -StateRoot $env:V4_RELEASE_STATE_ROOT

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -139,7 +139,29 @@ Dedicated self-hosted Windows runners executing production releases must satisfy
 3. **Stale Output Purge**: Target bundle and evidence directories are purged of previous candidate installers, signatures, and evidence prior to building. Stale outputs from aborted or previous runs can never be reused.
 4. **Isolated Key Storage**: Private updater keys and certificate stores must reside outside the repository tree, accessible only via restricted paths or secure hardware/cloud seams.
 
-### 2.4 Production Passphrase Transport: Windows Credential Manager Session Broker
+### 2.4 GitHub Actions Runner Isolation and Operator Requirements
+
+The labels `self-hosted, windows, v4-release, single-tenant` identify the production signing
+runner boundary. Only `release-v4.yml` and `rehearse-v4-production-topology.yml` may target that
+label set. Both workflows are `workflow_dispatch` only, require the canonical repository's
+`refs/heads/main` dispatch context, and are protected by the `v4-production-release` environment.
+Pull-request, fork, push, and general CI workflows must remain on ordinary hosted or non-release
+runners.
+
+The runner-local `V4_UPDATER_PRIVATE_KEY_PATH` is provisioned outside the checkout and is never a
+workflow input. Release state is created under `RUNNER_TEMP`, outside `GITHUB_WORKSPACE`, and is
+removed by an unconditional cleanup step after bounded JSON evidence is retained. Checkout keeps
+`persist-credentials: false`; no generated token, private-key copy, or credential file may be
+written into the source workspace.
+
+The repository owner is responsible for keeping this runner dedicated to this repository's
+production release environment, applying OS/toolchain security patches, and preferring an ephemeral
+or regularly reimaged machine. The runner must never be registered for general public-repository CI.
+If compromise is suspected, disable the runner and production environment, revoke or rotate the
+updater key using [v4-updater-key-custody.md](v4-updater-key-custody.md), inspect release and
+metadata history, and reimage or replace the runner before restoring release access.
+
+### 2.5 Production Passphrase Transport: Windows Credential Manager Session Broker
 
 Incident #140 established that parent-process environment variable inheritance does not reach Actions step processes on dedicated runner hosts (such as PUMZ). Parent-process env inheritance is explicitly **not** the production transport.
 

--- a/rust/tools/sky_ci_classifier/src/lib.rs
+++ b/rust/tools/sky_ci_classifier/src/lib.rs
@@ -58,6 +58,8 @@ pub const RELEASE_FILES: &[&str] = &[
     "scripts/v4_release_pipeline.ps1",
     "scripts/orchestrate_v4_production_release.ps1",
     "scripts/test_v4_production_orchestrator.ps1",
+    "scripts/verify_v4_release_runner.ps1",
+    "scripts/cleanup_v4_release_state.ps1",
     "scripts/test_v4_release_pipeline.ps1",
     "scripts/v4_updater_credential_broker.ps1",
     "scripts/set_v4_updater_session_credential.ps1",

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -469,17 +469,112 @@ const APPROVED_RELEASE_RUNNER_WORKFLOWS: &[&str] = &[
 const RELEASE_RUNNER_LABEL_MARKER: &str =
     "runs-on: [self-hosted, windows, v4-release, single-tenant]";
 
-fn workflow_declares_event(source: &str, event: &str) -> bool {
-    source
-        .lines()
-        .any(|line| line.trim_start().starts_with(event))
+fn approved_release_runner_job(relative: &str) -> Option<&'static str> {
+    match relative {
+        ".github/workflows/release-v4.yml" => Some("release"),
+        ".github/workflows/rehearse-v4-production-topology.yml" => Some("rehearsal"),
+        _ => None,
+    }
+}
+
+fn workflow_job_blocks(source: &str) -> Vec<(String, String)> {
+    let mut jobs = Vec::new();
+    let mut in_jobs = false;
+    let mut current_id = None;
+    let mut current_block = String::new();
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        if !in_jobs {
+            if indent == 0 && trimmed == "jobs:" {
+                in_jobs = true;
+            }
+            continue;
+        }
+        if indent == 0 && !trimmed.is_empty() {
+            if let Some(job_id) = current_id.take() {
+                jobs.push((job_id, std::mem::take(&mut current_block)));
+            }
+            break;
+        }
+        if indent == 2 && !trimmed.is_empty() && !trimmed.starts_with('#') && trimmed.ends_with(':')
+        {
+            if let Some(job_id) = current_id.take() {
+                jobs.push((job_id, std::mem::take(&mut current_block)));
+            }
+            current_id = Some(trimmed.trim_end_matches(':').to_owned());
+            continue;
+        }
+        if current_id.is_some() {
+            current_block.push_str(line);
+            current_block.push('\n');
+        }
+    }
+    if let Some(job_id) = current_id {
+        jobs.push((job_id, current_block));
+    }
+
+    jobs
+}
+
+fn job_uses_sensitive_runner(job: &str) -> bool {
+    job.lines().any(|line| {
+        let trimmed = line.trim_start();
+        trimmed.starts_with("runs-on:")
+            && (trimmed.contains("self-hosted")
+                || trimmed.contains("v4-release")
+                || trimmed.contains("single-tenant"))
+    })
+}
+
+fn job_has_exact_release_runner_labels(job: &str) -> bool {
+    job.lines()
+        .any(|line| line.trim() == RELEASE_RUNNER_LABEL_MARKER)
+}
+
+fn job_has_protected_release_environment(job: &str) -> bool {
+    job.lines()
+        .any(|line| line.trim() == "environment: v4-production-release")
+}
+
+fn workflow_declares_only_dispatch(source: &str) -> bool {
+    let mut in_on = false;
+    let mut found_dispatch = false;
+    for line in source.lines() {
+        let trimmed = line.trim();
+        let indent = line.len() - line.trim_start().len();
+        if !in_on {
+            if indent == 0 && trimmed == "on:" {
+                in_on = true;
+            }
+            continue;
+        }
+        if indent == 0 && !trimmed.is_empty() {
+            break;
+        }
+        if indent == 2 && trimmed.ends_with(':') {
+            let event = trimmed.trim_end_matches(':');
+            if event == "workflow_dispatch" {
+                found_dispatch = true;
+            } else {
+                return false;
+            }
+        }
+    }
+    found_dispatch
 }
 
 fn validate_release_runner_workflow(relative: &str, source: &str) -> Result<()> {
-    let uses_sensitive_runner = source.contains("self-hosted")
+    let jobs = workflow_job_blocks(source);
+    let sensitive_jobs = jobs
+        .iter()
+        .filter(|(_, job)| job_uses_sensitive_runner(job))
+        .collect::<Vec<_>>();
+    let source_mentions_sensitive_runner = source.contains("self-hosted")
         || source.contains("v4-release")
         || source.contains("single-tenant");
-    if !uses_sensitive_runner {
+    if !source_mentions_sensitive_runner {
         return Ok(());
     }
     if !APPROVED_RELEASE_RUNNER_WORKFLOWS.contains(&relative) {
@@ -488,27 +583,52 @@ fn validate_release_runner_workflow(relative: &str, source: &str) -> Result<()> 
         )
         .into());
     }
-    for forbidden_event in ["pull_request:", "pull_request_target:", "push:"] {
-        if workflow_declares_event(source, forbidden_event) {
+    if !workflow_declares_only_dispatch(source) {
+        return Err(format!(
+            "production release runner workflow must whitelist workflow_dispatch as its only trigger: {relative}"
+        )
+        .into());
+    }
+    let approved_job = approved_release_runner_job(relative).ok_or_else(|| {
+        format!("approved release runner workflow has no approved job mapping: {relative}")
+    })?;
+    if sensitive_jobs.is_empty() {
+        return Err(format!(
+            "release runner labels could not be mapped to a job block: {relative}"
+        )
+        .into());
+    }
+    for (job_id, job) in &sensitive_jobs {
+        if job_id != approved_job {
             return Err(format!(
-                "production release runner workflow declares an untrusted trigger `{forbidden_event}`: {relative}"
+                "job `{job_id}` is not approved for the production release runner boundary: {relative}"
+            )
+            .into());
+        }
+        if !job_has_exact_release_runner_labels(job) {
+            return Err(format!(
+                "job `{job_id}` must use the exact dedicated release runner labels: {relative}"
+            )
+            .into());
+        }
+        if !job_has_protected_release_environment(job) {
+            return Err(format!(
+                "job `{job_id}` must declare environment: v4-production-release in its own job block: {relative}"
             )
             .into());
         }
     }
-    if source.matches(RELEASE_RUNNER_LABEL_MARKER).count() != 1 {
+    if sensitive_jobs.len() != 1 {
         return Err(format!(
-            "approved release runner workflow must contain exactly one signing-runner job: {relative}"
+            "approved release runner workflow must contain exactly one sensitive runner job: {relative}"
         )
         .into());
     }
     for marker in [
-        RELEASE_RUNNER_LABEL_MARKER,
         "workflow_dispatch:",
         "dispatch-boundary",
         "github.event.repository.default_branch",
         "refs/heads/main",
-        "environment: v4-production-release",
         "V4_UPDATER_PRIVATE_KEY_PATH",
         "RUNNER_TEMP",
         "verify_v4_release_runner.ps1",
@@ -3054,7 +3174,24 @@ jobs:
 "#;
         let error = validate_release_runner_workflow(".github/workflows/release-v4.yml", workflow)
             .expect_err("approved release workflow must reject PR triggers");
-        assert!(error.to_string().contains("untrusted trigger"));
+        assert!(error.to_string().contains("only trigger"));
+    }
+
+    #[test]
+    fn release_runner_contract_rejects_unprotected_sensitive_job_subset() {
+        let workflow = r#"
+on:
+  workflow_dispatch:
+jobs:
+  release:
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+    environment: v4-production-release
+  unprotected:
+    runs-on: [self-hosted, windows, v4-release]
+"#;
+        let error = validate_release_runner_workflow(".github/workflows/release-v4.yml", workflow)
+            .expect_err("an unprotected sensitive job subset must be rejected");
+        assert!(error.to_string().contains("not approved"));
     }
 
     #[test]

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -237,6 +237,8 @@ const ACTIVE_RELEASE_SURFACES: &[&str] = &[
     "scripts/promote_v4_metadata.ps1",
     "scripts/orchestrate_v4_production_release.ps1",
     "scripts/ci_tauri_update_e2e_core.ps1",
+    "scripts/verify_v4_release_runner.ps1",
+    "scripts/cleanup_v4_release_state.ps1",
     ".github/workflows/release.yml",
     ".github/workflows/release-v4.yml",
     ".github/workflows/rehearse-v4-production-topology.yml",
@@ -460,6 +462,117 @@ fn release_metadata_contract(root: &Path) -> Result<()> {
     Ok(())
 }
 
+const APPROVED_RELEASE_RUNNER_WORKFLOWS: &[&str] = &[
+    ".github/workflows/release-v4.yml",
+    ".github/workflows/rehearse-v4-production-topology.yml",
+];
+const RELEASE_RUNNER_LABEL_MARKER: &str =
+    "runs-on: [self-hosted, windows, v4-release, single-tenant]";
+
+fn workflow_declares_event(source: &str, event: &str) -> bool {
+    source
+        .lines()
+        .any(|line| line.trim_start().starts_with(event))
+}
+
+fn validate_release_runner_workflow(relative: &str, source: &str) -> Result<()> {
+    let uses_sensitive_runner = source.contains("self-hosted")
+        || source.contains("v4-release")
+        || source.contains("single-tenant");
+    if !uses_sensitive_runner {
+        return Ok(());
+    }
+    if !APPROVED_RELEASE_RUNNER_WORKFLOWS.contains(&relative) {
+        return Err(format!(
+            "unapproved workflow targets the production release runner boundary: {relative}"
+        )
+        .into());
+    }
+    for forbidden_event in ["pull_request:", "pull_request_target:", "push:"] {
+        if workflow_declares_event(source, forbidden_event) {
+            return Err(format!(
+                "production release runner workflow declares an untrusted trigger `{forbidden_event}`: {relative}"
+            )
+            .into());
+        }
+    }
+    if source.matches(RELEASE_RUNNER_LABEL_MARKER).count() != 1 {
+        return Err(format!(
+            "approved release runner workflow must contain exactly one signing-runner job: {relative}"
+        )
+        .into());
+    }
+    for marker in [
+        RELEASE_RUNNER_LABEL_MARKER,
+        "workflow_dispatch:",
+        "dispatch-boundary",
+        "github.event.repository.default_branch",
+        "refs/heads/main",
+        "environment: v4-production-release",
+        "V4_UPDATER_PRIVATE_KEY_PATH",
+        "RUNNER_TEMP",
+        "verify_v4_release_runner.ps1",
+        "cleanup_v4_release_state.ps1",
+        "persist-credentials: false",
+    ] {
+        if !source.contains(marker) {
+            return Err(format!(
+                "approved release runner workflow is missing its trust-boundary marker `{marker}`: {relative}"
+            )
+            .into());
+        }
+    }
+    for forbidden_input in [
+        "updater_private_key_path:",
+        "inputs.updater_private_key_path",
+    ] {
+        if source.contains(forbidden_input) {
+            return Err(format!(
+                "production release runner workflow accepts an operator-controlled key path `{forbidden_input}`: {relative}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn release_runner_contract(root: &Path) -> Result<()> {
+    let workflows_root = root.join(".github/workflows");
+    let mut observed = BTreeSet::new();
+    for entry in WalkDir::new(&workflows_root) {
+        let entry = entry.map_err(|error| error.to_string())?;
+        if !entry.file_type().is_file()
+            || !matches!(
+                entry
+                    .path()
+                    .extension()
+                    .and_then(|extension| extension.to_str()),
+                Some("yml" | "yaml")
+            )
+        {
+            continue;
+        }
+        let relative = entry
+            .path()
+            .strip_prefix(root)
+            .map_err(|error| error.to_string())?
+            .to_string_lossy()
+            .replace('\\', "/");
+        let source = fs::read_to_string(entry.path())?;
+        validate_release_runner_workflow(&relative, &source)?;
+        if APPROVED_RELEASE_RUNNER_WORKFLOWS.contains(&relative.as_str()) {
+            observed.insert(relative);
+        }
+    }
+    for required in APPROVED_RELEASE_RUNNER_WORKFLOWS {
+        if !observed.contains(*required) {
+            return Err(format!("approved release runner workflow is missing: {required}").into());
+        }
+    }
+    println!("[xtask] v4 release runner trust boundary: PASS");
+    Ok(())
+}
+
 fn v4_release_pipeline_contract_source(
     workflow: &str,
     pipeline: &str,
@@ -476,7 +589,13 @@ fn v4_release_pipeline_contract_source(
         "contents: write",
         "GH_TOKEN: ${{ github.token }}",
         "ref: ${{ inputs.source_sha }}",
-        "Verify runner-local updater key configuration",
+        "release-dispatch-boundary",
+        "github.event.repository.default_branch",
+        "refs/heads/main",
+        "environment: v4-production-release",
+        "Verify isolated production runner boundary",
+        "verify_v4_release_runner.ps1",
+        "cleanup_v4_release_state.ps1",
         "V4_UPDATER_PRIVATE_KEY_PATH",
         "-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH",
         "persist-credentials: false",
@@ -663,9 +782,16 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
         "name: V4 Production Topology Rehearsal",
         "workflow_dispatch:",
         "runs-on: [self-hosted, windows, v4-release, single-tenant]",
+        "rehearsal-dispatch-boundary",
+        "github.event.repository.default_branch",
+        "refs/heads/main",
+        "environment: v4-production-release",
         "ref: ${{ inputs.source_sha }}",
         "persist-credentials: false",
-        "updater_private_key_path:",
+        "Verify isolated rehearsal runner boundary",
+        "verify_v4_release_runner.ps1",
+        "cleanup_v4_release_state.ps1",
+        "Preserve bounded rehearsal evidence",
         "BuildCandidate",
         "test_v4_production_topology_rehearsal.ps1",
         "-CandidateStateRoot $env:V4_REHEARSAL_STATE_ROOT",
@@ -688,6 +814,9 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
         "FinalVerify",
         "gh release",
         "softprops/action-gh-release",
+        "updater_private_key_path:",
+        "inputs.updater_private_key_path",
+        "KeepStateOnFailure",
     ] {
         if topology_workflow.contains(forbidden) {
             return Err(format!(
@@ -2558,6 +2687,7 @@ pub fn run(group: &str, skip_supply_chain: bool) -> Result<()> {
             tauri_bundle::validate_config(&root)?;
             v4_trust_material_contract(&root)?;
             release_metadata_contract(&root)?;
+            release_runner_contract(&root)?;
             v4_release_pipeline_contract(&root)?;
             packaged_ci_contract(&root)?;
             v4_legacy_updater_retirement(&root)?;
@@ -2899,6 +3029,35 @@ read_only=true
     }
 
     #[test]
+    fn release_runner_contract_rejects_sensitive_runner_on_general_ci() {
+        let workflow = r#"
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+"#;
+        let error = validate_release_runner_workflow(".github/workflows/ci.yml", workflow)
+            .expect_err("general CI must not target the production signing runner");
+        assert!(error.to_string().contains("unapproved workflow"));
+    }
+
+    #[test]
+    fn release_runner_contract_rejects_untrusted_trigger_on_approved_workflow() {
+        let workflow = r#"
+on:
+  workflow_dispatch:
+  pull_request:
+jobs:
+  release:
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+"#;
+        let error = validate_release_runner_workflow(".github/workflows/release-v4.yml", workflow)
+            .expect_err("approved release workflow must reject PR triggers");
+        assert!(error.to_string().contains("untrusted trigger"));
+    }
+
+    #[test]
     fn v4_release_pipeline_contract_requires_draft_download_and_publish_order() {
         let workflow = r#"
 name: V4 Release Pipeline
@@ -2914,7 +3073,13 @@ jobs:
       attestations: write
     runs-on: [self-hosted, windows, v4-release, single-tenant]
     ref: ${{ inputs.source_sha }}
-    Verify runner-local updater key configuration
+    release-dispatch-boundary
+    github.event.repository.default_branch
+    refs/heads/main
+    environment: v4-production-release
+    Verify isolated production runner boundary
+    verify_v4_release_runner.ps1
+    cleanup_v4_release_state.ps1
     V4_UPDATER_PRIVATE_KEY_PATH
     -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
     persist-credentials: false

--- a/scripts/cleanup_v4_release_state.ps1
+++ b/scripts/cleanup_v4_release_state.ps1
@@ -1,0 +1,47 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$StateRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    throw "V4 release state cleanup failed closed: $Message"
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$workspace = if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+    $repoRoot
+} else {
+    [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+}
+if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { Fail "RUNNER_TEMP is unavailable" }
+$runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP)
+$runnerTempPrefix = $runnerTemp.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+$workspacePrefix = $workspace.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+$repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+
+foreach ($root in $StateRoot) {
+    if ([string]::IsNullOrWhiteSpace($root)) { Fail "StateRoot is required" }
+    $statePath = [IO.Path]::GetFullPath($root)
+    if ($statePath.Equals($workspace, [StringComparison]::OrdinalIgnoreCase) -or
+        $statePath.StartsWith($workspacePrefix, [StringComparison]::OrdinalIgnoreCase) -or
+        $statePath.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) -or
+        $statePath.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "refusing to remove a path inside the repository workspace"
+    }
+    if (-not ($statePath.Equals($runnerTemp, [StringComparison]::OrdinalIgnoreCase) -or
+        $statePath.StartsWith($runnerTempPrefix, [StringComparison]::OrdinalIgnoreCase))) {
+        Fail "refusing to remove a path outside RUNNER_TEMP"
+    }
+    if (Test-Path -LiteralPath $statePath -PathType Leaf) {
+        Fail "refusing to remove a state file where a directory is required"
+    }
+    if (Test-Path -LiteralPath $statePath -PathType Container) {
+        Remove-Item -LiteralPath $statePath -Recurse -Force
+    }
+}
+
+Write-Host "V4 release state cleanup: PASS (runner-local state roots removed)"

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -109,7 +109,7 @@ if (-not $pipeline.Contains("FixtureTargetDir")) {
     Fail "production qualification must pass an explicit fixture target directory"
 }
 foreach ($marker in @(
-    'runner-local updater key configuration',
+    'Verify isolated production runner boundary',
     'V4_UPDATER_PRIVATE_KEY_PATH',
     '-UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH'
 )) {
@@ -346,6 +346,8 @@ if ($wrongNotesProbe.ExitCode -eq 0) {
 }
 
 foreach ($brokerFile in @(
+    'verify_v4_release_runner.ps1',
+    'cleanup_v4_release_state.ps1',
     'v4_updater_credential_broker.ps1',
     'set_v4_updater_session_credential.ps1',
     'remove_v4_updater_session_credential.ps1',
@@ -368,7 +370,13 @@ foreach ($marker in @(
     'actions/attest@',
     '--source-digest $env:GITHUB_SHA',
     'Initialize release state root', 'RUNNER_TEMP', 'GITHUB_RUN_ID', 'GITHUB_ENV',
-    'Verify runner-local updater key configuration',
+    'release-dispatch-boundary',
+    'github.event.repository.default_branch',
+    'refs/heads/main',
+    'environment: v4-production-release',
+    'Verify isolated production runner boundary',
+    'verify_v4_release_runner.ps1',
+    'cleanup_v4_release_state.ps1',
     'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
 )) {
     if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }
@@ -392,9 +400,16 @@ foreach ($marker in @(
     'name: V4 Production Topology Rehearsal',
     'workflow_dispatch:',
     'runs-on: [self-hosted, windows, v4-release, single-tenant]',
+    'rehearsal-dispatch-boundary',
+    'github.event.repository.default_branch',
+    'refs/heads/main',
+    'environment: v4-production-release',
     'ref: ${{ inputs.source_sha }}',
     'persist-credentials: false',
-    'updater_private_key_path:',
+    'Verify isolated rehearsal runner boundary',
+    'verify_v4_release_runner.ps1',
+    'cleanup_v4_release_state.ps1',
+    'Preserve bounded rehearsal evidence',
     'BuildCandidate',
     'test_v4_production_topology_rehearsal.ps1',
     '-CandidateStateRoot $env:V4_REHEARSAL_STATE_ROOT',
@@ -414,7 +429,10 @@ foreach ($forbidden in @(
     'PromoteMetadata',
     'FinalVerify',
     'gh release',
-    'softprops/action-gh-release'
+    'softprops/action-gh-release',
+    'updater_private_key_path:',
+    'inputs.updater_private_key_path',
+    'KeepStateOnFailure'
 )) {
     if ($topologyWorkflow.Contains($forbidden)) {
         Fail "production-topology rehearsal workflow contains a legacy release-topology marker: $forbidden"

--- a/scripts/verify_v4_release_runner.ps1
+++ b/scripts/verify_v4_release_runner.ps1
@@ -1,0 +1,78 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$UpdaterPrivateKeyPath,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$StateRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Fail([string]$Message) {
+    throw "V4 release runner boundary failed closed: $Message"
+}
+
+function Get-FullPath([string]$Path, [string]$Name) {
+    if ([string]::IsNullOrWhiteSpace($Path)) { Fail "$Name is required" }
+    try {
+        return [IO.Path]::GetFullPath($Path)
+    } catch {
+        Fail "$Name is not a valid path"
+    }
+}
+
+function Assert-OutsideWorkspace([string]$Path, [string]$Name, [string]$Workspace) {
+    $workspacePrefix = $Workspace.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if ($Path.Equals($Workspace, [StringComparison]::OrdinalIgnoreCase) -or
+        $Path.StartsWith($workspacePrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "$Name must be outside the repository workspace"
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$workspace = if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+    $repoRoot
+} else {
+    Get-FullPath $env:GITHUB_WORKSPACE "GITHUB_WORKSPACE"
+}
+$keyPath = Get-FullPath $UpdaterPrivateKeyPath "UpdaterPrivateKeyPath"
+if (-not (Test-Path -LiteralPath $keyPath -PathType Leaf)) {
+    Fail "updater private key path is not a file"
+}
+$keyPath = (Resolve-Path -LiteralPath $keyPath).Path
+Assert-OutsideWorkspace $keyPath "updater private key" $workspace
+Assert-OutsideWorkspace $keyPath "updater private key" $repoRoot
+
+if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { Fail "RUNNER_TEMP is unavailable" }
+$runnerTemp = Get-FullPath $env:RUNNER_TEMP "RUNNER_TEMP"
+$runnerTempPrefix = $runnerTemp.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+
+foreach ($root in $StateRoot) {
+    $statePath = Get-FullPath $root "StateRoot"
+    Assert-OutsideWorkspace $statePath "StateRoot" $workspace
+    Assert-OutsideWorkspace $statePath "StateRoot" $repoRoot
+    if (-not ($statePath.Equals($runnerTemp, [StringComparison]::OrdinalIgnoreCase) -or
+        $statePath.StartsWith($runnerTempPrefix, [StringComparison]::OrdinalIgnoreCase))) {
+        Fail "StateRoot must remain under RUNNER_TEMP"
+    }
+    if (Test-Path -LiteralPath $statePath -PathType Leaf) {
+        Fail "StateRoot must be a directory"
+    }
+    if ((Test-Path -LiteralPath $statePath -PathType Container) -and
+        @(Get-ChildItem -LiteralPath $statePath -Force).Count -ne 0) {
+        Fail "StateRoot must be empty before release execution"
+    }
+    New-Item -ItemType Directory -Path $statePath -Force | Out-Null
+}
+
+$gitConfig = Join-Path $workspace ".git/config"
+if (Test-Path -LiteralPath $gitConfig -PathType Leaf) {
+    $gitConfigText = Get-Content -LiteralPath $gitConfig -Raw
+    if ($gitConfigText -match "(?i)(http\.extraheader|x-access-token|authorization:)" ) {
+        Fail "source checkout contains persisted GitHub credentials"
+    }
+}
+
+Write-Host "V4 release runner boundary: PASS (dedicated runner paths and checkout credential hygiene verified)"


### PR DESCRIPTION
Closes #164

## Baseline and head

- Required baseline: `20d9267b91dd1ad059bc1e4553b4db87f0ed30f7`
- Exact head SHA: `e70ab60ac0274e863c9380cc89ce29098401c51d`

## Scope

- Add canonical-repository/default-branch preflight jobs to production release and production-topology rehearsal workflows.
- Keep the sensitive runner label set limited to the approved release/rehearsal workflows and enforce that invariant in `cargo xtask check static`.
- Put rehearsal behind the protected `v4-production-release` environment with explicit read-only permissions.
- Remove the rehearsal `workflow_dispatch` updater-key-path input; both workflows now use runner-local `V4_UPDATER_PRIVATE_KEY_PATH`.
- Add fail-closed runner checks for key-file location, state-root location under `RUNNER_TEMP`, and persisted checkout credentials.
- Add unconditional bounded state cleanup and retain only bounded JSON rehearsal evidence before cleanup.
- Document dedicated/ephemeral runner operation, patching, key handling, and compromise recovery.

## Preserved invariants

- No updater cryptography or two-repository compatibility changes.
- Production release remains draft-first, build-once, exact-byte qualified, immutable, attested, and environment-gated.
- `persist-credentials: false` remains required on source checkout.
- Existing updater key custody and Credential Manager session-broker contracts remain unchanged.
- No #163 site/ADR cleanup or #165 owner/admin cutover action is included.

## Verification

- `cargo xtask check all` — PASS
- `cargo test --manifest-path rust/Cargo.toml -p sky_xtask` — 72 passed
- `cargo test --manifest-path rust/tools/sky_ci_classifier/Cargo.toml` — 12 passed
- `pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_release_pipeline.ps1` — PASS
- PowerShell parser validation for changed scripts — PASS
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — PASS
- `git diff --check` — PASS

## Owner/operator actions not performed by this PR

The repository owner must still ensure the `v4-production-release` environment has the intended protected reviewers/rules, keep the signing runner registered only for this repository and release labels, and maintain/reimage/rotate credentials according to the documented runbook.