### PR TITLE
fix(v4): remove admin-only immutable preflight

### DIFF
--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1019,8 +1019,9 @@ fn v4_release_pipeline_contract_source(
         "Invoke-GitHubApi",
         "v4_release_asset_upload.ps1",
         "upload_url",
-        "immutable-releases",
         "Assert-ImmutableRelease",
+        "Assert-ImmutableRelease $published",
+        "repository release is not marked immutable",
         "ci_tauri_update_e2e.ps1",
         "CandidateInstallerPath",
         "CandidateSignaturePath",
@@ -1052,6 +1053,27 @@ fn v4_release_pipeline_contract_source(
                 format!("v4 release coordinator is missing its required marker: {marker}").into(),
             );
         }
+    }
+    if pipeline.contains("repos/$repository/immutable-releases") {
+        return Err(
+            "ValidateRepository must not call the administration-only immutable-releases endpoint"
+                .into(),
+        );
+    }
+    let publish_position = pipeline
+        .find("function Invoke-PublishDraft")
+        .ok_or("v4 release coordinator is missing the publication state")?;
+    let immutable_guard_position = pipeline
+        .find("Assert-ImmutableRelease $published")
+        .ok_or("v4 release coordinator is missing the published immutable-release guard")?;
+    let promote_position = pipeline
+        .find("function Invoke-PromoteMetadata")
+        .ok_or("v4 release coordinator is missing the metadata promotion state")?;
+    if immutable_guard_position < publish_position || immutable_guard_position > promote_position {
+        return Err(
+            "published immutable-release verification must remain after publication and before metadata promotion"
+                .into(),
+        );
     }
     let draft_boundary = pipeline
         .find("function Invoke-CreateDraft")
@@ -3772,7 +3794,7 @@ function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already
 function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
 function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; cargo xtask builtin-catalog verify-installed; SKY_BUILTIN_CATALOG_FRESH_SELFTEST; installed-built-in-catalog-exact-manifest-file-set-sha-parseability; manifest_validated; file_set_exact; sha256_verified; songs_parseable; fresh-appdata-built-in-user-composition; freshUserSongs = @(; Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue; previousAppDataRoot; previousFreshSelfTest; if ($null -eq $previousAppDataRoot); Remove-Item Env:SKY_APP_DATA_ROOT; if ($null -eq $previousFreshSelfTest); Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST; selftest-update-active-playback; ci_v4_release_latest_guard.ps1; promote_v4_metadata.ps1; release-metadata; published_at; Start-MpScan; scan_performed }
 function Invoke-RecordAttestations { GH_TOKEN }
-function Invoke-PublishDraft { draft = $false; make_latest = $false }
+function Invoke-PublishDraft { draft = $false; make_latest = $false; Assert-ImmutableRelease $published; repository release is not marked immutable }
 function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication; branch = "release-metadata"; GITHUB_REPOSITORY; Invoke-GitHubApi }
 function Invoke-FinalVerify { FinalVerify }
 "#;

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -378,7 +378,9 @@ foreach ($marker in @(
     'GitHub''s successful DELETE endpoints return an empty body',
     'Get-FileHash', 'verify-signature', 'sbom', 'verify-tauri-bundle',
     'current-user', 'active-playback-install-rejected', 'upload_url',
-    'immutable-releases', 'Assert-ImmutableRelease', 'Start-MpScan',
+    'Assert-ImmutableRelease $published', 'repository release is not marked immutable',
+    'V4 immutable publication guard self-test', 'immutable=false rejected',
+    'Start-MpScan',
     'previous-v4-to-exact-downloaded-candidate-update',
     'selftest-update-active-playback', 'scan_performed',
     'cargo xtask builtin-catalog verify-installed',
@@ -399,6 +401,13 @@ foreach ($marker in @(
     '(?m)^# [^\r\n]+(?=\r?$)'
 )) {
     if (-not $pipeline.Contains($marker)) { Fail "pipeline marker is missing: $marker" }
+}
+if ($pipeline.Contains('repos/$repository/immutable-releases')) {
+    Fail "ValidateRepository must not call the administration-only immutable-releases endpoint"
+}
+$pipelineSelfTestOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $pipelinePath -State SelfTest 2>&1 | Out-String
+if ($LASTEXITCODE -ne 0 -or $pipelineSelfTestOutput -notmatch 'immutable=false rejected; immutable=true accepted') {
+    Fail "pipeline immutable publication guard self-test did not reject immutable=false"
 }
 foreach ($marker in @(
     'function Get-SanitizedReleaseProbeOutput',

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -320,12 +320,8 @@ function Assert-RepositoryReleasePolicy {
         Fail "canonical repository main is not initialized"
     }
     if ([string]$main.ref -ne "refs/heads/main") { Fail "canonical repository main ref is not canonical" }
-    $immutable = Invoke-GitHubApi -Arguments @("api", "repos/$repository/immutable-releases") -AllowNotFound
-    if ($null -eq $immutable -or -not [bool]$immutable.enabled) {
-        Fail "canonical repository immutable-releases policy is not enabled"
-    }
     Assert-MetadataBranchReadiness $repository
-    Write-Host "V4 repository release preconditions: PASS (main exists; immutable releases enabled; release-metadata ready)"
+    Write-Host "V4 repository release preconditions: PASS (main exists; release-metadata ready; immutable publication is checked on the published release)"
 }
 
 function Get-PublicMetadataDocument([string]$Channel) {
@@ -1077,6 +1073,14 @@ function Invoke-SelfTest {
     } catch {
         if ($_.Exception.Message -notmatch "promotion before publication") { throw }
     }
+    try {
+        Assert-ImmutableRelease ([pscustomobject]@{ immutable = $false })
+        Fail "immutable=false unexpectedly passed the publication guard"
+    } catch {
+        if ($_.Exception.Message -notmatch "repository release is not marked immutable") { throw }
+    }
+    Assert-ImmutableRelease ([pscustomobject]@{ immutable = $true })
+    Write-Host "V4 immutable publication guard self-test: PASS (immutable=false rejected; immutable=true accepted)"
     $mock.attested = $true
     $mock.published = $true
     $mock.promoted = $true


### PR DESCRIPTION
## Summary

- remove the Administration: read-only `/immutable-releases` API call from `ValidateRepository`
- keep canonical `main` and `release-metadata` preflight checks permission-compatible with the existing release-job permissions
- retain `Assert-ImmutableRelease $published` after publication and before metadata promotion
- add executable and static regressions proving `immutable=false` fails closed and the admin-only endpoint cannot return to `ValidateRepository`

## Scope and safety

- no Administration permission added
- no metadata App-token or repository-topology changes
- no release workflow/state ordering changes
- no rehearsal or official release dispatch from this PR

Refs #165