### PR TITLE
fix(v4): preserve empty fresh song enumeration

### DIFF
--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -989,6 +989,8 @@ fn v4_release_pipeline_contract_source(
         "sha256_verified",
         "songs_parseable",
         "fresh-appdata-built-in-user-composition",
+        "freshUserSongs = @(",
+        "Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue",
         "SKY_BUILTIN_CATALOG_FRESH_SELFTEST",
         "previousFreshSelfTest",
         "if ($null -eq $previousAppDataRoot)",
@@ -1019,6 +1021,15 @@ fn v4_release_pipeline_contract_source(
     {
         return Err(
             "v4 release coordinator regression test is missing build-once/publication guards"
+                .into(),
+        );
+    }
+    if !regression.contains("Test-StrictModeEmptyFreshUserSongs")
+        || !regression.contains("freshUserSongs = @(")
+        || !regression.contains("$freshUserSongs.Count -ne 0")
+    {
+        return Err(
+            "v4 release coordinator regression test is missing the StrictMode empty-directory guard"
                 .into(),
         );
     }
@@ -3442,13 +3453,14 @@ function Invoke-BuildCandidate {
 }
 function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; make_latest = $false; GitHub's successful DELETE endpoints return an empty body }
 function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
-function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; cargo xtask builtin-catalog verify-installed; SKY_BUILTIN_CATALOG_FRESH_SELFTEST; installed-built-in-catalog-exact-manifest-file-set-sha-parseability; manifest_validated; file_set_exact; sha256_verified; songs_parseable; fresh-appdata-built-in-user-composition; previousAppDataRoot; previousFreshSelfTest; if ($null -eq $previousAppDataRoot); Remove-Item Env:SKY_APP_DATA_ROOT; if ($null -eq $previousFreshSelfTest); Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST; selftest-update-active-playback; ci_v4_release_latest_guard.ps1; promote_v4_metadata.ps1; release-metadata; published_at; Start-MpScan; scan_performed }
+function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; cargo xtask builtin-catalog verify-installed; SKY_BUILTIN_CATALOG_FRESH_SELFTEST; installed-built-in-catalog-exact-manifest-file-set-sha-parseability; manifest_validated; file_set_exact; sha256_verified; songs_parseable; fresh-appdata-built-in-user-composition; freshUserSongs = @(; Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue; previousAppDataRoot; previousFreshSelfTest; if ($null -eq $previousAppDataRoot); Remove-Item Env:SKY_APP_DATA_ROOT; if ($null -eq $previousFreshSelfTest); Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST; selftest-update-active-playback; ci_v4_release_latest_guard.ps1; promote_v4_metadata.ps1; release-metadata; published_at; Start-MpScan; scan_performed }
 function Invoke-RecordAttestations { GH_TOKEN }
 function Invoke-PublishDraft { draft = $false; make_latest = $false }
 function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication; branch = "release-metadata"; GITHUB_REPOSITORY; Invoke-GitHubApi }
 function Invoke-FinalVerify { FinalVerify }
 "#;
         let regression = r#"
+function Test-StrictModeEmptyFreshUserSongs { Set-StrictMode -Version Latest; freshUserSongs = @(); $freshUserSongs.Count -ne 0 }
 class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$UploadedThroughReleaseUrl = $false; [bool]$ExactDownloadedBytes = $false; [bool]$immutable = $false; candidate rebuilt; promotion before immutable publication; BuildCount -ne 1; UploadedThroughReleaseUrl; ExactDownloadedBytes; immutable }
 "#;
         assert!(v4_release_pipeline_contract_source(workflow, pipeline, regression).is_ok());
@@ -3475,6 +3487,19 @@ class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$Upl
             )
             .is_err(),
             "production qualification must retain installed built-in catalog verification"
+        );
+        let missing_empty_directory_regression = regression.replace(
+            "Test-StrictModeEmptyFreshUserSongs",
+            "Test-MissingRegression",
+        );
+        assert!(
+            v4_release_pipeline_contract_source(
+                workflow,
+                pipeline,
+                &missing_empty_directory_regression
+            )
+            .is_err(),
+            "production qualification must retain the executable StrictMode empty-directory regression"
         );
     }
 

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -46,6 +46,27 @@ foreach ($source in @(
 
 function Fail([string]$Message) { throw "FAILED: $Message" }
 
+function Test-StrictModeEmptyFreshUserSongs {
+    Set-StrictMode -Version Latest
+    $testRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-v4-empty-fresh-songs-test-" + [guid]::NewGuid().ToString("N"))
+    $freshSongsRoot = Join-Path $testRoot "songs"
+    try {
+        New-Item -ItemType Directory -Path $freshSongsRoot -Force | Out-Null
+        $freshUserSongs = @(
+            Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue
+        )
+        if ($freshUserSongs.Count -ne 0) {
+            Fail "empty fresh songs directory unexpectedly contained user songs"
+        }
+    } finally {
+        if (Test-Path -LiteralPath $testRoot) {
+            Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Test-StrictModeEmptyFreshUserSongs
+
 function Get-SanitizedReleaseProbeOutput {
     param(
         [AllowEmptyString()]

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -827,11 +827,9 @@ function Invoke-QualifyDownloaded {
             $catalogSelftest = Start-Process -FilePath $app -ArgumentList @("--selftest-desktop-shell") -WindowStyle Hidden -Wait -PassThru
             if ($catalogSelftest.ExitCode -ne 0) { Fail "downloaded candidate fresh built-in catalog self-test failed with exit code $($catalogSelftest.ExitCode)" }
             $freshSongsRoot = Join-Path $freshAppData "songs"
-            $freshUserSongs = if (Test-Path -LiteralPath $freshSongsRoot -PathType Container) {
-                @(Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse)
-            } else {
-                @()
-            }
+            $freshUserSongs = @(
+                Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue
+            )
             if ($freshUserSongs.Count -ne 0) { Fail "downloaded candidate fresh built-in catalog self-test populated user songs" }
             $freshBuiltinCatalogEvidence = [ordered]@{
                 status = "PASS"


### PR DESCRIPTION
Refs #165

Narrow fix for the StrictMode zero-result enumeration failure in the production QualifyDownloaded path.

Changes:
- Replace the conditional fresh user-song enumeration with an explicit PowerShell array assignment, matching the proven CI pattern.
- Preserve the fail-closed Count check.
- Add an executable Set-StrictMode -Version Latest regression for an empty songs directory.
- Extend the release pipeline contract to require both the array-boundary implementation and the executable regression.

Preserved invariants:
- No changes to PublishDraft, PromoteMetadata, metadata App token scope, make_latest=false, runner policy, or draft rehearsal machinery.
- No rehearsal or official release was dispatched from this PR.

Verification:
- cargo xtask check all
- pwsh -NoProfile -NonInteractive -File scripts/test_v4_release_pipeline.ps1
- targeted xtask release-pipeline contract test
- git diff --check