### PR TITLE
fix: pass rehearsal state roots safely

### DIFF
--- a/.github/workflows/rehearse-v4-production-topology.yml
+++ b/.github/workflows/rehearse-v4-production-topology.yml
@@ -84,9 +84,11 @@ jobs:
 
       - name: Verify isolated rehearsal runner boundary
         run: |
-          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/verify_v4_release_runner.ps1 `
-            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH `
-            -StateRoot $env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT
+          $runnerBoundaryArgs = @{
+            UpdaterPrivateKeyPath = $env:V4_UPDATER_PRIVATE_KEY_PATH
+            StateRoot = @($env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT)
+          }
+          & (Join-Path $PWD "scripts/verify_v4_release_runner.ps1") @runnerBoundaryArgs
 
       - name: Verify dedicated runner tools
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
@@ -128,5 +130,7 @@ jobs:
       - name: Clean runner-local rehearsal state
         if: always()
         run: |
-          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/cleanup_v4_release_state.ps1 `
-            -StateRoot $env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT
+          $cleanupArgs = @{
+            StateRoot = @($env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT)
+          }
+          & (Join-Path $PWD "scripts/cleanup_v4_release_state.ps1") @cleanupArgs

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1040,7 +1040,10 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
         "persist-credentials: false",
         "Verify isolated rehearsal runner boundary",
         "verify_v4_release_runner.ps1",
+        "StateRoot = @($env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT)",
+        "& (Join-Path $PWD \"scripts/verify_v4_release_runner.ps1\") @runnerBoundaryArgs",
         "cleanup_v4_release_state.ps1",
+        "& (Join-Path $PWD \"scripts/cleanup_v4_release_state.ps1\") @cleanupArgs",
         "Preserve bounded rehearsal evidence",
         "BuildCandidate",
         "test_v4_production_topology_rehearsal.ps1",
@@ -1067,6 +1070,7 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
         "updater_private_key_path:",
         "inputs.updater_private_key_path",
         "KeepStateOnFailure",
+        "-StateRoot $env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT",
     ] {
         if topology_workflow.contains(forbidden) {
             return Err(format!(

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -436,7 +436,10 @@ foreach ($marker in @(
     'persist-credentials: false',
     'Verify isolated rehearsal runner boundary',
     'verify_v4_release_runner.ps1',
+    'StateRoot = @($env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT)',
+    '& (Join-Path $PWD "scripts/verify_v4_release_runner.ps1") @runnerBoundaryArgs',
     'cleanup_v4_release_state.ps1',
+    '& (Join-Path $PWD "scripts/cleanup_v4_release_state.ps1") @cleanupArgs',
     'Preserve bounded rehearsal evidence',
     'BuildCandidate',
     'test_v4_production_topology_rehearsal.ps1',
@@ -460,7 +463,8 @@ foreach ($forbidden in @(
     'softprops/action-gh-release',
     'updater_private_key_path:',
     'inputs.updater_private_key_path',
-    'KeepStateOnFailure'
+    'KeepStateOnFailure',
+    '-StateRoot $env:V4_REHEARSAL_STATE_ROOT, $env:V4_REHEARSAL_QUALIFICATION_STATE_ROOT'
 )) {
     if ($topologyWorkflow.Contains($forbidden)) {
         Fail "production-topology rehearsal workflow contains a legacy release-topology marker: $forbidden"


### PR DESCRIPTION
## Summary

- fix the rehearsal runner-boundary invocation to pass both `StateRoot` values as a PowerShell array through a direct in-process script call;
- apply the same safe array/splat shape to runner-local cleanup;
- add release-contract and PowerShell self-test guards rejecting the old nested `pwsh -File ... value1, value2` binding.

Refs #165

## Scope and preserved invariants

- baseline: `87d970f79cdcf15bf331041af37bc70f9c6f62bd`;
- rehearsal workflow only; production `release-v4.yml` is unchanged;
- dedicated runner labels, protected environment, exact source checkout, RUNNER_TEMP-only roots, and updater key boundary are unchanged;
- no release creation/publication, metadata promotion, signing-material change, or runner action was performed;
- failed rehearsal run `34335230788` was not rerun.

## Verification

- `pwsh scripts/test_v4_release_pipeline.ps1` — PASS
- `cargo test --manifest-path rust/xtask/Cargo.toml` — PASS (74 tests)
- `cargo xtask check all` — PASS
- `git diff --check` — PASS

Exact PR head: `4cdd40f0791f03c4b33eba70783e77635a85d007`.