### PR TITLE
ci: use GitHub App token for metadata promotion

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -244,9 +244,19 @@ jobs:
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT
 
+      - name: Mint release-metadata GitHub App token
+        id: metadata-app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.V4_RELEASE_METADATA_APP_ID }}
+          private-key: ${{ secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Promote release metadata only after immutable publication
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}
         run: |
           pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
             -State PromoteMetadata `

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -518,6 +518,135 @@ fn workflow_job_blocks(source: &str) -> Vec<(String, String)> {
     jobs
 }
 
+fn workflow_step_blocks(source: &str) -> Vec<(String, String)> {
+    let mut steps = Vec::new();
+    let mut current_name = None;
+    let mut current_block = String::new();
+
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        let indent = line.len() - line.trim_start().len();
+        if indent == 6 && trimmed.starts_with("- name: ") {
+            if let Some(name) = current_name.take() {
+                steps.push((name, std::mem::take(&mut current_block)));
+            }
+            current_name = Some(trimmed["- name: ".len()..].to_owned());
+            current_block.push_str(line);
+            current_block.push('\n');
+            continue;
+        }
+        if current_name.is_some() {
+            current_block.push_str(line);
+            current_block.push('\n');
+        }
+    }
+    if let Some(name) = current_name {
+        steps.push((name, current_block));
+    }
+
+    steps
+}
+
+fn validate_metadata_app_token_scope(workflow: &str) -> Result<()> {
+    const MINT_STEP: &str = "Mint release-metadata GitHub App token";
+    const PROMOTE_STEP: &str = "Promote release metadata only after immutable publication";
+    const APP_TOKEN_OUTPUT: &str = "steps.metadata-app-token.outputs.token";
+    const APP_PRIVATE_KEY: &str = "secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY";
+
+    let steps = workflow_step_blocks(workflow);
+    let mint = steps
+        .iter()
+        .find(|(name, _)| name == MINT_STEP)
+        .map(|(_, block)| block.as_str())
+        .ok_or("v4 release workflow is missing the metadata App token mint step")?;
+    let promote = steps
+        .iter()
+        .find(|(name, _)| name == PROMOTE_STEP)
+        .map(|(_, block)| block.as_str())
+        .ok_or("v4 release workflow is missing the metadata promotion step")?;
+
+    for marker in [
+        "id: metadata-app-token",
+        "uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349",
+        "app-id: ${{ vars.V4_RELEASE_METADATA_APP_ID }}",
+        "private-key: ${{ secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY }}",
+        "owner: ${{ github.repository_owner }}",
+        "repositories: ${{ github.event.repository.name }}",
+        "permission-contents: write",
+    ] {
+        if !mint.contains(marker) {
+            return Err(format!(
+                "metadata App token mint step is missing required marker: {marker}"
+            )
+            .into());
+        }
+    }
+    if mint.contains("\n        run:") || mint.contains("\n        env:") {
+        return Err(
+            "metadata App private key must be consumed only by the token-mint action".into(),
+        );
+    }
+    if workflow.matches(APP_PRIVATE_KEY).count() != 1 {
+        return Err(
+            "metadata App private key must occur exactly once in the release workflow".into(),
+        );
+    }
+    if workflow.matches(APP_TOKEN_OUTPUT).count() != 1 {
+        return Err(
+            "metadata App installation token must be used by exactly one workflow step".into(),
+        );
+    }
+    if !promote.contains(APP_TOKEN_OUTPUT) {
+        return Err("only PromoteMetadata may consume the metadata App token".into());
+    }
+    if promote.contains("GH_TOKEN: ${{ github.token }}") {
+        return Err("PromoteMetadata must not use the repository GITHUB_TOKEN".into());
+    }
+
+    for (name, block) in &steps {
+        if name != MINT_STEP && block.contains(APP_PRIVATE_KEY) {
+            return Err(
+                format!("metadata App private key escaped the token-mint action: {name}").into(),
+            );
+        }
+        if name != PROMOTE_STEP && block.contains(APP_TOKEN_OUTPUT) {
+            return Err(
+                format!("metadata App token was used outside PromoteMetadata: {name}").into(),
+            );
+        }
+    }
+
+    for normal_step in [
+        "Create exact candidate draft in canonical repository",
+        "Publish the already-qualified draft immutably",
+        "Re-fetch and verify final public release and metadata",
+    ] {
+        let block = steps
+            .iter()
+            .find(|(name, _)| name == normal_step)
+            .map(|(_, block)| block.as_str())
+            .ok_or_else(|| format!("v4 release workflow is missing release step: {normal_step}"))?;
+        if !block.contains("GH_TOKEN: ${{ github.token }}") {
+            return Err(format!(
+                "normal release step must retain the repository GITHUB_TOKEN: {normal_step}"
+            )
+            .into());
+        }
+    }
+
+    let mint_position = workflow
+        .find("- name: Mint release-metadata GitHub App token")
+        .ok_or("metadata App token mint step position is unavailable")?;
+    let promote_position = workflow
+        .find("- name: Promote release metadata only after immutable publication")
+        .ok_or("metadata promotion step position is unavailable")?;
+    if mint_position >= promote_position {
+        return Err("metadata App token must be minted immediately before promotion".into());
+    }
+
+    Ok(())
+}
+
 fn job_uses_sensitive_runner(job: &str) -> bool {
     job.lines().any(|line| {
         let trimmed = line.trim_start();
@@ -785,6 +914,7 @@ fn v4_release_pipeline_contract_source(
             "repository GITHUB_TOKEN must be present on every GitHub-mutating/read step".into(),
         );
     }
+    validate_metadata_app_token_scope(&workflow)?;
 
     if pipeline
         .matches("orchestrate_v4_production_release.ps1")
@@ -3214,6 +3344,28 @@ jobs:
     github.event.repository.default_branch
     refs/heads/main
     environment: v4-production-release
+    steps:
+      - name: Create exact candidate draft in canonical repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Publish the already-qualified draft immutably
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Mint release-metadata GitHub App token
+        id: metadata-app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.V4_RELEASE_METADATA_APP_ID }}
+          private-key: ${{ secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+      - name: Promote release metadata only after immutable publication
+        env:
+          GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}
+      - name: Re-fetch and verify final public release and metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
     Verify isolated production runner boundary
     verify_v4_release_runner.ps1
     cleanup_v4_release_state.ps1
@@ -3267,6 +3419,52 @@ class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$Upl
         assert!(
             v4_release_pipeline_contract_source(workflow, &duplicated_build, regression).is_err()
         );
+    }
+
+    #[test]
+    fn metadata_app_token_is_scoped_to_promotion_and_keeps_private_key_in_action_input() {
+        let workflow = r#"
+      - name: Create exact candidate draft in canonical repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Publish the already-qualified draft immutably
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Mint release-metadata GitHub App token
+        id: metadata-app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.V4_RELEASE_METADATA_APP_ID }}
+          private-key: ${{ secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+      - name: Promote release metadata only after immutable publication
+        env:
+          GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}
+      - name: Re-fetch and verify final public release and metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+"#;
+        assert!(validate_metadata_app_token_scope(workflow).is_ok());
+
+        let broad_token = workflow.replace(
+            "GH_TOKEN: ${{ github.token }}\n      - name: Publish",
+            "GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}\n      - name: Publish",
+        );
+        assert!(validate_metadata_app_token_scope(&broad_token).is_err());
+
+        let repository_token_for_promotion = workflow.replace(
+            "GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}",
+            "GH_TOKEN: ${{ github.token }}",
+        );
+        assert!(validate_metadata_app_token_scope(&repository_token_for_promotion).is_err());
+
+        let private_key_in_env = workflow.replace(
+            "        with:\n          app-id:",
+            "        env:\n          app-id:",
+        );
+        assert!(validate_metadata_app_token_scope(&private_key_in_env).is_err());
     }
 
     #[test]

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -374,12 +374,40 @@ foreach ($marker in @(
     'github.event.repository.default_branch',
     'refs/heads/main',
     'environment: v4-production-release',
+    'Mint release-metadata GitHub App token',
+    'id: metadata-app-token',
+    'actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349',
+    'app-id: ${{ vars.V4_RELEASE_METADATA_APP_ID }}',
+    'private-key: ${{ secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY }}',
+    'owner: ${{ github.repository_owner }}',
+    'repositories: ${{ github.event.repository.name }}',
+    'permission-contents: write',
+    'GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}',
     'Verify isolated production runner boundary',
     'verify_v4_release_runner.ps1',
     'cleanup_v4_release_state.ps1',
     'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
 )) {
     if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }
+}
+$metadataTokenMarker = 'GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}'
+$metadataTokenUses = ([regex]::Matches($workflow, [regex]::Escape($metadataTokenMarker))).Count
+if ($metadataTokenUses -ne 1) {
+    Fail "metadata App installation token must be used exactly once"
+}
+$metadataPrivateKeyMarker = 'secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY'
+$metadataPrivateKeyUses = ([regex]::Matches($workflow, [regex]::Escape($metadataPrivateKeyMarker))).Count
+if ($metadataPrivateKeyUses -ne 1) {
+    Fail "metadata App private key must be consumed exactly once by the token-mint action"
+}
+$promotionStart = $workflow.IndexOf('- name: Promote release metadata only after immutable publication', [StringComparison]::Ordinal)
+if ($promotionStart -lt 0) { Fail "metadata promotion step is missing" }
+$promotionEnd = $workflow.IndexOf("`n      - name:", $promotionStart + 1, [StringComparison]::Ordinal)
+if ($promotionEnd -lt 0) { $promotionEnd = $workflow.Length }
+$promotionBlock = $workflow.Substring($promotionStart, $promotionEnd - $promotionStart)
+if (-not $promotionBlock.Contains($metadataTokenMarker) -or
+    $promotionBlock.Contains('GH_TOKEN: ${{ github.token }}')) {
+    Fail "metadata promotion must use only the short-lived App token"
 }
 foreach ($forbidden in @(
     'cargo xtask dist', 'Sky-Auto-Player-Updater.exe', 'MANIFEST.json.sig',


### PR DESCRIPTION
## Summary

- mint a short-lived GitHub App installation token inside the protected `v4-production-release` job;
- scope the token to `pumni/Sky-Auto-Player` with `contents: write` only;
- use it only for the `PromoteMetadata` step, while draft/download/publish/final verification retain `github.token`;
- add static and regression guards against broad App-token use, private-key leakage, or old authority topology.

Refs #165

## Preserved invariants

- exact source SHA and main-branch dispatch boundary;
- dedicated single-tenant runner and protected environment;
- build-once, exact-byte re-download/qualification, updater signature, SBOM and OIDC attestations;
- immutable publication before metadata promotion;
- strict monotonic metadata and optimistic SHA concurrency;
- unauthenticated raw metadata final verification and `make_latest=false` legacy v3 Latest guard;
- no PAT, authority token, second repository, compatibility bridge, or generic credential broker.

The private key is consumed only as `${{ secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY }}` by the SHA-pinned token-mint action. It is not copied to a run step, environment variable, file, workspace, output, or artifact.

## Verification

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check` — PASS
- `cargo test --manifest-path rust/xtask/Cargo.toml` — PASS (74 tests)
- `cargo xtask check static` — PASS
- `cargo xtask check all` — PASS
- `pwsh scripts/test_v4_release_pipeline.ps1` — PASS

## Owner/admin assumptions

The dedicated App is installed only on `pumni/Sky-Auto-Player`; `V4_RELEASE_METADATA_APP_ID` is an environment variable and `V4_RELEASE_METADATA_APP_PRIVATE_KEY` is an environment secret in `v4-production-release`. The active `Protect release-metadata` ruleset supplies the App integration bypass. This PR does not dispatch a rehearsal or release, mutate metadata, or change runner state.

Exact PR head: `d30421ba4a05492d9813c71ec06e2714270a32f7`.