### PR TITLE
chore: prepare v4.0.1 final release gate

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sky_desktop_shell"
-version = "4.0.0"
+version = "4.0.1"
 workspace = "../../rust"
 edition.workspace = true
 rust-version.workspace = true

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -1,0 +1,78 @@
+# Sky Auto Player v4.0.1
+
+> Release-gate record for the first official v4 release lineage. This file is
+> prepared for the exact source commit that will be tagged `v4.0.1`; it does
+> not claim publication until the owner/admin cutover gate in issue #165
+> passes.
+
+## Release identity
+
+- Canonical repository: `pumni/Sky-Auto-Player`
+- Canonical tag: `v4.0.1`
+- Release channel: stable
+- Release metadata: the main repository's protected `release-metadata` branch
+- GitHub Latest policy: publish with `make_latest=false` while the legacy v3
+  `v3.5.0` Latest release remains the coexistence guard
+
+`v4.0.1` is the first supported v4 release. The earlier v4.0.0 and RC
+artifacts were rehearsal/pre-release infrastructure only; there is no supported
+bridge or compatibility path from those artifacts.
+
+## Distribution and update contract
+
+The supported Windows package is the exact Tauri NSIS installer and its
+Ed25519 updater signature. The final release transaction must qualify the
+re-downloaded GitHub Release assets byte-for-byte before immutable publication.
+The transaction also records the matching SPDX SBOM and GitHub OIDC provenance
+attestation for the exact source and artifact bytes.
+
+Stable and beta updater metadata are published only after the immutable release
+is verified. The client consumes the unauthenticated raw endpoints below:
+
+```text
+https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json
+https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json
+```
+
+The stable channel must contain a strictly monotonic SemVer promotion and the
+metadata signature and artifact URL must resolve to this repository. Bootstrap
+must not fabricate a `latest.json` file.
+
+## Gate status
+
+This source document is intentionally pre-publication evidence. The official
+release remains blocked until issue #165 records passing evidence for the
+same-repository draft rehearsal, exact-byte qualification, signature, SBOM,
+provenance, legacy Latest preservation, protected metadata branch, protected
+production environment, isolated signing runner, and final owner/admin
+cutover checklist.
+
+## Owner/admin cutover checklist
+
+These items are intentionally recorded as unchecked until the release owner
+proves them against the live repository and the exact approved source SHA:
+
+- [ ] Immutable releases are enabled and enforced by the repository owner.
+- [ ] `release-metadata` is initialized with the bootstrap contract and protected
+      by the approved branch ruleset.
+- [ ] `v4-production-release` has the required reviewers, variables, and
+      secrets, with bypass behavior reviewed.
+- [ ] The production signing runner is isolated from general CI and online only
+      for approved release/rehearsal jobs.
+- [ ] `V4_RELEASE_AUTHORITY_TOKEN` and obsolete authority credentials are
+      removed from repository and environment secrets.
+- [ ] The legacy rehearsal repository is retained or deleted according to the
+      owner's documented cleanup decision after the final reference scan.
+- [ ] A final repository scan passes after any legacy-repository cleanup.
+- [ ] The official workflow is dispatched once, from the exact approved source
+      SHA, with version `4.0.1`, tag `v4.0.1`, and `make_latest=false`.
+- [ ] The published immutable release, public stable metadata, installer,
+      updater signature, clean install, and update path are independently
+      verified.
+
+Observed before owner/admin cutover on the preparation branch: immutable
+releases are enabled but owner enforcement is not confirmed; the
+`release-metadata` branch exists but has no branch protection; the production
+environment has no protection rules; `V4_RELEASE_AUTHORITY_TOKEN` remains in
+the environment; and `pumni/Sky-Auto-Player-Releases` still exists. These
+observations are NO-GO evidence, not release approval.

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -10,7 +10,8 @@
 - Canonical repository: `pumni/Sky-Auto-Player`
 - Canonical tag: `v4.0.1`
 - Release channel: stable
-- Release metadata: the main repository's protected `release-metadata` branch
+- Release metadata: the main repository's `release-metadata` branch, which must
+  be protected before GO
 - GitHub Latest policy: publish with `make_latest=false` while the legacy v3
   `v3.5.0` Latest release remains the coexistence guard
 
@@ -61,8 +62,9 @@ proves them against the live repository and the exact approved source SHA:
       for approved release/rehearsal jobs.
 - [ ] `V4_RELEASE_AUTHORITY_TOKEN` and obsolete authority credentials are
       removed from repository and environment secrets.
-- [ ] The legacy rehearsal repository is retained or deleted according to the
-      owner's documented cleanup decision after the final reference scan.
+- [ ] After the final reference scan, delete the legacy rehearsal repository
+      `pumni/Sky-Auto-Player-Releases`; retaining it is not a supported
+      single-repository release state.
 - [ ] A final repository scan passes after any legacy-repository cleanup.
 - [ ] The official workflow is dispatched once, from the exact approved source
       SHA, with version `4.0.1`, tag `v4.0.1`, and `make_latest=false`.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3219,7 +3219,7 @@ version = "0.1.0"
 
 [[package]]
 name = "sky_desktop_shell"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "getrandom 0.3.4",
  "raw-window-handle",


### PR DESCRIPTION
## Summary

- prepare the canonical v4.0.1 package and lockfile version;
- add `docs/releases/v4.0.1.md` as the first-official-v4 release-gate record;
- record the owner/admin cutover checklist and current NO-GO observations without claiming publication.

Refs #165

## Verification

- `cargo xtask check all` — PASS
- `cargo xtask version check --tag v4.0.1` — PASS
- `pwsh scripts/test_v4_release_pipeline.ps1` — PASS
- `pwsh scripts/ci_v4_release_latest_guard.ps1` — PASS (`v3.5.0`, `make_latest=false`, read-only)

## Gate status

This PR does not perform or claim owner/admin actions. The live checks currently show:

- immutable releases enabled, owner enforcement not confirmed;
- `release-metadata` exists but is not branch-protected and must be protected before GO;
- `v4-production-release` has no protection rules;
- `V4_RELEASE_AUTHORITY_TOKEN` remains in the environment;
- `pumni/Sky-Auto-Player-Releases` still exists and must be deleted after the final reference scan;
- no source-matching draft rehearsal was run: available local output is stale `4.0.0-rc.2`, and no signing material was used.

Do not dispatch or merge the official release from this PR until the coordinator records the remaining exact-byte rehearsal and owner/admin gates as PASS. Issue #165 must remain open through those gates and the final GO decision.