### PR TITLE
docs(v4): finalize v4.0.1 public release notes

### DIFF
--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -1,80 +1,35 @@
 # Sky Auto Player v4.0.1
 
-> Release-gate record for the first official v4 release lineage. This file is
-> prepared for the exact source commit that will be tagged `v4.0.1`; it does
-> not claim publication until the owner/admin cutover gate in issue #165
-> passes.
+`v4.0.1` is the first supported v4 release lineage for Sky Auto Player.
 
 ## Release identity
 
 - Canonical repository: `pumni/Sky-Auto-Player`
 - Canonical tag: `v4.0.1`
 - Release channel: stable
-- Release metadata: the main repository's `release-metadata` branch, which must
-  be protected before GO
-- GitHub Latest policy: publish with `make_latest=false` while the legacy v3
-  `v3.5.0` Latest release remains the coexistence guard
-
-`v4.0.1` is the first supported v4 release. The earlier v4.0.0 and RC
-artifacts were rehearsal/pre-release infrastructure only; there is no supported
-bridge or compatibility path from those artifacts.
+- GitHub Latest policy: v4 releases use `make_latest=false` so the legacy v3
+  `v3.5.0` Latest release remains available during the coexistence period
 
 ## Distribution and update contract
 
-The supported Windows package is the exact Tauri NSIS installer and its
-Ed25519 updater signature. The final release transaction must qualify the
-re-downloaded GitHub Release assets byte-for-byte before immutable publication.
-The transaction also records the matching SPDX SBOM and GitHub OIDC provenance
-attestation for the exact source and artifact bytes.
+The supported Windows package is the Tauri NSIS installer and its Ed25519
+updater signature. Release assets are qualified byte-for-byte, with matching
+SHA-256 evidence, SPDX SBOM, and GitHub OIDC provenance attestation.
 
-Stable and beta updater metadata are published only after the immutable release
-is verified. The client consumes the unauthenticated raw endpoints below:
+The v4 updater consumes unauthenticated raw metadata from the canonical
+repository's `release-metadata` branch:
 
 ```text
 https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json
 https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json
 ```
 
-The stable channel must contain a strictly monotonic SemVer promotion and the
-metadata signature and artifact URL must resolve to this repository. Bootstrap
-must not fabricate a `latest.json` file.
+Stable metadata advances only through a strictly monotonic SemVer promotion;
+beta metadata remains on its separate prerelease channel. The metadata
+contract never fabricates a channel `latest.json` file during bootstrap.
 
-## Gate status
+## Compatibility
 
-This source document is intentionally pre-publication evidence. The official
-release remains blocked until issue #165 records passing evidence for the
-same-repository draft rehearsal, exact-byte qualification, signature, SBOM,
-provenance, legacy Latest preservation, protected metadata branch, protected
-production environment, isolated signing runner, and final owner/admin
-cutover checklist.
-
-## Owner/admin cutover checklist
-
-These items are intentionally recorded as unchecked until the release owner
-proves them against the live repository and the exact approved source SHA:
-
-- [ ] Immutable releases are enabled and enforced by the repository owner.
-- [ ] `release-metadata` is initialized with the bootstrap contract and protected
-      by the approved branch ruleset.
-- [ ] `v4-production-release` has the required reviewers, variables, and
-      secrets, with bypass behavior reviewed.
-- [ ] The production signing runner is isolated from general CI and online only
-      for approved release/rehearsal jobs.
-- [ ] `V4_RELEASE_AUTHORITY_TOKEN` and obsolete authority credentials are
-      removed from repository and environment secrets.
-- [ ] After the final reference scan, delete the legacy rehearsal repository
-      `pumni/Sky-Auto-Player-Releases`; retaining it is not a supported
-      single-repository release state.
-- [ ] A final repository scan passes after any legacy-repository cleanup.
-- [ ] The official workflow is dispatched once, from the exact approved source
-      SHA, with version `4.0.1`, tag `v4.0.1`, and `make_latest=false`.
-- [ ] The published immutable release, public stable metadata, installer,
-      updater signature, clean install, and update path are independently
-      verified.
-
-Observed before owner/admin cutover on the preparation branch: immutable
-releases are enabled but owner enforcement is not confirmed; the
-`release-metadata` branch exists but has no branch protection; the production
-environment has no protection rules; `V4_RELEASE_AUTHORITY_TOKEN` remains in
-the environment; and `pumni/Sky-Auto-Player-Releases` still exists. These
-observations are NO-GO evidence, not release approval.
+The earlier v4.0.0 and RC artifacts were development and rehearsal artifacts,
+not supported release targets. There is no compatibility bridge or alternate
+v4 update endpoint for those artifacts.

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -464,6 +464,28 @@ $packageVersion = [regex]::Match(
     '(?m)^version\s*=\s*"([^"]+)"'
 ).Groups[1].Value
 $validNotesPath = Join-Path $repoRoot "docs/releases/v$packageVersion.md"
+$canonicalReleaseNotes = Get-Content -LiteralPath $validNotesPath -Raw
+foreach ($forbiddenPublicReleaseNotesPattern in @(
+    '(?i)\bNO-GO\b',
+    '(?i)pre-publication',
+    '(?i)owner/admin',
+    '(?i)cutover',
+    '(?i)release remains blocked',
+    '(?i)not release approval',
+    '(?i)gate status',
+    '(?i)has no branch protection',
+    '(?i)has no protection rules',
+    '(?i)must be protected before GO',
+    '(?i)observed before',
+    '(?i)preparation branch',
+    'V4_RELEASE_AUTHORITY_TOKEN',
+    'Sky-Auto-Player-Releases'
+)) {
+    if ($canonicalReleaseNotes -match $forbiddenPublicReleaseNotesPattern) {
+        Fail "canonical v4.0.1 public release notes contain an internal gate phrase: $forbiddenPublicReleaseNotesPattern"
+    }
+}
+Write-Host "V4.0.1 public release notes contract: PASS (no internal gate state or obsolete topology wording)"
 $validNotesProbe = Invoke-ReleaseNotesValidation $validNotesPath
 if ($validNotesProbe.ExitCode -ne 0 -or $validNotesProbe.Output -notmatch "V4 release identity: PASS") {
     Fail "canonical release notes were rejected by ValidateRequest. Diagnostics:`n$($validNotesProbe.Output)"


### PR DESCRIPTION
## Summary

- finalize `docs/releases/v4.0.1.md` as public release notes for the first supported v4 lineage
- retain the single-repository distribution/update contract, legacy v3 Latest coexistence, and no-bridge compatibility statement
- remove owner/admin checklists, stale pre-publication observations, NO-GO status, obsolete credentials, and old-repository wording
- add a release-contract regression guard preventing internal gate state from entering the canonical release body

## Scope

- docs and release-contract regression only
- no release workflow or state-machine changes
- no rehearsal or release dispatch from this PR

Refs #165