### PR TITLE
docs: update single-repository v4 release architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@
 
 *Auto-plays Sky music sheets on Windows — notes, chords, and holds land on the beat with sub-millisecond native precision.*
 
-[![Latest version](https://img.shields.io/github/v/release/pumni/Sky-Auto-Player-Releases?style=for-the-badge&label=version&color=blue&logo=rust&logoColor=white)](https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/pumni/Sky-Auto-Player-Releases/total?style=for-the-badge&label=downloads&logo=github&color=success)](https://github.com/pumni/Sky-Auto-Player-Releases/releases)
+[![Downloads](https://img.shields.io/github/downloads/pumni/Sky-Auto-Player/total?style=for-the-badge&label=downloads&logo=github&color=success)](https://github.com/pumni/Sky-Auto-Player/releases)
 [![License](https://img.shields.io/github/license/pumni/Sky-Auto-Player?style=for-the-badge&color=orange)](https://github.com/pumni/Sky-Auto-Player/blob/main/LICENSE)
 [![Stars](https://img.shields.io/github/stars/pumni/Sky-Auto-Player?style=for-the-badge&label=stars&color=gold)](https://github.com/pumni/Sky-Auto-Player/stargazers)
 
-**[🌐 Landing Page](https://pumni.github.io/Sky-Auto-Player/)** · **[FAQ](https://pumni.github.io/Sky-Auto-Player/faq/)** · **[Download Latest](https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest)**
+**[🌐 Landing Page](https://pumni.github.io/Sky-Auto-Player/)** · **[FAQ](https://pumni.github.io/Sky-Auto-Player/faq/)** · **[Releases / Downloads](https://github.com/pumni/Sky-Auto-Player/releases)**
 
 </div>
 
@@ -54,7 +53,7 @@ Sky Auto Player doesn't replay a coarse macro timer. It schedules every note lik
 
 **Requirements:** Windows 10 or 11 (64-bit). The canonical build is a per-user Tauri NSIS installer; it does not require administrator rights for installation. No system Python or Rust toolchain is required at runtime.
 
-1. Download the canonical Tauri NSIS installer from the [dedicated v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+1. Download the canonical Tauri NSIS installer from the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).
 2. Run the installer and keep the default current-user install location.
 3. Launch **Sky Auto Player** from the Start menu or installed shortcut.
 
@@ -81,7 +80,7 @@ Sky Auto Player doesn't replay a coarse macro timer. It schedules every note lik
 
 ## Updating
 
-Sky Auto Player checks the configured v4 channel through the dedicated release authority and displays a notification banner when an update is available.
+Sky Auto Player checks the configured v4 channel through validated metadata on the main repository's `release-metadata` branch and displays a notification banner when an update is available.
 
 Selecting **Update and Restart** uses the official Tauri updater through the Rust-owned `UpdateService`. It verifies the Tauri updater signature over the exact NSIS update artifact, then runs the current-user installer. The v4 product does not bundle `Sky-Auto-Player-Updater.exe`, use a portable ZIP updater, or use the retired v3 `MANIFEST.json.sig` contract.
 
@@ -89,7 +88,7 @@ Selecting **Update and Restart** uses the official Tauri updater through the Rus
 > Windows binaries in the current v4 release use the `unsigned-zero-budget` policy: they are
 > intentionally Authenticode-unsigned, so Windows may show Unknown Publisher or a SmartScreen
 > warning. This is a publisher-identity/UX trade-off, not a bypass of Tauri updater cryptographic
-> trust. Download v4 installers only from the dedicated [v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases); the installer and Tauri `.sig` sidecar are verified as exact release bytes during qualification.
+> trust. Download v4 installers only from the official [Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases); the installer and Tauri `.sig` sidecar are verified as exact release bytes during qualification.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,8 +44,8 @@ default.
   integrity/provenance, rollback, and release contract.
 - [v4-tauri-packaging.md](v4-tauri-packaging.md) — v4 local Tauri NSIS/updater artifact qualification
   and current-user packaging contract.
-- [v4-release-authority.md](v4-release-authority.md) — v4 immutable release namespace, static
-  metadata, channel isolation, and read-only acceptance contract.
+- [v4-release-authority.md](v4-release-authority.md) — current one-repository v4 release/update
+  runbook, immutable GitHub Releases, and protected `release-metadata` channel contract.
 - [v4-updater-key-custody.md](v4-updater-key-custody.md) — v4 updater trust root custody, backup,
   loss, compromise, rotation, and recovery runbook.
 - [v4-authenticode-provider-seam.md](v4-authenticode-provider-seam.md) — v4 production Authenticode

--- a/docs/adr/ADR-0006-v4-distribution-installation-update.md
+++ b/docs/adr/ADR-0006-v4-distribution-installation-update.md
@@ -1,8 +1,12 @@
 # ADR-0006: V4 Clean Distribution, Installation, and Update Boundary
 
-Status: accepted
+Status: superseded by [ADR-0007](ADR-0007-single-repository-v4-release-architecture.md)
 
 Date: 2026-09-03
+
+> Historical decision record. This ADR preserves the pre-release two-repository design and its
+> rationale; it is not the current production architecture. ADR-0007 supersedes the dedicated
+> release-authority topology before the first official v4 release.
 
 ## Context
 

--- a/docs/adr/ADR-0007-single-repository-v4-release-architecture.md
+++ b/docs/adr/ADR-0007-single-repository-v4-release-architecture.md
@@ -1,0 +1,89 @@
+# ADR-0007: Single-Repository V4 Release and Update Architecture
+
+Status: accepted
+
+Date: 2026-09-09
+
+Supersedes: [ADR-0006](ADR-0006-v4-distribution-installation-update.md) for the v4 release and
+update topology.
+
+## Context
+
+ADR-0006 separated v4 releases from the legacy v3 GitHub Latest namespace by introducing a second
+release repository. That design was useful for pre-release qualification and rehearsal, but it made
+the supported architecture depend on a second repository, a cross-repository credential, a second
+publication authority, and a compatibility boundary that would have to be maintained indefinitely.
+
+The implementation work completed for the first official v4 release now provides the required
+isolation without a second repository. The source repository can keep the legacy v3 Latest contract
+while publishing v4 releases with `make_latest=false`, and the v4 runtime can consume a separate
+protected metadata branch in that same repository.
+
+## Decision
+
+`pumni/Sky-Auto-Player` is the only active repository for v4 source, GitHub Releases, updater
+metadata, provenance, and release documentation.
+
+`pumni/Sky-Auto-Player-Releases` was pre-release/rehearsal infrastructure only. It is not part of
+the supported production architecture and must not be used as a v4 compatibility endpoint.
+
+`v4.0.1` is the first official v4 release lineage. There is no supported bridge from v4.0.0
+rehearsal builds, no compatibility shim, no dual endpoint, and no permanent second-repository
+topology.
+
+V4 update deployment state is held on the protected `release-metadata` branch in the official
+repository:
+
+```text
+https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json
+https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json
+```
+
+The branch contains mutable stable/beta channel pointers; GitHub Release assets and tags remain
+immutable. Channel files are created only by a qualified post-publication promotion, and promotion
+is strictly monotonic by SemVer. Bootstrap does not fabricate `latest.json` files.
+
+## Release transaction
+
+The same-repository production pipeline is draft-first and builds the exact source SHA once:
+
+```text
+ValidateRequest -> ValidateRepository -> BuildCandidate -> CreateDraft
+  -> DownloadDraft -> QualifyDownloaded -> RecordAttestations
+  -> PublishDraft -> PromoteMetadata -> FinalVerify
+```
+
+`ValidateRepository` checks the canonical repository, `main`, immutable-release policy, and
+metadata-branch readiness before `CreateDraft`. Publication uses the canonical repository
+`GITHUB_TOKEN` and `make_latest=false` while v3 coexistence remains required. Metadata promotion
+occurs only after immutable publication. `FinalVerify` checks the public release and the exact
+unauthenticated raw metadata endpoint used by the client.
+
+## Security properties retained
+
+Simplifying repository topology does not weaken the release boundary. The architecture retains:
+
+- exact-byte qualification after draft asset re-download;
+- mandatory Tauri updater signature verification;
+- SHA-256 evidence for the installer and signature sidecar;
+- SPDX SBOM and source-bound provenance/attestations;
+- immutable published releases and tags;
+- protected `v4-production-release` environment and isolated signing runner;
+- least-privilege GitHub Actions permissions with credentials not persisted in the workspace;
+- fail-closed canonical repository, channel, platform, URL, signature, and SemVer validation.
+
+The updater private key remains outside the repository and runner workspace. The updater runtime
+does not accept endpoint overrides or a release-repository fallback. Authenticode policy remains
+the separately documented `unsigned-zero-budget` policy; it is independent of updater signature
+authorization.
+
+## Consequences
+
+The supported release path has one repository identity, one release API authority, and one clearly
+bounded metadata branch. Operators no longer need a dedicated release-authority token or a runtime
+compatibility path. The former repository can be removed as an owner/admin cutover action after the
+rehearsal and final release gate in issue #165.
+
+The v3 Latest namespace remains protected by explicit `make_latest=false` release behavior until
+v3 coexistence is retired. A future change to that boundary requires a new ADR and release-gate
+evidence.

--- a/docs/distribution-and-update.md
+++ b/docs/distribution-and-update.md
@@ -26,7 +26,7 @@ protocol. Tauri updater signatures and the retired v3 manifest signature are
 different contracts; only the former is used for v4 updates.
 
 V4 update ordering is SemVer-only. Rust owns the fixed stable/beta metadata
-endpoints and channel policy; React cannot provide updater authority, keys,
+endpoints and channel policy; React cannot provide metadata endpoints, keys,
 URLs, or downgrade policy. The v4 trust root is public-only in source, while
 the private updater key remains external, encrypted at rest with an independent
 encrypted backup. Optional Authenticode signer inputs remain external; no
@@ -40,7 +40,8 @@ SPDX SBOM, provenance, clean worktree, install/launch/uninstall, and the
 post-download previous-v4-to-candidate-v4 fixture evidence. That fixture
 consumes the exact installer and `.sig` re-downloaded from the draft; it does
 not rebuild the candidate. Release orchestration remains subject to the
-dedicated v4 release authority and its reviewed promotion policy.
+single-repository runbook in `v4-release-authority.md` and its reviewed
+promotion policy.
 
 The remainder of this document is retained as a historical v3-maintenance
 reference. It is not a current v4 runtime, packaging, release, or update
@@ -207,24 +208,24 @@ The native updater uses HTTPS only and checks redirects against:
 bases, arbitrary mirrors, shell downloads, and TLS-verification bypasses are
 rejected. Release metadata never supplies the manual browser destination.
 
-### V4 authority boundary
+### V4 release-metadata boundary
 
 V4 never queries either v3 endpoint above. The Rust `UpdateService` selects
 exactly one of these fixed Tauri static metadata endpoints from the persisted
 channel setting:
 
 ```text
-stable: https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json
-beta:   https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json
+stable: https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json
+beta:   https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json
 ```
 
-The metadata contains only the canonical Windows NSIS asset from the dedicated
-`pumni/Sky-Auto-Player-Releases` authority and the exact contents of its
-`.exe.sig` sidecar. Stable and beta metadata have separate paths and are never
-interchanged. Endpoint URLs, keys, artifact paths, and downgrade policy do
-not cross the Rust/React boundary. See `v4-release-authority.md` for the
-generator, validator, post-qualification promotion, and read-only namespace
-acceptance.
+The metadata contains only the canonical Windows NSIS asset from an immutable
+GitHub Release in `pumni/Sky-Auto-Player` and the exact contents of its `.exe.sig`
+sidecar. Stable and beta metadata have separate paths and are never interchanged.
+Endpoint URLs, keys, artifact paths, and downgrade policy do not cross the
+Rust/React boundary. See `v4-release-authority.md` for the generator, validator,
+strictly monotonic post-qualification promotion, and final public endpoint
+verification.
 
 ### 4. Archive and manifest safety
 

--- a/docs/migration/v4-clean-distribution-execution.md
+++ b/docs/migration/v4-clean-distribution-execution.md
@@ -2,9 +2,11 @@
 
 Date: 2026-09-03
 
-Status: Phase 7 is complete on the WO-06 source-hardening branch. The current
-v4 workspace and release path use Tauri NSIS and the official Tauri updater;
-the retired custom updater is not a v4 dependency or release authority.
+Status: historical execution specification; superseded by
+`docs/adr/ADR-0007-single-repository-v4-release-architecture.md`.
+
+> This completed planning document preserves the pre-release migration history. Its former
+> two-repository topology and release-authority terminology are not current production guidance.
 
 Related ADR: `docs/adr/ADR-0006-v4-distribution-installation-update.md`
 

--- a/docs/migration/v4-codex-work-orders.md
+++ b/docs/migration/v4-codex-work-orders.md
@@ -2,9 +2,10 @@
 
 Date: 2026-09-03
 
-This file is the execution queue for heavy implementation work intended to run locally on Windows.
-The governing architecture is `docs/adr/ADR-0006-v4-distribution-installation-update.md`; the execution
-specification is `docs/migration/v4-clean-distribution-execution.md`.
+This file is the historical execution queue for heavy implementation work intended to run locally
+on Windows. It is superseded by `docs/adr/ADR-0007-single-repository-v4-release-architecture.md`
+and is not current implementation guidance. Its original ADR and execution specification links are
+preserved as historical context.
 
 ## Global instructions for every work order
 

--- a/docs/releases/v4.0.0-rc.1.md
+++ b/docs/releases/v4.0.0-rc.1.md
@@ -1,5 +1,8 @@
 # Sky Auto Player v4.0.0-rc.1
 
+> Historical rehearsal candidate. It is retained for release evidence only and is not a supported
+> v4 compatibility endpoint or migration target.
+
 This release candidate is the first v4 beta-channel candidate prepared for
 qualification through the dedicated v4 release authority.
 

--- a/docs/releases/v4.0.0-rc.2.md
+++ b/docs/releases/v4.0.0-rc.2.md
@@ -1,5 +1,8 @@
 # Sky Auto Player v4.0.0-rc.2
 
+> Historical rehearsal candidate. It is retained for release evidence only and is not a supported
+> v4 compatibility endpoint or migration target.
+
 This release candidate is the second v4 beta-channel candidate prepared for
 qualification through the dedicated v4 release authority. It supersedes
 v4.0.0-rc.1, which was consumed during authority candidate qualification.

--- a/docs/releases/v4.0.0-rc.4.md
+++ b/docs/releases/v4.0.0-rc.4.md
@@ -1,5 +1,8 @@
 # Sky Auto Player v4.0.0-rc.4
 
+> Historical rehearsal candidate. It is retained for release evidence only and is not a supported
+> v4 compatibility endpoint or migration target.
+
 This release candidate is the fourth v4 beta-channel candidate prepared for
 qualification through the dedicated v4 release authority. It supersedes
 v4.0.0-rc.3, which was consumed during authority candidate qualification.

--- a/docs/releases/v4.0.0-rc.5.md
+++ b/docs/releases/v4.0.0-rc.5.md
@@ -1,5 +1,8 @@
 # Sky Auto Player v4.0.0-rc.5
 
+> Historical rehearsal candidate. It is retained for release evidence only and is not a supported
+> v4 compatibility endpoint or migration target.
+
 This release candidate is the fifth v4 beta-channel candidate prepared for
 qualification through the dedicated v4 release authority. It supersedes
 v4.0.0-rc.4, which was consumed during authority candidate qualification.

--- a/docs/releases/v4.0.0-rc.6.md
+++ b/docs/releases/v4.0.0-rc.6.md
@@ -1,5 +1,8 @@
 # Sky Auto Player v4.0.0-rc.6
 
+> Historical rehearsal candidate. It is retained for release evidence only and is not a supported
+> v4 compatibility endpoint or migration target.
+
 This release candidate is the sixth v4 beta-channel candidate prepared for
 qualification through the dedicated v4 release authority. It supersedes
 v4.0.0-rc.5, which was consumed during authority candidate qualification.

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -1,6 +1,9 @@
 # Sky Auto Player v4.0.0
 
-Sky Auto Player v4.0.0 is the stable v4 release prepared through the
+> Historical rehearsal/pre-release record. `v4.0.1` is the first official v4 release lineage;
+> this document does not define a supported release or compatibility path.
+
+Sky Auto Player v4.0.0 was a pre-release rehearsal build prepared through the
 dedicated v4 release authority and its governed qualification transaction.
 
 ## Distribution and updates

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -1,157 +1,133 @@
-# V4 Release Authority
+# V4 Release and Update Runbook
 
-V4 has a separate public release authority:
-
-```text
-pumni/Sky-Auto-Player-Releases
-```
-
-The source repository `pumni/Sky-Auto-Player` remains the legacy v3 release
-namespace. The v4 Rust `UpdateService` has exactly two compiled metadata
-endpoints:
+This is the current v4 release and update runbook. The supported architecture has one official
+repository:
 
 ```text
-stable: https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/stable/latest.json
-beta:   https://raw.githubusercontent.com/pumni/Sky-Auto-Player-Releases/main/channels/beta/latest.json
+pumni/Sky-Auto-Player
 ```
 
-These URLs are selected by Rust from the persisted channel setting. They are
-not supplied by React, environment variables, command-line arguments, or a
-GitHub Releases fallback. The dedicated repository may remain without either
-`latest.json` file until the first qualified v4 promotion; a missing endpoint
-therefore fails closed.
+The repository contains the v4 source, immutable GitHub Releases, release provenance, and the
+`release-metadata` deployment branch, which must be protected before production cutover.
+`v4.0.1` is the first official v4 release lineage.
+The earlier v4.0.0 builds were rehearsal/pre-release infrastructure and are not a supported
+compatibility endpoint or migration target. There is no bridge, fallback, compatibility shim, or
+permanent second-repository release topology.
 
-## Canonical published asset
+## Public update channels
 
-The Windows package uses the actual Tauri NSIS output and has one updater
-asset/signature pair per release:
+The Rust `UpdateService` selects exactly one of these compiled, unauthenticated raw endpoints from
+the persisted channel setting:
+
+```text
+stable: https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json
+beta:   https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json
+```
+
+The frontend cannot provide an endpoint, key, URL, or downgrade policy. The `release-metadata`
+branch is mutable deployment state separate from immutable GitHub Release assets. Its channel files
+are created only by a successful qualified promotion; bootstrap must not create fabricated
+`latest.json` files. Until the first qualified promotion, a missing channel file fails closed.
+Branch ruleset/protection and the approved workflow/maintainer promotion path are owner/admin
+prerequisites tracked by issue #165; no official v4.0.1 dispatch is allowed before that gate passes.
+
+Stable and beta are independent paths:
+
+```text
+release-metadata/
+  channels/
+    stable/latest.json
+    beta/latest.json
+```
+
+Each promotion validates the complete Tauri metadata contract and requires a strictly greater
+SemVer than the current file in that channel. Equal-version and downgrade writes are rejected.
+
+## Canonical release asset
+
+The supported Windows package is the Tauri NSIS installer and its updater signature:
 
 ```text
 Sky Auto Player_<version>_x64-setup.exe
 Sky Auto Player_<version>_x64-setup.exe.sig
 ```
 
-The immutable release URL is derived from the exact version and filename:
+The immutable asset URL is derived from the version and filename in the official repository:
 
 ```text
-https://github.com/pumni/Sky-Auto-Player-Releases/releases/download/v<version>/Sky%20Auto%20Player_<version>_x64-setup.exe
+https://github.com/pumni/Sky-Auto-Player/releases/download/v<version>/Sky%20Auto%20Player_<version>_x64-setup.exe
 ```
 
-No portable ZIP, v3 `MANIFEST.json`, alias filename, source-repository
-release, or signature URL is valid v4 updater metadata. The `.sig` field in
-metadata contains the exact text from the published Tauri `.sig` file.
+Metadata contains the exact `.sig` text and the canonical `windows-x86_64` platform only. Portable
+ZIPs, custom v3 manifests, aliases, non-HTTPS URLs, other repositories, query/fragment state,
+malformed dates, extra platforms, and non-canonical artifact names are invalid v4 metadata.
 
-## Deterministic metadata
+## Deterministic metadata commands
 
-`cargo xtask release-authority generate` accepts only qualified-release
-inputs: the canonical SemVer version, normalized release notes, a
-second-precision UTC RFC3339 publication date, the exact
-`windows-x86_64` Tauri platform, the immutable asset URL, and the exact
-signature file. It emits the official Tauri static JSON shape:
+The repository-owned generator and validator are exposed through the `release-metadata` command:
 
-```json
-{
-  "version": "4.0.0",
-  "notes": "...",
-  "pub_date": "2026-09-04T00:00:00Z",
-  "platforms": {
-    "windows-x86_64": {
-      "signature": "<contents of .sig>",
-      "url": "<exact immutable asset URL>"
-    }
-  }
-}
+```text
+cargo xtask release-metadata generate --channel <stable|beta> --version <semver> \
+  --notes-file <path> --pub-date <rfc3339> --platform windows-x86_64 \
+  --asset-url <url> --signature-file <path> --output <path>
+
+cargo xtask release-metadata validate --channel <stable|beta> --metadata <path>
+
+cargo xtask release-metadata validate-monotonic --channel <stable|beta> \
+  --current <path> --candidate <path>
 ```
 
-`cargo xtask release-authority validate --channel stable|beta` validates the
-same bounded contract. Stable accepts only final SemVer releases; beta is
-explicitly a prerelease channel. Stable and beta are separate destination
-paths: `channels/stable/latest.json` and `channels/beta/latest.json`. The
-validator rejects v3 URLs, non-HTTPS URLs, other owners/repos, query or
-fragment state, SemVer build metadata, malformed dates, extra platforms, and
-non-canonical artifact names.
+Stable accepts final SemVer releases; beta accepts prereleases. The validator also checks release
+identity, exact platform shape, signature contents, canonical URLs, and channel policy.
 
-The packaged qualification path emits a bounded
-`tauri-nsis-qualified-release` evidence object containing the canonical
-version/name/size pair and SHA-256 digests for both the installer and `.sig`,
-  plus `unsigned-zero-budget` Authenticode-state evidence and SPDX SBOM references/digests.
-  The installer is truthfully recorded as Authenticode-unsigned.
-`qualified=true` is not accepted by itself: the promotion gate rejects missing
-  or extra fields, `test` or other non-governed Authenticode modes, malformed evidence, digest
-mismatches, and same-name assets with different bytes. Metadata promotion is a separate operation after the
-immutable release has been published and the exact published assets have
-passed qualification. It compares GitHub's asset digest when present, or
-downloads and hashes the exact canonical asset when the API omits a digest.
-The promotion action copies only the validated generated file into the
-selected channel path; it never creates placeholder production metadata and
-never rebuilds or replaces a published binary. Stable promotion cannot write
-the beta path, and beta promotion cannot write the stable path.
+## Release transaction
 
-The repository-owned acceptance check
-`scripts/ci_v4_release_authority_acceptance.ps1` is read-only. It verifies
-that the public source repository's `/releases/latest` is still a published
-v3 release with its canonical v3 assets and that the dedicated authority is a
-public repository. It does not create, upload, publish, edit, or delete any
-release.
+The production workflow `.github/workflows/release-v4.yml` is manual, runs only through the
+protected `v4-production-release` environment on the dedicated signing runner, and uses the
+canonical repository token for same-repository release operations. Its transaction is:
 
-`scripts/promote_v4_metadata.ps1` is the separate promotion gate. It requires
-the bounded evidence emitted by the packaged qualification path, runs the Rust
-metadata validator, reads the dedicated repository's published release and
-exact installer/`.sig` pair, and compares names, sizes, and SHA-256 digests
-against the qualified bytes before atomically copying metadata into the
-selected channel path in an authority checkout. Its `-SelfTest` regression
-path proves arbitrary `qualified=true` evidence and same-name/different-bytes
-assets are rejected. The dedicated v4 release pipeline invokes this validator
-only after it has published the immutable draft, then writes the validated
-channel file through the bounded authority credential. The promotion helper
-itself never creates, edits, replaces, or deletes a GitHub release asset.
+```text
+ValidateRequest -> ValidateRepository -> BuildCandidate -> CreateDraft
+  -> DownloadDraft -> QualifyDownloaded -> RecordAttestations
+  -> PublishDraft -> PromoteMetadata -> FinalVerify
+```
 
-The dedicated authority must have GitHub immutable releases enabled before
-the first production transaction. `ValidateAuthority` checks both the
-existing `refs/heads/main` bootstrap and the repository's immutable-release
-setting; `PublishDraft` and `FinalVerify` require the returned release object
-to report `immutable=true`. Assets are uploaded only through the
-release-specific `upload_url` returned by the create-release response, and a
-duplicate-name/upload error is never repaired by deleting or replacing an
-asset. A failed unpublished draft may be deleted and recreated with the same
-version after the candidate is fixed; once published or promoted, the release
-and tag are immutable and any fix requires a new SemVer/RC.
+The ordering is security-critical:
 
-## Release pipeline and authority bootstrap
+1. Validate the canonical repository, `main` source ref, immutable-release policy, and
+   `release-metadata` branch readiness before creating a draft.
+2. Build the exact source SHA once and create a draft in the official repository.
+3. Re-download the draft installer and signature, then qualify those exact bytes.
+4. Record SBOM and provenance/attestation evidence bound to the exact source and artifacts.
+5. Publish the already-qualified draft immutably with `make_latest=false` while the v3 Latest
+   contract remains protected.
+6. Generate, validate, and promote only the selected stable/beta metadata file after publication.
+7. Re-fetch the public release and verify the exact unauthenticated `raw.githubusercontent.com`
+   endpoint used by the client.
 
-`.github/workflows/release-v4.yml` is the only production v4 publication entry
-point. It is manual, runs on the dedicated/single-tenant Windows runner, and
-uses `V4_RELEASE_AUTHORITY_TOKEN` for release/assets/channel metadata writes.
-The source `GITHUB_TOKEN` and OIDC permissions remain separate and are used for
-source-bound attestations. The updater private key is not a GitHub secret: the
-production workflow does not accept a key-path input and reads
-`V4_UPDATER_PRIVATE_KEY_PATH` only from dedicated runner-local process
-configuration.
-The authority token contract is bounded to the dedicated repository only, with
-the minimum Administration read and Contents read/write capability needed to
-inspect immutable-release policy, create/read/publish release records, upload
-release assets, and write `channels/<channel>/latest.json`; it has no
-source-repository, Actions, secrets, package, or updater-key permission.
+Published release assets and tags are never repaired in place. A failed unpublished draft may be
+recreated after correction; a published fix requires a greater SemVer release.
 
-The pipeline first requires `refs/heads/main` in this repository. An empty
-authority repository therefore fails closed with an instruction to perform a
-separately reviewed one-time bootstrap. That bootstrap must create the minimal
-authority `main` history (including the channel directory contract) outside a
-production release dispatch. A release dispatch never creates the first
-authority commit as a side effect.
+## Qualification and trust properties
 
-The current pre-provider release policy is temporary `unsigned-zero-budget`: no
-Authenticode provider credentials are required in PR CI or ordinary CI, and an
-optional real-signer seam is separately governed. Production GA should use an approved real
-signer when a provider is selected and available; the release order is sign, verify, upload the
-signed draft, qualify the exact downloaded artifact, then publish. The retired v3 updater is preserved by Git
-history and the `v3-maintenance` line, but is not part of the current v4
-workspace or product graph.
+The release gate preserves these properties while using one repository:
 
-The v4 Tauri updater public trust root is committed independently of this
-release-authority metadata contract. Its operational private key remains
-outside the repository. The post-download fixture bridge trusts `[old,new]`
-and verifies the exact downloaded candidate bytes during `Update::download()`;
-the production candidate itself is not rebuilt by that qualification. A full
-non-PR workflow dispatch is required for provenance and SPDX attestation
-evidence.
+- build once, then qualify and publish the exact same bytes;
+- mandatory Tauri updater signature verification;
+- exact installer and signature SHA-256 evidence;
+- SPDX SBOM and GitHub OIDC provenance/attestation;
+- immutable GitHub Release publication;
+- strict stable/beta SemVer policy and monotonic metadata promotion;
+- protected production environment and isolated signing runner;
+- runner-local updater key outside the workspace, with no key-path workflow input;
+- least-privilege permissions and `persist-credentials: false` checkout;
+- fail-closed validation when metadata, release assets, signatures, or public endpoints differ.
+
+The current Authenticode policy is `unsigned-zero-budget`: updater cryptographic trust remains
+mandatory even while Windows publisher identity is intentionally unsigned. Any future production
+signer requires separate qualification and does not change the repository or metadata topology.
+
+For runner isolation, evidence retention, rehearsal, and owner/admin cutover requirements, see
+[`v4-release-execution-topology.md`](v4-release-execution-topology.md) and issue #165. Owner/admin
+actions such as branch protection, secret removal, repository deletion, and the final v4.0.1
+dispatch are not performed by this runbook.

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -5,7 +5,8 @@ candidate qualification lifecycle, and provenance model for production v4 releas
 of Sky Auto Player.
 
 Governed by:
-- [docs/adr/ADR-0006-v4-distribution-installation-update.md](adr/ADR-0006-v4-distribution-installation-update.md)
+- [docs/adr/ADR-0007-single-repository-v4-release-architecture.md](adr/ADR-0007-single-repository-v4-release-architecture.md)
+- [docs/adr/ADR-0006-v4-distribution-installation-update.md](adr/ADR-0006-v4-distribution-installation-update.md) (historical, superseded)
 - [v4-tauri-packaging.md](v4-tauri-packaging.md)
 - [v4-release-authority.md](v4-release-authority.md)
 - [v4-updater-key-custody.md](v4-updater-key-custody.md)
@@ -244,8 +245,8 @@ Before initiating any build or invoking external tools, the orchestrator validat
    immediately after the production build to ensure build tools did not mutate tracked source or
    manifest files.
 4. **Version Alignment**: `desktop/src-tauri/Cargo.toml` package version matches `-Version`.
-5. **Channel Policy**: Aligned with WO-04 release authority (`stable` requires non-prerelease SemVer;
-   `beta` requires prerelease SemVer).
+5. **Channel Policy**: Aligned with the `release-metadata` contract (`stable` requires non-prerelease
+   SemVer; `beta` requires prerelease SemVer).
 6. **Key Path Isolation**: `-UpdaterPrivateKeyPath` is verified to reside outside the repository tree.
 7. **Key Validity Check**: Invokes `cargo xtask updater-trust verify-private-key` against the private key
    *before* building. Key ID is dynamically derived from canonical public root.
@@ -340,12 +341,11 @@ never rebuilt. The packaged candidate also proves that update admission is
 rejected while playback is active.
 
 Before creating a new RC, the exact production qualification topology can be
-rehearsed without creating a release-authority draft. The manual workflow
+rehearsed without creating a GitHub Release draft. The manual workflow
 `.github/workflows/rehearse-v4-production-topology.yml` must be dispatched from
 the ref containing the exact requested source SHA. It uses the same dedicated
 runner labels and explicit updater-key path as production, builds one candidate,
-then runs the script below. It has no release-authority token and no authority
-mutation state.
+then runs the script below. It has no release mutation or metadata promotion state.
 
 ```powershell
 pwsh scripts/test_v4_production_topology_rehearsal.ps1 -CandidateStateRoot $candidateStateRoot -StateRoot (Join-Path $env:RUNNER_TEMP "sky-v4-production-topology-rehearsal") -Version $version -Channel $channel -Tag "v$version" -SourceSha $sourceSha -WorkflowSha $sourceSha
@@ -374,19 +374,14 @@ and recreated with the same version after the candidate is fixed. Published
 assets, release tags, and metadata remain immutable; fixes then require a new
 SemVer/RC.
 
-The authority preflight requires `pumni/Sky-Auto-Player-Releases` to have an
-existing `main` branch. If the authority is empty, the workflow stops and the
-maintainer must perform a separately reviewed one-time minimal bootstrap; the
-release transaction never creates initial authority history implicitly. The
-only cross-repository secret is the bounded
-`V4_RELEASE_AUTHORITY_TOKEN`, scoped to the authority repository's
-Administration-read and Contents read/write permissions needed to inspect
-immutable releases, create/upload/read/publish the draft, and write channel
-metadata. It is never used for updater-key custody. A maintainer may run
-`scripts/test_v4_release_authority_rehearsal.ps1 -ConfirmDisposable` after
-bootstrap; that explicit rehearsal creates and deletes one uniquely tagged
-draft and verifies upload/download bytes through the real authority API. It
-never publishes a release or mutates an existing tag.
+The production preflight validates the canonical `pumni/Sky-Auto-Player` repository,
+the requested `main` source, immutable-release policy, and readiness of the
+`release-metadata` branch before `CreateDraft`. Bootstrap is a separately reviewed
+owner/maintainer operation and never creates fabricated channel files. The production
+workflow uses the same-repository `GITHUB_TOKEN` with job-scoped write permissions;
+there is no cross-repository release token. Metadata promotion is a post-publication
+operation and is strictly monotonic per channel. `FinalVerify` checks the public
+release and the unauthenticated raw endpoint used by the runtime updater.
 
 ---
 

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -3,7 +3,8 @@
 V4 uses the Tauri Windows bundler as its canonical package producer. The
 foundation enables the NSIS package and updater artifact generation. The
 Rust-owned `UpdateService` now drives the official Tauri updater through the
-dedicated v4 release authority described in `v4-release-authority.md`.
+single-repository release and `release-metadata` contract described in
+`v4-release-authority.md`.
 Production metadata may be absent until a qualified promotion. The independent
 Tauri updater trust root is committed as public material in the Tauri config
 and Rust updater boundary; missing or invalid trust material fails closed.
@@ -193,8 +194,9 @@ The isolated CI updater qualification runs
 script owns the fixture `CARGO_TARGET_DIR` for each throwaway build and serves
 the signed candidate from a loopback fixture, installs the previous v4 package, and verifies the official
 Tauri updater reaches the candidate version after restart. It also verifies
-the bridge `[old,new]` to cutover `[new]` trust transition against real
-packaged clients. The same evidence records the ordered native quiesce,
+the reviewed overlap `[old,new]` to cutover `[new]` updater-trust transition against real
+packaged clients. This is a signing-key rotation fixture, not a compatibility path for
+pre-release v4 builds. The same evidence records the ordered native quiesce,
 key-release, state-persistence, and resource-close phases.
 
 ## Acceptance boundary
@@ -205,6 +207,7 @@ uninstall remain Windows-manual acceptance evidence; the packaged update
 qualification is the deterministic previous-v4 -> candidate-v4 acceptance
 path. A full non-PR run must be dispatched from the branch so provenance and
 SPDX attestations are generated and verified before acceptance. The production
-release/channel authority is configured by WO-04. The v4 updater public trust
+release and `release-metadata` channel contract is documented in
+`v4-release-authority.md`. The v4 updater public trust
 root and rotation policy are implemented here; an approved Authenticode
 provider is optional future work and is not a release prerequisite.

--- a/docs/v4-updater-key-custody.md
+++ b/docs/v4-updater-key-custody.md
@@ -200,7 +200,7 @@ Windows Authenticode is an OS / SmartScreen / install-time gate during manual in
 Consequently, an attacker who possesses the private updater key could forge update signatures
 that deployed client instances would accept as valid if the attacker can serve them via an
 update channel. Therefore, **the primary and immediate authorization gate against updater key
-compromise is the Release Authority channel freeze**.
+compromise is the protected `release-metadata` channel freeze**.
 
 ### Incident Response Procedure
 
@@ -209,9 +209,10 @@ If the private updater key is suspected or confirmed to be compromised:
 1. **Severity 1 Incident Declaration**:
    - Immediately invoke the security process in `SECURITY.md`.
 
-2. **Freeze Release Authority Channels (Critical Containment)**:
+2. **Freeze `release-metadata` Channels (Critical Containment)**:
    - Immediately delete or overwrite `channels/stable/latest.json` and `channels/beta/latest.json`
-     in `pumni/Sky-Auto-Player-Releases` with emergency quarantine metadata (empty or revoked).
+     in the `release-metadata` branch of `pumni/Sky-Auto-Player` with emergency quarantine metadata
+     (empty or revoked).
    - This immediately halts all background update polling by existing clients, preventing them
      from fetching attacker-signed payloads.
 

--- a/site/src/components/faq/FaqPage.astro
+++ b/site/src/components/faq/FaqPage.astro
@@ -73,14 +73,14 @@ const structuredData = {
         <p>
           {
             isVi
-              ? 'Tải bản phát hành mới nhất rồi mở Library khi bài hát của bạn đã sẵn sàng.'
-              : 'Download the latest release, then open the Library when your song is ready.'
+              ? 'Mở trang bản phát hành rồi mở Library khi bài hát của bạn đã sẵn sàng.'
+              : 'Browse the releases, then open the Library when your song is ready.'
           }
         </p>
       </div>
       <div class="final-cta__actions">
         <a class="button button--primary" href={SITE.releaseUrl}
-          >{isVi ? 'Tải bản mới nhất' : 'Download latest release'}</a
+          >{isVi ? 'Xem bản phát hành' : 'Browse releases'}</a
         >
         <a class="button button--secondary" href={withBase(isVi ? '/vi/' : '/')}
           >{isVi ? 'Về trang chủ' : 'Back to landing page'}</a

--- a/site/src/content/faq/en/download.md
+++ b/site/src/content/faq/en/download.md
@@ -6,4 +6,4 @@ category: 'General'
 question: 'Where can I download Sky Auto Player?'
 ---
 
-Download the canonical Tauri NSIS installer from the [dedicated v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+Download the canonical Tauri NSIS installer from the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).

--- a/site/src/content/faq/en/free.md
+++ b/site/src/content/faq/en/free.md
@@ -6,4 +6,4 @@ category: 'General'
 question: 'Is Sky Auto Player free?'
 ---
 
-Yes. It is open source under GNU GPL v3.0 and the packaged v4 release is available from the [dedicated v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest).
+Yes. It is open source under GNU GPL v3.0 and the packaged v4 release is available from the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).

--- a/site/src/content/faq/en/updates.md
+++ b/site/src/content/faq/en/updates.md
@@ -10,4 +10,4 @@ The app checks the configured v4 channel and offers **Update and Restart**. The 
 updater, mediated by the Rust-owned `UpdateService`, verifies the exact NSIS artifact through its
 `.exe.sig` and runs the current-user installer. V4 has no bundled custom updater executable,
 portable ZIP updater, or `MANIFEST.json.sig` contract. If an update cannot be staged, download
-the canonical installer from the [dedicated v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+the canonical installer from the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).

--- a/site/src/content/faq/vi/download.md
+++ b/site/src/content/faq/vi/download.md
@@ -6,4 +6,4 @@ category: 'General'
 question: "T\u1ea3i Sky Auto Player \u1edf \u0111\u00e2u?"
 ---
 
-Tải installer Tauri NSIS canonical từ [v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+Tải installer Tauri NSIS canonical từ [trang GitHub Releases chính thức của Sky Auto Player](https://github.com/pumni/Sky-Auto-Player/releases).

--- a/site/src/content/faq/vi/free.md
+++ b/site/src/content/faq/vi/free.md
@@ -6,4 +6,4 @@ category: 'General'
 question: "Sky Auto Player c\u00f3 mi\u1ec5n ph\u00ed kh\u00f4ng?"
 ---
 
-Có. Ứng dụng là mã nguồn mở theo GNU GPL v3.0 và bản v4 đóng gói được cung cấp trên [v4 release authority riêng](https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest).
+Có. Ứng dụng là mã nguồn mở theo GNU GPL v3.0 và bản v4 đóng gói được cung cấp trên [trang GitHub Releases chính thức của Sky Auto Player](https://github.com/pumni/Sky-Auto-Player/releases).

--- a/site/src/content/faq/vi/updates.md
+++ b/site/src/content/faq/vi/updates.md
@@ -9,4 +9,4 @@ question: "C\u01a1 ch\u1ebf c\u1eadp nh\u1eadt c\u1ee7a Sky Auto Player ho\u1ea1
 Ứng dụng kiểm tra channel v4 và cung cấp **Update and Restart**. Official Tauri updater qua
 `UpdateService` Rust xác minh artifact NSIS đúng bằng `.exe.sig` rồi chạy installer current-user.
 V4 không có custom updater executable, updater ZIP portable hoặc hợp đồng `MANIFEST.json.sig`.
-Nếu update không thể stage, hãy tải installer canonical từ [v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+Nếu update không thể stage, hãy tải installer canonical từ [trang GitHub Releases chính thức của Sky Auto Player](https://github.com/pumni/Sky-Auto-Player/releases).

--- a/site/src/content/guides/en/en-troubleshooting.md
+++ b/site/src/content/guides/en/en-troubleshooting.md
@@ -101,10 +101,10 @@ in use inside Sky.
 ## Windows SmartScreen warning on launch
 
 **Cause**: The installer or an installed binary did not pass the expected Authenticode identity
-or was not downloaded from the canonical v4 authority.
+or was not downloaded from the official Sky Auto Player GitHub Releases page.
 
 **Fix**: Do not bypass the warning. Delete the download and obtain the installer and `.exe.sig`
-sidecar again from the [v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+sidecar again from the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).
 
 ## Updating manually
 
@@ -114,7 +114,7 @@ sidecar again from the [v4 release authority](https://github.com/pumni/Sky-Auto-
 
 1. Retry **Update and Restart** from the in-app update notice.
 2. If it still fails, uninstall only after preserving app data, then download the current
-   canonical NSIS installer from the [v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+   canonical NSIS installer from the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).
 3. Do not use a v3 ZIP, `MANIFEST.json`, or standalone updater executable for v4.
 
 ## The HUD shows high timing jitter

--- a/site/src/content/guides/en/en-windows-setup.md
+++ b/site/src/content/guides/en/en-windows-setup.md
@@ -36,7 +36,7 @@ evidence:
 
 ## Download and install
 
-1. Go to the [dedicated v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+1. Go to the [official Sky Auto Player GitHub Releases page](https://github.com/pumni/Sky-Auto-Player/releases).
 2. Download the canonical Tauri NSIS installer and its `.exe.sig` sidecar.
 3. Run the installer and keep the default current-user location.
 4. Launch **Sky Auto Player** from the installed shortcut.
@@ -48,7 +48,7 @@ You do not need to edit it manually — all supported settings are available fro
 app's **Settings** dialog.
 
 The canonical installer is Authenticode-qualified. If Windows reports an installer integrity or
-publisher error, discard it and download the exact package again from the v4 release authority.
+publisher error, discard it and download the exact package again from the official GitHub Releases page.
 
 ## Adding songs
 
@@ -67,7 +67,8 @@ publisher error, discard it and download the exact package again from the v4 rel
 
 ## Updating
 
-Sky Auto Player checks the configured v4 channel through the dedicated release authority and
+Sky Auto Player checks the configured v4 channel through validated metadata on the main repository's
+`release-metadata` branch and
 shows a banner when an update is available. **Update and Restart** uses the official Tauri
 updater through the Rust-owned `UpdateService`; it verifies the Tauri `.sig` and runs the
 current-user NSIS installer. V4 has no bundled `Sky-Auto-Player-Updater.exe`, portable ZIP

--- a/site/src/content/guides/vi/vi-troubleshooting.md
+++ b/site/src/content/guides/vi/vi-troubleshooting.md
@@ -99,10 +99,10 @@ dùng trong Sky.
 ## Cảnh báo Windows SmartScreen khi khởi động
 
 **Nguyên nhân**: Installer hoặc binary không đạt identity Authenticode mong đợi, hoặc không
-được tải từ release authority v4 canonical.
+được tải từ trang GitHub Releases chính thức của Sky Auto Player.
 
 **Sửa**: Không bỏ qua cảnh báo. Xóa file và tải lại installer cùng sidecar `.exe.sig` từ
-[release authority v4](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+[trang GitHub Releases chính thức của Sky Auto Player](https://github.com/pumni/Sky-Auto-Player/releases).
 
 ## Cập nhật thủ công
 
@@ -111,7 +111,7 @@ dùng trong Sky.
 **Sửa**:
 
 1. Thử lại **Update and Restart** từ thông báo cập nhật trong app.
-2. Nếu vẫn thất bại, tải installer NSIS canonical từ [v4 release authority](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+2. Nếu vẫn thất bại, tải installer NSIS canonical từ [trang GitHub Releases chính thức của Sky Auto Player](https://github.com/pumni/Sky-Auto-Player/releases).
 3. Không dùng ZIP v3, `MANIFEST.json` hoặc updater executable độc lập cho v4.
 
 ## HUD hiển thị jitter timing cao

--- a/site/src/content/guides/vi/vi-windows-setup.md
+++ b/site/src/content/guides/vi/vi-windows-setup.md
@@ -35,7 +35,7 @@ evidence:
 
 ## Tải xuống và cài đặt
 
-1. Vào [release authority v4](https://github.com/pumni/Sky-Auto-Player-Releases/releases).
+1. Vào [trang GitHub Releases chính thức của Sky Auto Player](https://github.com/pumni/Sky-Auto-Player/releases).
 2. Tải installer Tauri NSIS canonical và sidecar `.exe.sig`.
 3. Chạy installer và giữ vị trí current-user mặc định.
 4. Mở **Sky Auto Player** từ shortcut đã cài.
@@ -46,7 +46,7 @@ Lần đầu khởi động, ứng dụng tạo dữ liệu trong vùng app-data
 thủ công — mọi cài đặt được hỗ trợ đều có trong hộp thoại **Settings**.
 
 Installer canonical được xác minh Authenticode. Nếu Windows báo lỗi integrity hoặc publisher,
-hãy xóa file và tải lại từ release authority v4.
+hãy xóa file và tải lại từ trang GitHub Releases chính thức.
 
 ## Thêm bài hát
 
@@ -65,7 +65,8 @@ hãy xóa file và tải lại từ release authority v4.
 
 ## Cập nhật
 
-Sky Auto Player kiểm tra channel v4 qua release authority riêng và hiển thị banner khi có bản
+Sky Auto Player kiểm tra channel v4 qua metadata đã được xác thực trên branch `release-metadata`
+trong repository chính và hiển thị banner khi có bản
 mới. **Update and Restart** dùng official Tauri updater qua `UpdateService` Rust; updater xác
 minh `.sig` rồi chạy installer current-user. V4 không có `Sky-Auto-Player-Updater.exe`, updater
 ZIP portable hoặc hợp đồng `MANIFEST.json.sig` tùy biến.

--- a/site/src/data/home.en.ts
+++ b/site/src/data/home.en.ts
@@ -90,7 +90,7 @@ export const homeEn: HomeContent = {
       {
         title: 'Download',
         description:
-          'Get the canonical Tauri NSIS installer from the dedicated v4 release authority and install it for the current user.',
+          'Get the canonical Tauri NSIS installer from the official Sky Auto Player GitHub Releases page and install it for the current user.',
       },
       {
         title: 'Add a sheet',
@@ -179,7 +179,7 @@ export const homeEn: HomeContent = {
   finalCta: {
     title: 'Your next performance is already written.',
     description: 'Download Sky Auto Player, add a sheet and let the timing take care of itself.',
-    primaryCta: 'Download latest release',
+    primaryCta: 'Browse releases',
     secondaryCta: 'View source on GitHub',
   },
 };

--- a/site/src/data/home.vi.ts
+++ b/site/src/data/home.vi.ts
@@ -87,7 +87,7 @@ export const homeVi: HomeContent = {
       {
         title: 'Tải xuống',
         description:
-          'Tải installer Tauri NSIS canonical từ v4 release authority và cài đặt cho current user.',
+          'Tải installer Tauri NSIS canonical từ trang GitHub Releases chính thức của Sky Auto Player và cài đặt cho current user.',
       },
       {
         title: 'Thêm sheet nhạc',
@@ -176,7 +176,7 @@ export const homeVi: HomeContent = {
   finalCta: {
     title: 'Màn trình diễn tiếp theo đã nằm sẵn trong sheet.',
     description: 'Tải Sky Auto Player, thêm một sheet và để ứng dụng xử lý phần timing.',
-    primaryCta: 'Tải bản mới nhất',
+    primaryCta: 'Xem các bản phát hành',
     secondaryCta: 'Xem mã nguồn trên GitHub',
   },
 };

--- a/site/src/data/site.ts
+++ b/site/src/data/site.ts
@@ -1,7 +1,7 @@
 export const SITE = {
   name: 'Sky Auto Player',
   repositoryUrl: 'https://github.com/pumni/Sky-Auto-Player',
-  releaseUrl: 'https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest',
+  releaseUrl: 'https://github.com/pumni/Sky-Auto-Player/releases',
   productionOrigin: 'https://pumni.github.io',
   basePath: '/Sky-Auto-Player',
 } as const;

--- a/site/src/layouts/GuideLayout.astro
+++ b/site/src/layouts/GuideLayout.astro
@@ -164,7 +164,7 @@ const structuredData = [
         </div>
         <div class="guide-page__cta-actions">
           <a class="button button--primary" href={SITE.releaseUrl}>
-            {isVi ? 'Tải bản mới nhất' : 'Download latest release'}
+            {isVi ? 'Xem bản phát hành' : 'Browse releases'}
           </a>
           <a class="button button--secondary" href={withBase(guideBaseUrl)}>
             {isVi ? 'Tất cả hướng dẫn' : 'All guides'}

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -15,7 +15,7 @@ export function GET() {
 - [FAQ](${base}/faq/)
 - [Vietnamese home](${base}/vi/)
 - [Vietnamese FAQ](${base}/vi/faq/)
-- [Latest release](${SITE.releaseUrl})
+- [Releases](${SITE.releaseUrl})
 - [Source repository](${SITE.repositoryUrl})
 
 ## Guides

--- a/site/tests/e2e/accessibility.spec.ts
+++ b/site/tests/e2e/accessibility.spec.ts
@@ -43,7 +43,7 @@ test.describe('accessibility and responsive contracts', () => {
     await expect(page.locator('.nav-download')).toBeVisible();
     await expect(page.locator('.nav-download')).toHaveAttribute(
       'href',
-      'https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest',
+      'https://github.com/pumni/Sky-Auto-Player/releases',
     );
     await expect(page.locator('picture source[media="(max-width: 40rem)"]')).toHaveAttribute(
       'srcset',

--- a/site/tests/e2e/navigation.spec.ts
+++ b/site/tests/e2e/navigation.spec.ts
@@ -101,7 +101,7 @@ test.describe('navigation and route contracts', () => {
     await expect(page.locator('.nav-download')).toBeVisible();
     await expect(page.locator('.nav-download')).toHaveAttribute(
       'href',
-      'https://github.com/pumni/Sky-Auto-Player-Releases/releases/latest',
+      'https://github.com/pumni/Sky-Auto-Player/releases',
     );
   });
 });

--- a/site/tests/e2e/site-contracts.spec.ts
+++ b/site/tests/e2e/site-contracts.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 const origin = 'http://localhost:4321/Sky-Auto-Player';
+const officialReleasesUrl = 'https://github.com/pumni/Sky-Auto-Player/releases';
+const legacyLatestUrl = `${officialReleasesUrl}/latest`;
 
 const canonicalRoutes = [
   { path: '/', lang: 'en', canonical: 'https://pumni.github.io/Sky-Auto-Player/' },
@@ -45,6 +47,18 @@ test.describe('published route and asset contracts', () => {
       expect(html).toContain('<link rel="canonical" href="' + redirect.canonical + '"');
       expect(html).toContain('url=' + redirect.link);
       expect(html).toContain('href="' + redirect.link + '"');
+    }
+  });
+
+  test('active v4-facing pages use the releases collection, not legacy Latest', async ({
+    request,
+  }) => {
+    for (const path of ['/', '/faq/', '/vi/', '/vi/faq/']) {
+      const response = await request.get(origin + path);
+      expect(response.status()).toBe(200);
+      const html = await response.text();
+      expect(html).toContain(officialReleasesUrl);
+      expect(html).not.toContain(legacyLatestUrl);
     }
   });
 


### PR DESCRIPTION
Closes #163

## Summary

- update README, badges, site release links, English/Vietnamese FAQ pages, Windows setup guides, and troubleshooting pages to use `pumni/Sky-Auto-Player`;
- document `release-metadata` stable/beta channels and the v4.0.1 first-official-release boundary;
- replace the former v4 release-authority document with the current single-repository release/update runbook;
- add ADR-0007 and mark ADR-0006 superseded without rewriting its historical decision;
- mark migration and v4.0.0 rehearsal records as historical rather than current production guidance.

## Invariants preserved

- no compatibility bridge or fallback to the former v4 rehearsal repository;
- immutable GitHub Releases, exact-byte qualification, Tauri updater signatures, SBOM/provenance, `make_latest=false`, and protected release environment remain documented;
- `release-metadata` bootstrap does not fabricate `latest.json`, and promotion remains strictly monotonic;
- owner/admin branch protection, secret/repository cutover, and official v4.0.1 dispatch remain deferred to #165.

## Verification

- `cargo xtask check all` — PASS
- `cargo xtask check static` — PASS
- `bun run check` from `site/` — PASS (one existing Zod deprecation hint, zero errors)
- `git diff --check` — PASS