### PR TITLE
feat(v4): add controlled same-repository draft rehearsal

### DIFF
--- a/.github/workflows/rehearse-v4-draft.yml
+++ b/.github/workflows/rehearse-v4-draft.yml
@@ -1,0 +1,261 @@
+name: V4 Controlled Same-Repository Draft Rehearsal
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Canonical v4 SemVer (without v prefix or build metadata)"
+        required: true
+        type: string
+      channel:
+        description: "v4 metadata channel"
+        required: true
+        type: choice
+        options: [stable, beta]
+      tag:
+        description: "Canonical repository release tag; must be exactly v<version>"
+        required: true
+        type: string
+      source_sha:
+        description: "Exact source commit SHA; must equal this workflow checkout and GITHUB_SHA"
+        required: true
+        type: string
+      release_notes_path:
+        description: "Bounded release notes file in the checked-out source"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: v4-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  draft-rehearsal-dispatch-boundary:
+    name: Validate canonical draft rehearsal dispatch context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fail closed outside the canonical default branch
+        shell: bash
+        env:
+          EXPECTED_REPOSITORY: pumni/Sky-Auto-Player
+          EXPECTED_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_EVENT_NAME" = "workflow_dispatch" || { echo "draft rehearsal requires workflow_dispatch" >&2; exit 1; }
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_REPOSITORY" || { echo "draft rehearsal repository is not canonical" >&2; exit 1; }
+          test "$GITHUB_REF" = "refs/heads/main" || { echo "draft rehearsal must be dispatched from refs/heads/main" >&2; exit 1; }
+          test "$EXPECTED_DEFAULT_BRANCH" = "main" || { echo "canonical repository default branch must be main" >&2; exit 1; }
+
+  draft-rehearsal:
+    name: V4 controlled same-repository draft rehearsal
+    needs: draft-rehearsal-dispatch-boundary
+    if: needs.draft-rehearsal-dispatch-boundary.result == 'success'
+    # This is the same dedicated/single-tenant runner class used by production.
+    runs-on: [self-hosted, windows, v4-release, single-tenant]
+    environment: v4-production-release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      V4_DRAFT_REHEARSAL_VERSION: ${{ inputs.version }}
+      V4_DRAFT_REHEARSAL_CHANNEL: ${{ inputs.channel }}
+      V4_DRAFT_REHEARSAL_TAG: ${{ inputs.tag }}
+      V4_DRAFT_REHEARSAL_SOURCE_SHA: ${{ inputs.source_sha }}
+      V4_DRAFT_REHEARSAL_WORKFLOW_SHA: ${{ github.sha }}
+      V4_DRAFT_REHEARSAL_NOTES_PATH: ${{ inputs.release_notes_path }}
+
+    steps:
+      - name: Initialize isolated draft rehearsal state root
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { throw "RUNNER_TEMP is unavailable" }
+          if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { throw "GITHUB_RUN_ID is unavailable" }
+          $base = Join-Path $env:RUNNER_TEMP ("sky-v4-draft-rehearsal-" + $env:GITHUB_RUN_ID)
+          "V4_DRAFT_REHEARSAL_STATE_ROOT=$base" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Check out the exact requested source SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify isolated draft rehearsal runner boundary
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/verify_v4_release_runner.ps1 `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT
+
+      - name: Validate exact v4 draft rehearsal request
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State ValidateRequest `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_DRAFT_REHEARSAL_NOTES_PATH
+
+      - name: Verify canonical repository release policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State ValidateRepository `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_DRAFT_REHEARSAL_NOTES_PATH
+
+      - name: Snapshot external release state before draft creation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_draft_rehearsal_external_state.ps1 `
+            -Mode Capture `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG
+
+      - name: Verify dedicated runner tools
+        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,gh.exe
+
+      - name: Build one exact candidate with the production builder
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State BuildCandidate `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -UpdaterPrivateKeyPath $env:V4_UPDATER_PRIVATE_KEY_PATH
+
+      - name: Create exact candidate draft in canonical repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State CreateDraft `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -ReleaseNotesPath $env:V4_DRAFT_REHEARSAL_NOTES_PATH
+
+      - name: Re-download exact draft assets from canonical repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State DownloadDraft `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT
+
+      - name: Qualify exact re-downloaded candidate bytes
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State QualifyDownloaded `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT
+
+      - name: Attest exact downloaded candidate and signature
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded\*.exe
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded\*.sig
+
+      - name: Attest SPDX SBOM for exact downloaded candidate
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded\*.exe
+          sbom-path: ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded\SBOM.spdx.json
+
+      - name: Verify exact-source OIDC attestations
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $gh = (Get-Command gh.exe -CommandType Application -ErrorAction Stop).Source
+          $downloaded = Join-Path $env:V4_DRAFT_REHEARSAL_STATE_ROOT "downloaded"
+          $installer = @(Get-ChildItem -LiteralPath $downloaded -Filter "*.exe" -File)
+          $signature = @(Get-ChildItem -LiteralPath $downloaded -Filter "*.sig" -File)
+          if ($installer.Count -ne 1 -or $signature.Count -ne 1) { throw "Downloaded attestation subject set is not exact" }
+          $signerWorkflow = "$env:GITHUB_REPOSITORY/.github/workflows/rehearse-v4-draft.yml"
+          & $gh attestation verify $installer[0].FullName -R $env:GITHUB_REPOSITORY --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
+          if ($LASTEXITCODE -ne 0) { throw "Installer exact-source attestation verification failed" }
+          & $gh attestation verify $signature[0].FullName -R $env:GITHUB_REPOSITORY --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
+          if ($LASTEXITCODE -ne 0) { throw "Updater signature exact-source attestation verification failed" }
+          & $gh attestation verify $installer[0].FullName -R $env:GITHUB_REPOSITORY --predicate-type https://spdx.dev/Document/v2.3 --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
+          if ($LASTEXITCODE -ne 0) { throw "SBOM exact-source attestation verification failed" }
+
+      - name: Record verified exact-byte attestations
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 `
+            -State RecordAttestations `
+            -Version $env:V4_DRAFT_REHEARSAL_VERSION `
+            -Channel $env:V4_DRAFT_REHEARSAL_CHANNEL `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA `
+            -WorkflowSha $env:V4_DRAFT_REHEARSAL_WORKFLOW_SHA `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT
+
+      - name: Remove only the rehearsal draft and matching tag
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/cleanup_v4_draft_rehearsal.ps1 `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG `
+            -SourceSha $env:V4_DRAFT_REHEARSAL_SOURCE_SHA
+
+      - name: Verify external release state was unchanged
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_draft_rehearsal_external_state.ps1 `
+            -Mode Verify `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT `
+            -Tag $env:V4_DRAFT_REHEARSAL_TAG
+
+      - name: Preserve bounded draft rehearsal evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: v4-controlled-draft-rehearsal-${{ github.run_id }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\**\*.json
+
+      - name: Clean runner-local draft rehearsal state
+        if: always()
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/cleanup_v4_release_state.ps1 `
+            -StateRoot $env:V4_DRAFT_REHEARSAL_STATE_ROOT

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -143,9 +143,18 @@ Dedicated self-hosted Windows runners executing production releases must satisfy
 ### 2.4 GitHub Actions Runner Isolation and Operator Requirements
 
 The labels `self-hosted, windows, v4-release, single-tenant` identify the production signing
-runner boundary. Only `release-v4.yml` and `rehearse-v4-production-topology.yml` may target that
-label set. Both workflows are `workflow_dispatch` only, require the canonical repository's
+runner boundary. The exact approved workflow/job allowlist is:
+
+- `.github/workflows/release-v4.yml` — job `release`, the official immutable publication path.
+- `.github/workflows/rehearse-v4-production-topology.yml` — job `rehearsal`, qualification-topology only.
+- `.github/workflows/rehearse-v4-draft.yml` — job `draft-rehearsal`, controlled draft rehearsal only.
+
+All three workflows are `workflow_dispatch` only, require the canonical repository's
 `refs/heads/main` dispatch context, and are protected by the `v4-production-release` environment.
+The draft rehearsal may create and delete only its own matching unpublished draft/tag, may create
+and verify OIDC attestations for the exact downloaded candidate, and must never publish a release
+or promote `release-metadata`. It uses the same exact runner labels and source-bound checkout as
+the official path; it is not an official publication or metadata-promotion path.
 Pull-request, fork, push, and general CI workflows must remain on ordinary hosted or non-release
 runners.
 
@@ -346,6 +355,18 @@ rehearsed without creating a GitHub Release draft. The manual workflow
 the ref containing the exact requested source SHA. It uses the same dedicated
 runner labels and explicit updater-key path as production, builds one candidate,
 then runs the script below. It has no release mutation or metadata promotion state.
+
+After that topology gate passes, the controlled same-repository draft rehearsal
+may exercise the GitHub draft boundary without publishing it. The manual workflow
+`.github/workflows/rehearse-v4-draft.yml` uses the same exact source binding, protected
+environment, dedicated runner, and concurrency group as the official release workflow.
+It executes `ValidateRequest -> ValidateRepository -> BuildCandidate -> CreateDraft
+-> DownloadDraft -> QualifyDownloaded -> RecordAttestations`, then deletes only the
+matching unpublished draft/tag. Its OIDC and SPDX attestations are verified against the
+exact downloaded bytes before `RecordAttestations`; `PublishDraft`, metadata promotion,
+and final public-release verification are intentionally unreachable in this workflow.
+The rehearsal snapshots and compares legacy v3 GitHub Latest plus both public
+`release-metadata` channel endpoints before and after cleanup.
 
 ```powershell
 pwsh scripts/test_v4_production_topology_rehearsal.ps1 -CandidateStateRoot $candidateStateRoot -StateRoot (Join-Path $env:RUNNER_TEMP "sky-v4-production-topology-rehearsal") -Version $version -Channel $channel -Tag "v$version" -SourceSha $sourceSha -WorkflowSha $sourceSha

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -823,7 +823,50 @@ fn release_runner_contract(root: &Path) -> Result<()> {
             return Err(format!("approved release runner workflow is missing: {required}").into());
         }
     }
+    release_runner_documentation_contract(root)?;
     println!("[xtask] v4 release runner trust boundary: PASS");
+    Ok(())
+}
+
+fn release_runner_documentation_contract(root: &Path) -> Result<()> {
+    let documentation = fs::read_to_string(root.join("docs/v4-release-execution-topology.md"))?;
+    release_runner_documentation_contract_source(&documentation)
+}
+
+fn release_runner_documentation_contract_source(documentation: &str) -> Result<()> {
+    let section_start = documentation
+        .find("### 2.4 GitHub Actions Runner Isolation and Operator Requirements")
+        .ok_or("release runner documentation is missing section 2.4")?;
+    let section = &documentation[section_start..];
+    let section = section
+        .find("\n### ")
+        .map_or(section, |end| &section[..end]);
+
+    let mut documented = BTreeSet::new();
+    for (index, code_segment) in section.split('`').enumerate() {
+        if index % 2 == 1 && code_segment.starts_with(".github/workflows/") {
+            documented.insert(code_segment.to_owned());
+        }
+    }
+    let expected = APPROVED_RELEASE_RUNNER_WORKFLOWS
+        .iter()
+        .map(|workflow| (*workflow).to_owned())
+        .collect::<BTreeSet<_>>();
+    if documented != expected {
+        return Err(format!(
+            "documented release runner workflow allowlist does not match the enforced allowlist: documented={documented:?}, enforced={expected:?}"
+        )
+        .into());
+    }
+    for workflow in APPROVED_RELEASE_RUNNER_WORKFLOWS {
+        let marker = format!("`{workflow}`");
+        if section.matches(&marker).count() != 1 {
+            return Err(format!(
+                "documented release runner workflow must appear exactly once in section 2.4: {workflow}"
+            )
+            .into());
+        }
+    }
     Ok(())
 }
 
@@ -3586,6 +3629,33 @@ jobs:
         let error = validate_release_runner_workflow(".github/workflows/release-v4.yml", workflow)
             .expect_err("an unprotected sensitive job subset must be rejected");
         assert!(error.to_string().contains("not approved"));
+    }
+
+    #[test]
+    fn release_runner_documentation_allowlist_matches_enforced_workflows() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let documentation = fs::read_to_string(root.join("docs/v4-release-execution-topology.md"))
+            .expect("release runner documentation fixture must exist");
+        release_runner_documentation_contract_source(&documentation)
+            .expect("documentation must enumerate exactly the approved runner workflows");
+
+        let missing = documentation.replace(
+            "`.github/workflows/rehearse-v4-draft.yml`",
+            "`draft-rehearsal-workflow-omitted.yml`",
+        );
+        assert!(
+            release_runner_documentation_contract_source(&missing).is_err(),
+            "documentation must fail when an approved runner workflow is omitted"
+        );
+
+        let extra = documentation.replace(
+            "- `.github/workflows/release-v4.yml` — job `release`, the official immutable publication path.",
+            "- `.github/workflows/release-v4.yml` — job `release`, the official immutable publication path.\n- `.github/workflows/unapproved.yml` — not approved.",
+        );
+        assert!(
+            release_runner_documentation_contract_source(&extra).is_err(),
+            "documentation must fail when an unapproved runner workflow is added"
+        );
     }
 
     #[test]

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -239,9 +239,12 @@ const ACTIVE_RELEASE_SURFACES: &[&str] = &[
     "scripts/ci_tauri_update_e2e_core.ps1",
     "scripts/verify_v4_release_runner.ps1",
     "scripts/cleanup_v4_release_state.ps1",
+    "scripts/cleanup_v4_draft_rehearsal.ps1",
+    "scripts/v4_draft_rehearsal_external_state.ps1",
     ".github/workflows/release.yml",
     ".github/workflows/release-v4.yml",
     ".github/workflows/rehearse-v4-production-topology.yml",
+    ".github/workflows/rehearse-v4-draft.yml",
     "desktop/src-tauri/src/native_update.rs",
     "desktop/src-tauri/tauri.conf.json",
     "desktop/src-tauri/Cargo.toml",
@@ -465,6 +468,7 @@ fn release_metadata_contract(root: &Path) -> Result<()> {
 const APPROVED_RELEASE_RUNNER_WORKFLOWS: &[&str] = &[
     ".github/workflows/release-v4.yml",
     ".github/workflows/rehearse-v4-production-topology.yml",
+    ".github/workflows/rehearse-v4-draft.yml",
 ];
 const RELEASE_RUNNER_LABEL_MARKER: &str =
     "runs-on: [self-hosted, windows, v4-release, single-tenant]";
@@ -473,6 +477,7 @@ fn approved_release_runner_job(relative: &str) -> Option<&'static str> {
     match relative {
         ".github/workflows/release-v4.yml" => Some("release"),
         ".github/workflows/rehearse-v4-production-topology.yml" => Some("rehearsal"),
+        ".github/workflows/rehearse-v4-draft.yml" => Some("draft-rehearsal"),
         _ => None,
     }
 }
@@ -1036,14 +1041,211 @@ fn v4_release_pipeline_contract_source(
     Ok(())
 }
 
+fn v4_draft_rehearsal_contract_source(
+    workflow: &str,
+    cleanup: &str,
+    external_state: &str,
+) -> Result<()> {
+    let workflow = workflow.replace("\r\n", "\n");
+    for marker in [
+        "name: V4 Controlled Same-Repository Draft Rehearsal",
+        "workflow_dispatch:",
+        "group: v4-release-${{ inputs.tag }}",
+        "contents: read",
+        "contents: write",
+        "id-token: write",
+        "attestations: write",
+        "draft-rehearsal-dispatch-boundary",
+        "github.event.repository.default_branch",
+        "refs/heads/main",
+        "runs-on: [self-hosted, windows, v4-release, single-tenant]",
+        "environment: v4-production-release",
+        "ref: ${{ inputs.source_sha }}",
+        "persist-credentials: false",
+        "V4_UPDATER_PRIVATE_KEY_PATH",
+        "verify_v4_release_runner.ps1",
+        "cleanup_v4_release_state.ps1",
+        "Create exact candidate draft in canonical repository",
+        "Re-download exact draft assets from canonical repository",
+        "Qualify exact re-downloaded candidate bytes",
+        "Record verified exact-byte attestations",
+        "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6",
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        "--source-digest $env:GITHUB_SHA",
+        "-Mode Capture",
+        "-Mode Verify",
+        "cleanup_v4_draft_rehearsal.ps1",
+        "v4_draft_rehearsal_external_state.ps1",
+        "if: always()",
+    ] {
+        if !workflow.contains(marker) {
+            return Err(format!(
+                "controlled draft rehearsal workflow is missing its required marker: {marker}"
+            )
+            .into());
+        }
+    }
+    if !workflow_declares_only_dispatch(&workflow) {
+        return Err(
+            "controlled draft rehearsal must whitelist workflow_dispatch as its only trigger"
+                .into(),
+        );
+    }
+
+    let workflow_states = [
+        "-State ValidateRequest",
+        "-State ValidateRepository",
+        "-State BuildCandidate",
+        "-State CreateDraft",
+        "-State DownloadDraft",
+        "-State QualifyDownloaded",
+        "-State RecordAttestations",
+    ];
+    let mut previous = 0;
+    for marker in workflow_states {
+        let position = workflow.find(marker).ok_or_else(|| {
+            format!("controlled draft rehearsal is missing state marker: {marker}")
+        })?;
+        if position < previous {
+            return Err("controlled draft rehearsal states are not ordered fail-closed".into());
+        }
+        previous = position;
+    }
+
+    for forbidden in [
+        "PublishDraft",
+        "PromoteMetadata",
+        "FinalVerify",
+        "create-github-app-token",
+        "metadata-app-token",
+        "softprops/action-gh-release",
+        "gh release",
+        "actions/create-github-app-token",
+        "updater_private_key_path:",
+        "inputs.updater_private_key_path",
+        "make_latest = $true",
+        "V4_RELEASE_AUTHORITY_TOKEN",
+        "V4_RELEASE_AUTHORITY_REPOSITORY",
+    ] {
+        if workflow.contains(forbidden) {
+            return Err(format!(
+                "controlled draft rehearsal contains a forbidden publication or trust-boundary marker: {forbidden}"
+            )
+            .into());
+        }
+    }
+    if workflow.matches("GH_TOKEN: ${{ github.token }}").count() < 1 {
+        return Err(
+            "controlled draft rehearsal must use the repository GITHUB_TOKEN for GitHub operations"
+                .into(),
+        );
+    }
+
+    let cleanup = cleanup.replace("\r\n", "\n");
+    for marker in [
+        "RUNNER_TEMP",
+        "GITHUB_WORKSPACE",
+        "StateRoot must be a child of RUNNER_TEMP",
+        "source_sha",
+        "draft",
+        "published_at",
+        "body",
+        "git/ref/tags",
+        "--method",
+        "DELETE",
+        "remainingRelease",
+        "remainingTag",
+        "draft-cleanup-authorized.json",
+        "refusing to delete a published release",
+        "mismatched source",
+    ] {
+        if !cleanup.contains(marker) {
+            return Err(format!(
+                "controlled draft rehearsal cleanup is missing its fail-closed marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "PublishDraft",
+        "PromoteMetadata",
+        "FinalVerify",
+        "Sky-Auto-Player-Releases",
+        "V4_RELEASE_AUTHORITY_",
+    ] {
+        if cleanup.contains(forbidden) {
+            return Err(format!(
+                "controlled draft rehearsal cleanup contains a forbidden marker: {forbidden}"
+            )
+            .into());
+        }
+    }
+
+    let external_state = external_state.replace("\r\n", "\n");
+    for marker in [
+        "Capture",
+        "Verify",
+        "raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json",
+        "raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json",
+        "releases/latest",
+        "^v3\\.",
+        "AllowAutoRedirect",
+        "Headers.Authorization",
+        "StatusCode",
+        "sha256",
+        "external-state-before.json",
+        "external-state-after.json",
+        "GITHUB_REPOSITORY",
+        "target_release_absent",
+        "target_tag_absent",
+    ] {
+        if !external_state.contains(marker) {
+            return Err(format!(
+                "controlled draft rehearsal external-state check is missing its marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in [
+        "--method",
+        "POST",
+        "PATCH",
+        "PUT",
+        "DELETE",
+        "gh release",
+        "Sky-Auto-Player-Releases",
+        "V4_RELEASE_AUTHORITY_",
+    ] {
+        if external_state.contains(forbidden) {
+            return Err(format!(
+                "controlled draft rehearsal external-state check contains a mutation marker: {forbidden}"
+            )
+            .into());
+        }
+    }
+    if !external_state.contains("System.Net.Http.HttpMethod]::Get") {
+        return Err("raw metadata verification must use an explicit unauthenticated GET".into());
+    }
+    if external_state.contains("Headers.Authorization =") {
+        return Err("raw metadata verification must not assign an Authorization header".into());
+    }
+    Ok(())
+}
+
 fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
     let workflow_path = root.join(".github/workflows/release-v4.yml");
     let topology_workflow_path = root.join(".github/workflows/rehearse-v4-production-topology.yml");
+    let draft_workflow_path = root.join(".github/workflows/rehearse-v4-draft.yml");
     let pipeline_path = root.join("scripts/v4_release_pipeline.ps1");
     let regression_path = root.join("scripts/test_v4_release_pipeline.ps1");
+    let draft_cleanup_path = root.join("scripts/cleanup_v4_draft_rehearsal.ps1");
+    let external_state_path = root.join("scripts/v4_draft_rehearsal_external_state.ps1");
     let pipeline = fs::read_to_string(&pipeline_path)?;
     let regression = fs::read_to_string(&regression_path)?;
     let topology_workflow = fs::read_to_string(&topology_workflow_path)?;
+    let draft_workflow = fs::read_to_string(&draft_workflow_path)?;
+    let draft_cleanup = fs::read_to_string(&draft_cleanup_path)?;
+    let external_state = fs::read_to_string(&external_state_path)?;
     v4_release_pipeline_contract_source(
         &fs::read_to_string(&workflow_path)?,
         &pipeline,
@@ -1103,6 +1305,11 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
             .into());
         }
     }
+    v4_draft_rehearsal_contract_source(&draft_workflow, &draft_cleanup, &external_state).map_err(
+        |error| -> Box<dyn std::error::Error + Send + Sync> {
+            format!("controlled draft rehearsal contract: {error}").into()
+        },
+    )?;
     for script_name in [
         "scripts/v4_updater_credential_broker.ps1",
         "scripts/set_v4_updater_session_credential.ps1",
@@ -3379,6 +3586,46 @@ jobs:
         let error = validate_release_runner_workflow(".github/workflows/release-v4.yml", workflow)
             .expect_err("an unprotected sensitive job subset must be rejected");
         assert!(error.to_string().contains("not approved"));
+    }
+
+    #[test]
+    fn controlled_draft_rehearsal_contract_rejects_publication_and_weak_runner_regressions() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let workflow = fs::read_to_string(root.join(".github/workflows/rehearse-v4-draft.yml"))
+            .expect("controlled draft rehearsal workflow fixture must exist");
+        let cleanup = fs::read_to_string(root.join("scripts/cleanup_v4_draft_rehearsal.ps1"))
+            .expect("controlled draft cleanup fixture must exist");
+        let external =
+            fs::read_to_string(root.join("scripts/v4_draft_rehearsal_external_state.ps1"))
+                .expect("external state fixture must exist");
+
+        v4_draft_rehearsal_contract_source(&workflow, &cleanup, &external)
+            .expect("controlled draft rehearsal contract should pass its repository fixture");
+
+        let publication_regression = workflow.replace(
+            "-State RecordAttestations",
+            "-State RecordAttestations\n            -State PublishDraft",
+        );
+        assert!(
+            v4_draft_rehearsal_contract_source(&publication_regression, &cleanup, &external)
+                .is_err(),
+            "draft rehearsal must reject a publication state"
+        );
+
+        let weak_runner = workflow.replace(
+            RELEASE_RUNNER_LABEL_MARKER,
+            "runs-on: [self-hosted, windows, v4-release]",
+        );
+        let error = validate_release_runner_workflow(
+            ".github/workflows/rehearse-v4-draft.yml",
+            &weak_runner,
+        )
+        .expect_err("draft rehearsal must retain the exact signing runner labels");
+        assert!(
+            error
+                .to_string()
+                .contains("exact dedicated release runner labels")
+        );
     }
 
     #[test]

--- a/scripts/cleanup_v4_draft_rehearsal.ps1
+++ b/scripts/cleanup_v4_draft_rehearsal.ps1
@@ -1,0 +1,194 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$StateRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Tag,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SourceSha
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$canonicalRepository = "pumni/Sky-Auto-Player"
+
+function Fail([string]$Message) {
+    throw "V4 draft rehearsal cleanup failed closed: $Message"
+}
+
+function Get-PropertyValue([object]$Object, [string]$Name) {
+    if ($null -eq $Object) { return $null }
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) { return $null }
+    return $property.Value
+}
+
+function Get-IsolatedStateRoot {
+    if ([string]::IsNullOrWhiteSpace($StateRoot)) { Fail "StateRoot is required" }
+    if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { Fail "RUNNER_TEMP is unavailable" }
+
+    $full = [IO.Path]::GetFullPath($StateRoot)
+    $runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP)
+    $runnerTempPrefix = $runnerTemp.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $workspace = if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+        $repoRoot
+    } else {
+        [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+    }
+    $workspacePrefix = $workspace.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+
+    if ($full.Equals($runnerTemp, [StringComparison]::OrdinalIgnoreCase) -or
+        -not $full.StartsWith($runnerTempPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "StateRoot must be a child of RUNNER_TEMP"
+    }
+    if ($full.Equals($workspace, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.StartsWith($workspacePrefix, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "refusing to mutate a path inside the repository workspace"
+    }
+    New-Item -ItemType Directory -Path $full -Force | Out-Null
+    return $full
+}
+
+function Invoke-GitHubApi {
+    param(
+        [Parameter(Mandatory = $true)] [string[]]$Arguments,
+        [switch]$AllowNotFound
+    )
+
+    $errorPath = Join-Path $script:isolatedStateRoot ("gh-cleanup-error-" + [guid]::NewGuid().ToString("N") + ".log")
+    try {
+        $response = & gh @Arguments 2>$errorPath
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $errorText = if (Test-Path -LiteralPath $errorPath) { Get-Content -LiteralPath $errorPath -Raw } else { "" }
+            if ($AllowNotFound -and $errorText -match '(?i)(404|not found)') { return $null }
+            Fail "GitHub API request failed"
+        }
+        $responseText = ($response -join "`n")
+        if ([string]::IsNullOrWhiteSpace($responseText)) { return $null }
+        return ($responseText | ConvertFrom-Json)
+    } finally {
+        Remove-Item -LiteralPath $errorPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-CanonicalRepository {
+    if ($env:GITHUB_REPOSITORY -ne $canonicalRepository) {
+        Fail "cleanup is permitted only for the canonical repository"
+    }
+}
+
+function Assert-SourceIdentity {
+    if ([string]::IsNullOrWhiteSpace($Tag) -or $Tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+        Fail "Tag is not a canonical v4 release tag"
+    }
+    if ([string]::IsNullOrWhiteSpace($SourceSha) -or $SourceSha -notmatch '^[0-9a-fA-F]{40}$') {
+        Fail "SourceSha must be an exact 40-character commit SHA"
+    }
+}
+
+function Read-CleanupAuthorization {
+    $path = Join-Path $script:isolatedStateRoot "draft-cleanup-authorized.json"
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+    try {
+        return Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    } catch {
+        Fail "cleanup authorization marker is not valid JSON"
+    }
+}
+
+function Assert-CleanupAuthorization([object]$Authorization) {
+    if ($null -eq $Authorization -or [string](Get-PropertyValue $Authorization "status") -ne "READY") {
+        Fail "cleanup authorization marker is missing; refusing to mutate pre-existing draft/tag"
+    }
+    if ([string](Get-PropertyValue $Authorization "tag") -ne $Tag -or
+        [string](Get-PropertyValue $Authorization "source_sha") -ne $SourceSha.ToLowerInvariant()) {
+        Fail "cleanup authorization marker does not match the requested source identity"
+    }
+}
+
+function Assert-DraftMatchesSource([object]$Release) {
+    if ([string](Get-PropertyValue $Release "tag_name") -ne $Tag) {
+        Fail "draft release tag does not match the requested tag"
+    }
+    if (-not [bool](Get-PropertyValue $Release "draft") -or
+        -not [string]::IsNullOrWhiteSpace([string](Get-PropertyValue $Release "published_at"))) {
+        Fail "refusing to delete a published release"
+    }
+    $body = [string](Get-PropertyValue $Release "body")
+    $source = $SourceSha.ToLowerInvariant()
+    if ($body -notmatch "(?m)^source_sha:\s*$([regex]::Escape($source))\s*$") {
+        Fail "refusing to delete a draft with a mismatched source_sha"
+    }
+}
+
+function Assert-TagMatchesSource([object]$Ref) {
+    $object = Get-PropertyValue $Ref "object"
+    $sha = [string](Get-PropertyValue $object "sha")
+    if ($sha -notmatch '^[0-9a-fA-F]{40}$' -or
+        $sha.ToLowerInvariant() -ne $SourceSha.ToLowerInvariant()) {
+        Fail "refusing to delete a tag with a mismatched source"
+    }
+}
+
+$script:isolatedStateRoot = Get-IsolatedStateRoot
+Assert-CanonicalRepository
+Assert-SourceIdentity
+$authorization = Read-CleanupAuthorization
+$repository = $env:GITHUB_REPOSITORY
+$release = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/tags/$Tag") -AllowNotFound
+$tagRef = Invoke-GitHubApi -Arguments @("api", "repos/$repository/git/ref/tags/$Tag") -AllowNotFound
+
+if ($null -eq $authorization -and ($null -ne $release -or $null -ne $tagRef)) {
+    Fail "cleanup authorization marker is missing; refusing to mutate pre-existing draft/tag"
+}
+if ($null -ne $authorization) { Assert-CleanupAuthorization $authorization }
+
+$draftDeleted = $false
+$tagDeleted = $false
+if ($null -ne $release) {
+    Assert-DraftMatchesSource $release
+    $releaseId = Get-PropertyValue $release "id"
+    if ($null -eq $releaseId) { Fail "draft release id is missing" }
+    Invoke-GitHubApi -Arguments @(
+        "api", "--method", "DELETE", "repos/$repository/releases/$releaseId"
+    ) -AllowNotFound | Out-Null
+    $remainingRelease = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/tags/$Tag") -AllowNotFound
+    if ($null -ne $remainingRelease) { Fail "draft release could not be removed" }
+    $draftDeleted = $true
+}
+
+if ($null -ne $tagRef) {
+    if ($null -eq $release) {
+        Fail "refusing to delete an orphan tag without its matching draft release"
+    }
+    Assert-TagMatchesSource $tagRef
+    Invoke-GitHubApi -Arguments @(
+        "api", "--method", "DELETE", "repos/$repository/git/refs/tags/$Tag"
+    ) -AllowNotFound | Out-Null
+    $remainingTag = Invoke-GitHubApi -Arguments @("api", "repos/$repository/git/ref/tags/$Tag") -AllowNotFound
+    if ($null -ne $remainingTag) { Fail "draft tag could not be removed" }
+    $tagDeleted = $true
+}
+
+$evidence = [ordered]@{
+    schema_version = 1
+    status = "PASS"
+    repository = $repository
+    tag = $Tag
+    source_sha = $SourceSha.ToLowerInvariant()
+    draft_deleted = $draftDeleted
+    tag_deleted = $tagDeleted
+    published_release_refused = $false
+    mismatched_source_refused = $false
+}
+$evidencePath = Join-Path $script:isolatedStateRoot "draft-cleanup.json"
+$evidence | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $evidencePath -Encoding utf8
+Write-Host "V4 draft rehearsal cleanup: PASS (draft_deleted=$draftDeleted; tag_deleted=$tagDeleted)"

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -12,6 +12,9 @@ $fixtureCorePath = Join-Path $PSScriptRoot "ci_tauri_update_e2e_core.ps1"
 $uploadHelperPath = Join-Path $PSScriptRoot "v4_release_asset_upload.ps1"
 $workflowPath = Join-Path $repoRoot ".github/workflows/release-v4.yml"
 $topologyWorkflowPath = Join-Path $repoRoot ".github/workflows/rehearse-v4-production-topology.yml"
+$draftWorkflowPath = Join-Path $repoRoot ".github/workflows/rehearse-v4-draft.yml"
+$draftCleanupPath = Join-Path $PSScriptRoot "cleanup_v4_draft_rehearsal.ps1"
+$externalStatePath = Join-Path $PSScriptRoot "v4_draft_rehearsal_external_state.ps1"
 $pipeline = Get-Content -LiteralPath $pipelinePath -Raw
 $topologyRehearsal = Get-Content -LiteralPath $topologyRehearsalPath -Raw
 $fixtureWrapper = Get-Content -LiteralPath $fixtureWrapperPath -Raw
@@ -19,6 +22,9 @@ $fixtureCore = Get-Content -LiteralPath $fixtureCorePath -Raw
 $uploadHelper = Get-Content -LiteralPath $uploadHelperPath -Raw
 $workflow = Get-Content -LiteralPath $workflowPath -Raw
 $topologyWorkflow = Get-Content -LiteralPath $topologyWorkflowPath -Raw
+$draftWorkflow = Get-Content -LiteralPath $draftWorkflowPath -Raw
+$draftCleanup = Get-Content -LiteralPath $draftCleanupPath -Raw
+$externalState = Get-Content -LiteralPath $externalStatePath -Raw
 $testHarness = Get-Content -LiteralPath $PSCommandPath -Raw
 
 foreach ($source in @(
@@ -26,7 +32,10 @@ foreach ($source in @(
     [pscustomobject]@{ Name = "release pipeline"; Text = $pipeline },
     [pscustomobject]@{ Name = "metadata promotion"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "promote_v4_metadata.ps1") -Raw) },
     [pscustomobject]@{ Name = "asset upload"; Text = $uploadHelper },
-    [pscustomobject]@{ Name = "legacy Latest guard"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1") -Raw) }
+    [pscustomobject]@{ Name = "legacy Latest guard"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1") -Raw) },
+    [pscustomobject]@{ Name = "controlled draft rehearsal workflow"; Text = $draftWorkflow },
+    [pscustomobject]@{ Name = "controlled draft cleanup"; Text = $draftCleanup },
+    [pscustomobject]@{ Name = "controlled draft external-state check"; Text = $externalState }
 )) {
     foreach ($forbidden in @(
         "Sky-Auto-Player-Releases",
@@ -45,6 +54,97 @@ foreach ($source in @(
 }
 
 function Fail([string]$Message) { throw "FAILED: $Message" }
+
+foreach ($marker in @(
+    'name: V4 Controlled Same-Repository Draft Rehearsal',
+    'workflow_dispatch:',
+    'group: v4-release-${{ inputs.tag }}',
+    'draft-rehearsal-dispatch-boundary',
+    'runs-on: [self-hosted, windows, v4-release, single-tenant]',
+    'environment: v4-production-release',
+    'contents: write',
+    'id-token: write',
+    'attestations: write',
+    'ref: ${{ inputs.source_sha }}',
+    'persist-credentials: false',
+    'ValidateRequest', 'ValidateRepository', 'BuildCandidate', 'CreateDraft',
+    'DownloadDraft', 'QualifyDownloaded', 'RecordAttestations',
+    'actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6',
+    '--source-digest $env:GITHUB_SHA',
+    '-Mode Capture', '-Mode Verify',
+    'cleanup_v4_draft_rehearsal.ps1',
+    'v4_draft_rehearsal_external_state.ps1',
+    'if: always()',
+    'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'
+)) {
+    if (-not $draftWorkflow.Contains($marker)) {
+        Fail "controlled draft rehearsal workflow marker is missing: $marker"
+    }
+}
+$draftStates = @(
+    '-State ValidateRequest', '-State ValidateRepository', '-State BuildCandidate',
+    '-State CreateDraft', '-State DownloadDraft', '-State QualifyDownloaded',
+    '-State RecordAttestations'
+)
+$previousDraftStatePosition = -1
+foreach ($stateMarker in $draftStates) {
+    $draftStatePosition = $draftWorkflow.IndexOf($stateMarker)
+    if ($draftStatePosition -lt 0 -or $draftStatePosition -lt $previousDraftStatePosition) {
+        Fail "controlled draft rehearsal states are missing or out of order: $stateMarker"
+    }
+    $previousDraftStatePosition = $draftStatePosition
+}
+foreach ($forbidden in @(
+    'PublishDraft', 'PromoteMetadata', 'FinalVerify',
+    'create-github-app-token', 'metadata-app-token',
+    'softprops/action-gh-release', 'gh release',
+    'actions/create-github-app-token',
+    'updater_private_key_path:', 'inputs.updater_private_key_path',
+    'V4_RELEASE_AUTHORITY_TOKEN', 'V4_RELEASE_AUTHORITY_REPOSITORY',
+    'make_latest = $true'
+)) {
+    if ($draftWorkflow.Contains($forbidden)) {
+        Fail "controlled draft rehearsal workflow contains forbidden marker: $forbidden"
+    }
+}
+
+foreach ($marker in @(
+    'RUNNER_TEMP', 'GITHUB_WORKSPACE', 'StateRoot must be a child of RUNNER_TEMP',
+    'source_sha', 'published_at', 'git/ref/tags', '--method', 'DELETE',
+    'remainingRelease', 'remainingTag', 'draft-cleanup-authorized.json',
+    'refusing to delete a published release', 'mismatched source'
+)) {
+    if (-not $draftCleanup.Contains($marker)) {
+        Fail "controlled draft cleanup marker is missing: $marker"
+    }
+}
+foreach ($forbidden in @('PublishDraft', 'PromoteMetadata', 'FinalVerify', 'Sky-Auto-Player-Releases', 'V4_RELEASE_AUTHORITY_')) {
+    if ($draftCleanup.Contains($forbidden)) {
+        Fail "controlled draft cleanup contains forbidden marker: $forbidden"
+    }
+}
+
+foreach ($marker in @(
+    'Capture', 'Verify',
+    'raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json',
+    'raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json',
+    'releases/latest', '^v3\.', 'AllowAutoRedirect', 'Headers.Authorization',
+    'StatusCode', 'sha256', 'external-state-before.json', 'external-state-after.json',
+    'GITHUB_REPOSITORY', 'target_release_absent', 'target_tag_absent'
+)) {
+    if (-not $externalState.Contains($marker)) {
+        Fail "controlled draft external-state marker is missing: $marker"
+    }
+}
+foreach ($forbidden in @('--method', 'POST', 'PATCH', 'PUT', 'DELETE', 'gh release', 'Sky-Auto-Player-Releases', 'V4_RELEASE_AUTHORITY_')) {
+    if ($externalState.Contains($forbidden)) {
+        Fail "controlled draft external-state check contains forbidden mutation marker: $forbidden"
+    }
+}
+if (-not $externalState.Contains('System.Net.Http.HttpMethod]::Get') -or
+    $externalState.Contains('Headers.Authorization =')) {
+    Fail "raw metadata endpoint check must be an explicit unauthenticated GET"
+}
 
 function Test-StrictModeEmptyFreshUserSongs {
     Set-StrictMode -Version Latest

--- a/scripts/v4_draft_rehearsal_external_state.ps1
+++ b/scripts/v4_draft_rehearsal_external_state.ps1
@@ -1,0 +1,279 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Capture", "Verify")]
+    [string]$Mode,
+
+    [Parameter(Mandatory = $true)]
+    [string]$StateRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Tag
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$canonicalRepository = "pumni/Sky-Auto-Player"
+$metadataEndpoints = [ordered]@{
+    stable = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json"
+    beta = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json"
+}
+
+function Fail([string]$Message) {
+    throw "V4 draft rehearsal external-state check failed closed: $Message"
+}
+
+function Get-PropertyValue([object]$Object, [string]$Name) {
+    if ($null -eq $Object) { return $null }
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) { return $null }
+    return $property.Value
+}
+
+function Get-IsolatedStateRoot {
+    if ([string]::IsNullOrWhiteSpace($StateRoot)) { Fail "StateRoot is required" }
+    if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) { Fail "RUNNER_TEMP is unavailable" }
+
+    $full = [IO.Path]::GetFullPath($StateRoot)
+    $runnerTemp = [IO.Path]::GetFullPath($env:RUNNER_TEMP)
+    $runnerTempPrefix = $runnerTemp.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $workspace = if ([string]::IsNullOrWhiteSpace($env:GITHUB_WORKSPACE)) {
+        $repoRoot
+    } else {
+        [IO.Path]::GetFullPath($env:GITHUB_WORKSPACE)
+    }
+    $workspacePrefix = $workspace.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    $repoPrefix = $repoRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+
+    if ($full.Equals($runnerTemp, [StringComparison]::OrdinalIgnoreCase) -or
+        -not $full.StartsWith($runnerTempPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "StateRoot must be a child of RUNNER_TEMP"
+    }
+    if ($full.Equals($workspace, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.StartsWith($workspacePrefix, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.Equals($repoRoot, [StringComparison]::OrdinalIgnoreCase) -or
+        $full.StartsWith($repoPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "refusing to mutate a path inside the repository workspace"
+    }
+    New-Item -ItemType Directory -Path $full -Force | Out-Null
+    return $full
+}
+
+function Invoke-ReadOnlyGitHubApi {
+    param(
+        [Parameter(Mandatory = $true)] [string[]]$Arguments,
+        [switch]$AllowNotFound
+    )
+
+    $errorPath = Join-Path $script:isolatedStateRoot ("gh-state-error-" + [guid]::NewGuid().ToString("N") + ".log")
+    try {
+        $response = & gh @Arguments 2>$errorPath
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            $errorText = if (Test-Path -LiteralPath $errorPath) { Get-Content -LiteralPath $errorPath -Raw } else { "" }
+            if ($AllowNotFound -and $errorText -match '(?i)(404|not found)') { return $null }
+            Fail "GitHub API request failed"
+        }
+        $responseText = ($response -join "`n")
+        if ([string]::IsNullOrWhiteSpace($responseText)) { return $null }
+        return ($responseText | ConvertFrom-Json)
+    } finally {
+        Remove-Item -LiteralPath $errorPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Assert-CanonicalRepository {
+    if ($env:GITHUB_REPOSITORY -ne $canonicalRepository) {
+        Fail "external-state inspection is permitted only for the canonical repository"
+    }
+}
+
+function Assert-TagIdentity {
+    if ([string]::IsNullOrWhiteSpace($Tag) -or $Tag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+        Fail "Tag is not a canonical v4 release tag"
+    }
+}
+
+function Get-LegacyLatestSnapshot {
+    $release = Invoke-ReadOnlyGitHubApi -Arguments @(
+        "api", "repos/$env:GITHUB_REPOSITORY/releases/latest"
+    )
+    if ($null -eq $release) { Fail "legacy GitHub Latest release is unavailable" }
+    $tagName = [string](Get-PropertyValue $release "tag_name")
+    if ($tagName -notmatch '^v3\.') { Fail "GitHub Latest is not the expected immutable legacy v3 release" }
+    if ([bool](Get-PropertyValue $release "draft") -or
+        [string]::IsNullOrWhiteSpace([string](Get-PropertyValue $release "published_at"))) {
+        Fail "GitHub Latest is not a published non-draft release"
+    }
+
+    $assetRecords = @(
+        @(Get-PropertyValue $release "assets") | ForEach-Object {
+            $digest = Get-PropertyValue $_ "digest"
+            [ordered]@{
+                name = [string](Get-PropertyValue $_ "name")
+                size = [int64](Get-PropertyValue $_ "size")
+                digest = if ($null -eq $digest) { $null } else { [string]$digest }
+                browser_download_url = [string](Get-PropertyValue $_ "browser_download_url")
+            }
+        } | Sort-Object -Property name
+    )
+    return [ordered]@{
+        id = [int64](Get-PropertyValue $release "id")
+        tag_name = $tagName
+        draft = [bool](Get-PropertyValue $release "draft")
+        prerelease = [bool](Get-PropertyValue $release "prerelease")
+        published_at = [string](Get-PropertyValue $release "published_at")
+        assets = @($assetRecords)
+    }
+}
+
+function Get-RawMetadataSnapshot([string]$Channel) {
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $handler.AllowAutoRedirect = $false
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    $request = $null
+    $response = $null
+    try {
+        $url = [string]$metadataEndpoints[$Channel]
+        $request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Get, $url)
+        if ($null -ne $request.Headers.Authorization) {
+            Fail "raw metadata request must not carry an Authorization header"
+        }
+        $request.Headers.UserAgent.ParseAdd("Sky-Auto-Player-v4-draft-rehearsal/1.0")
+        $response = $client.SendAsync($request).GetAwaiter().GetResult()
+        if ($response.StatusCode -eq [System.Net.HttpStatusCode]::NotFound) {
+            return [ordered]@{
+                channel = $Channel
+                endpoint = $url
+                status = 404
+                byte_length = 0
+                sha256 = $null
+            }
+        }
+        if ($response.StatusCode -ne [System.Net.HttpStatusCode]::OK) {
+            Fail "raw $Channel metadata endpoint returned unexpected status $([int]$response.StatusCode)"
+        }
+        $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+        $sha = [Security.Cryptography.SHA256]::Create()
+        try {
+            $digest = [Convert]::ToHexString($sha.ComputeHash($bytes)).ToLowerInvariant()
+        } finally {
+            $sha.Dispose()
+        }
+        return [ordered]@{
+            channel = $Channel
+            endpoint = $url
+            status = 200
+            byte_length = [int64]$bytes.Length
+            sha256 = $digest
+        }
+    } finally {
+        if ($null -ne $response) { $response.Dispose() }
+        if ($null -ne $request) { $request.Dispose() }
+        $client.Dispose()
+        $handler.Dispose()
+    }
+}
+
+function Get-TargetResidue {
+    $release = Invoke-ReadOnlyGitHubApi -Arguments @(
+        "api", "repos/$env:GITHUB_REPOSITORY/releases/tags/$Tag"
+    ) -AllowNotFound
+    $tagRef = Invoke-ReadOnlyGitHubApi -Arguments @(
+        "api", "repos/$env:GITHUB_REPOSITORY/git/ref/tags/$Tag"
+    ) -AllowNotFound
+    return [ordered]@{
+        release_present = ($null -ne $release)
+        tag_present = ($null -ne $tagRef)
+    }
+}
+
+function Get-ExternalSnapshot {
+    $target = Get-TargetResidue
+    return [ordered]@{
+        schema_version = 1
+        repository = $env:GITHUB_REPOSITORY
+        legacy_latest = Get-LegacyLatestSnapshot
+        metadata = [ordered]@{
+            stable = Get-RawMetadataSnapshot "stable"
+            beta = Get-RawMetadataSnapshot "beta"
+        }
+        target = $target
+    }
+}
+
+function Convert-SnapshotToJson([object]$Snapshot) {
+    return $Snapshot | ConvertTo-Json -Compress -Depth 30
+}
+
+function Get-JsonSha256([string]$Json) {
+    $sha = [Security.Cryptography.SHA256]::Create()
+    try {
+        return [Convert]::ToHexString($sha.ComputeHash([Text.Encoding]::UTF8.GetBytes($Json))).ToLowerInvariant()
+    } finally {
+        $sha.Dispose()
+    }
+}
+
+function Write-JsonFile([string]$Path, [object]$Value) {
+    $json = $Value | ConvertTo-Json -Depth 30
+    [IO.File]::WriteAllText($Path, $json + "`n", [Text.UTF8Encoding]::new($false))
+}
+
+$script:isolatedStateRoot = Get-IsolatedStateRoot
+Assert-CanonicalRepository
+Assert-TagIdentity
+$beforePath = Join-Path $script:isolatedStateRoot "external-state-before.json"
+$afterPath = Join-Path $script:isolatedStateRoot "external-state-after.json"
+$verificationPath = Join-Path $script:isolatedStateRoot "external-state-verification.json"
+
+if ($Mode -eq "Capture") {
+    $snapshot = Get-ExternalSnapshot
+    if ([bool]$snapshot.target.release_present -or [bool]$snapshot.target.tag_present) {
+        Fail "target release/tag already exists before controlled draft rehearsal"
+    }
+    Write-JsonFile $beforePath $snapshot
+    Write-JsonFile (Join-Path $script:isolatedStateRoot "draft-cleanup-authorized.json") ([ordered]@{
+        schema_version = 1
+        status = "READY"
+        repository = $env:GITHUB_REPOSITORY
+        tag = $Tag
+        source_sha = [string]$env:V4_DRAFT_REHEARSAL_SOURCE_SHA
+        captured_utc = [DateTime]::UtcNow.ToString("o")
+    })
+    Write-Host "V4 draft rehearsal external-state capture: PASS (legacy Latest and stable/beta metadata snapshotted)"
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $beforePath -PathType Leaf)) {
+    Fail "external-state-before.json is missing"
+}
+$before = Get-Content -LiteralPath $beforePath -Raw | ConvertFrom-Json
+$after = Get-ExternalSnapshot
+if ([bool]$after.target.release_present -or [bool]$after.target.tag_present) {
+    Fail "controlled draft rehearsal left a release or tag residue"
+}
+Write-JsonFile $afterPath $after
+$beforeJson = Convert-SnapshotToJson $before
+$afterJson = Convert-SnapshotToJson $after
+$beforeHash = Get-JsonSha256 $beforeJson
+$afterHash = Get-JsonSha256 $afterJson
+if ($beforeJson -ne $afterJson) {
+    Fail "legacy Latest or stable/beta metadata changed during controlled draft rehearsal"
+}
+Write-JsonFile $verificationPath ([ordered]@{
+    schema_version = 1
+    status = "PASS"
+    repository = $env:GITHUB_REPOSITORY
+    tag = $Tag
+    target_release_absent = $true
+    target_tag_absent = $true
+    legacy_latest_unchanged = $true
+    stable_metadata_unchanged = $true
+    beta_metadata_unchanged = $true
+    before_sha256 = $beforeHash
+    after_sha256 = $afterHash
+})
+Write-Host "V4 draft rehearsal external-state verification: PASS (draft/tag absent; legacy Latest and stable/beta metadata unchanged)"


### PR DESCRIPTION
## Summary

- add a manual-only controlled same-repository draft rehearsal workflow from the exact requested `main` SHA
- reuse `ValidateRequest` through `RecordAttestations`, including exact draft re-download, qualification, OIDC attestations, and SPDX verification
- clean only a matching unpublished draft/tag after partial failures, with authorization marker and fail-closed source checks
- snapshot and compare legacy v3 Latest plus public stable/beta raw metadata without mutating metadata
- extend runner trust-boundary and release-contract regression tests

## Safety

- does not modify `.github/workflows/release-v4.yml`
- does not call `PublishDraft`, `PromoteMetadata`, or `FinalVerify`
- does not mint or use a metadata App token
- does not dispatch rehearsal or official release from this PR

Refs #165