### PR TITLE
fix(v4): serialize make_latest as release API enum

### DIFF
--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1005,7 +1005,9 @@ fn v4_release_pipeline_contract_source(
         "published_at",
         "draft = $true",
         "draft = $false",
-        "make_latest = $false",
+        "Get-V4ReleaseMakeLatestValue",
+        "make_latest = Get-V4ReleaseMakeLatestValue",
+        "make_latest is string enum false for create and publish",
         "target_commitish = $SourceSha.ToLowerInvariant()",
         "branch = \"release-metadata\"",
         "validate-monotonic",
@@ -1060,15 +1062,28 @@ fn v4_release_pipeline_contract_source(
                 .into(),
         );
     }
+    let create_draft_position = pipeline
+        .find("function Invoke-CreateDraft")
+        .ok_or("v4 release coordinator is missing the draft boundary")?;
     let publish_position = pipeline
         .find("function Invoke-PublishDraft")
         .ok_or("v4 release coordinator is missing the publication state")?;
-    let immutable_guard_position = pipeline
-        .find("Assert-ImmutableRelease $published")
-        .ok_or("v4 release coordinator is missing the published immutable-release guard")?;
     let promote_position = pipeline
         .find("function Invoke-PromoteMetadata")
         .ok_or("v4 release coordinator is missing the metadata promotion state")?;
+    if !pipeline[create_draft_position..publish_position]
+        .contains("make_latest = Get-V4ReleaseMakeLatestValue")
+        || !pipeline[publish_position..promote_position]
+            .contains("make_latest = Get-V4ReleaseMakeLatestValue")
+    {
+        return Err(
+            "CreateDraft and PublishDraft must use the GitHub make_latest string enum helper"
+                .into(),
+        );
+    }
+    let immutable_guard_position = pipeline
+        .find("Assert-ImmutableRelease $published")
+        .ok_or("v4 release coordinator is missing the published immutable-release guard")?;
     if immutable_guard_position < publish_position || immutable_guard_position > promote_position {
         return Err(
             "published immutable-release verification must remain after publication and before metadata promotion"
@@ -3786,15 +3801,15 @@ jobs:
     GH_TOKEN: ${{ github.token }}
 "#;
         let pipeline = r#"
-ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 make_latest = $false target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
+ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 Get-V4ReleaseMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue make_latest is string enum false for create and publish target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
 function Invoke-BuildCandidate {
   & pwsh -File orchestrate_v4_production_release.ps1
 }
-function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; make_latest = $false; GitHub's successful DELETE endpoints return an empty body }
+function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum false for create and publish; GitHub's successful DELETE endpoints return an empty body }
 function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
 function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; cargo xtask builtin-catalog verify-installed; SKY_BUILTIN_CATALOG_FRESH_SELFTEST; installed-built-in-catalog-exact-manifest-file-set-sha-parseability; manifest_validated; file_set_exact; sha256_verified; songs_parseable; fresh-appdata-built-in-user-composition; freshUserSongs = @(; Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue; previousAppDataRoot; previousFreshSelfTest; if ($null -eq $previousAppDataRoot); Remove-Item Env:SKY_APP_DATA_ROOT; if ($null -eq $previousFreshSelfTest); Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST; selftest-update-active-playback; ci_v4_release_latest_guard.ps1; promote_v4_metadata.ps1; release-metadata; published_at; Start-MpScan; scan_performed }
 function Invoke-RecordAttestations { GH_TOKEN }
-function Invoke-PublishDraft { draft = $false; make_latest = $false; Assert-ImmutableRelease $published; repository release is not marked immutable }
+function Invoke-PublishDraft { draft = $false; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum false for create and publish; Assert-ImmutableRelease $published; repository release is not marked immutable }
 function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication; branch = "release-metadata"; GITHUB_REPOSITORY; Invoke-GitHubApi }
 function Invoke-FinalVerify { FinalVerify }
 "#;

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -380,6 +380,9 @@ foreach ($marker in @(
     'current-user', 'active-playback-install-rejected', 'upload_url',
     'Assert-ImmutableRelease $published', 'repository release is not marked immutable',
     'V4 immutable publication guard self-test', 'immutable=false rejected',
+    'Get-V4ReleaseMakeLatestValue',
+    'V4 GitHub release payload self-test',
+    'make_latest is string enum false for create and publish',
     'Start-MpScan',
     'previous-v4-to-exact-downloaded-candidate-update',
     'selftest-update-active-playback', 'scan_performed',
@@ -408,6 +411,9 @@ if ($pipeline.Contains('repos/$repository/immutable-releases')) {
 $pipelineSelfTestOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $pipelinePath -State SelfTest 2>&1 | Out-String
 if ($LASTEXITCODE -ne 0 -or $pipelineSelfTestOutput -notmatch 'immutable=false rejected; immutable=true accepted') {
     Fail "pipeline immutable publication guard self-test did not reject immutable=false"
+}
+if ($pipelineSelfTestOutput -notmatch 'make_latest is string enum false for create and publish') {
+    Fail "pipeline GitHub release payload self-test did not verify the make_latest JSON enum type"
 }
 foreach ($marker in @(
     'function Get-SanitizedReleaseProbeOutput',

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -82,6 +82,11 @@ function Write-JsonFile([string]$Path, [object]$Value) {
     [IO.File]::WriteAllText($Path, $json + "`n", [Text.UTF8Encoding]::new($false))
 }
 
+function Get-V4ReleaseMakeLatestValue {
+    # GitHub's release API accepts an enum string here, not a JSON boolean.
+    return "false"
+}
+
 function Read-JsonFile([string]$Path) {
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { Fail "Required state file is missing: $Path" }
     return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
@@ -576,7 +581,7 @@ function Invoke-CreateDraft {
         body = $body + ([IO.File]::ReadAllText($notesPath)).Trim()
         draft = $true
         prerelease = ($Channel -eq "beta")
-        make_latest = $false
+        make_latest = Get-V4ReleaseMakeLatestValue
     })
     $release = Invoke-GitHubApi -Arguments @("api", "--method", "POST", "repos/$repository/releases", "--input", $payloadPath)
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "repository did not create the requested draft release" }
@@ -915,7 +920,7 @@ function Invoke-PublishDraft {
         if ($downloadedHash -ne [string]$expected.sha256) { Fail "qualified downloaded digest changed before publication: $expectedReleaseName" }
     }
     $patchPath = Join-Path (Get-EffectiveStateRoot) "publish-release.json"
-    Write-JsonFile $patchPath ([ordered]@{ draft = $false; make_latest = $false })
+    Write-JsonFile $patchPath ([ordered]@{ draft = $false; make_latest = Get-V4ReleaseMakeLatestValue })
     $published = Invoke-GitHubApi -Arguments @("api", "--method", "PATCH", "repos/$repository/releases/$($state.release_id)", "--input", $patchPath)
     if ($published.draft -or [string]::IsNullOrWhiteSpace([string]$published.published_at)) { Fail "repository did not publish the already-qualified draft" }
     Assert-ImmutableRelease $published
@@ -1081,6 +1086,22 @@ function Invoke-SelfTest {
     }
     Assert-ImmutableRelease ([pscustomobject]@{ immutable = $true })
     Write-Host "V4 immutable publication guard self-test: PASS (immutable=false rejected; immutable=true accepted)"
+
+    foreach ($draftValue in @($true, $false)) {
+        $payload = [ordered]@{
+            draft = $draftValue
+            make_latest = Get-V4ReleaseMakeLatestValue
+        }
+        $roundTrip = (($payload | ConvertTo-Json -Depth 20) | ConvertFrom-Json)
+        if ($roundTrip.make_latest -isnot [string] -or $roundTrip.make_latest -ne "false") {
+            Fail "GitHub release payload make_latest must round-trip as the string enum false"
+        }
+        if ($roundTrip.draft -isnot [bool] -or [bool]$roundTrip.draft -ne $draftValue) {
+            Fail "GitHub release payload draft must remain a JSON boolean"
+        }
+    }
+    Write-Host "V4 GitHub release payload self-test: PASS (make_latest is string enum false for create and publish)"
+
     $mock.attested = $true
     $mock.published = $true
     $mock.promoted = $true


### PR DESCRIPTION
## Summary
- serialize GitHub Release API make_latest as the required string enum "false" in both CreateDraft and PublishDraft
- add an executable PowerShell self-test that round-trips both payload shapes through JSON and verifies the actual types
- enforce the helper at both production state boundaries through the release contract checks

## Verification
- pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 -State SelfTest
- pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_release_pipeline.ps1
- cargo test --manifest-path rust/Cargo.toml -p sky_xtask --locked (78 passed)
- cargo xtask check static
- git diff --check

Refs #165

No rehearsal or release was dispatched. This PR does not change permissions, metadata token scope, runner policy, or state ordering.