### PR TITLE
fix(v4): detect unpublished draft releases by collection

### DIFF
--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -241,6 +241,7 @@ const ACTIVE_RELEASE_SURFACES: &[&str] = &[
     "scripts/cleanup_v4_release_state.ps1",
     "scripts/cleanup_v4_draft_rehearsal.ps1",
     "scripts/v4_draft_rehearsal_external_state.ps1",
+    "scripts/v4_release_draft_lookup.ps1",
     ".github/workflows/release.yml",
     ".github/workflows/release-v4.yml",
     ".github/workflows/rehearse-v4-production-topology.yml",
@@ -1049,6 +1050,13 @@ fn v4_release_pipeline_contract_source(
         "if ($null -eq $previousFreshSelfTest)",
         "Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST",
         "v4_updater_credential_broker.ps1",
+        "v4_release_draft_lookup.ps1",
+        "Select-V4ReleaseByTag",
+        "--paginate",
+        "--slurp",
+        "releases?per_page=100",
+        "existing draft source does not match the requested source",
+        "draft release could not be removed by release id",
     ] {
         if !pipeline.contains(marker) {
             return Err(
@@ -1115,6 +1123,12 @@ fn v4_release_pipeline_contract_source(
     {
         return Err(
             "v4 release coordinator regression test is missing the StrictMode empty-directory guard"
+            .into(),
+        );
+    }
+    if !regression.contains("Test-DraftLookupFallback") {
+        return Err(
+            "v4 release coordinator regression test is missing the hidden-draft collection fallback"
                 .into(),
         );
     }
@@ -1236,6 +1250,14 @@ fn v4_draft_rehearsal_contract_source(
         "remainingRelease",
         "remainingTag",
         "draft-cleanup-authorized.json",
+        "release-state.json",
+        "releases/$releaseId",
+        "v4_release_draft_lookup.ps1",
+        "Select-V4ReleaseByTag",
+        "--paginate",
+        "--slurp",
+        "releases?per_page=100",
+        "draft release could not be removed by release id",
         "refusing to delete a published release",
         "mismatched source",
     ] {
@@ -1278,6 +1300,11 @@ fn v4_draft_rehearsal_contract_source(
         "GITHUB_REPOSITORY",
         "target_release_absent",
         "target_tag_absent",
+        "v4_release_draft_lookup.ps1",
+        "Select-V4ReleaseByTag",
+        "--paginate",
+        "--slurp",
+        "releases?per_page=100",
     ] {
         if !external_state.contains(marker) {
             return Err(format!(
@@ -3801,7 +3828,7 @@ jobs:
     GH_TOKEN: ${{ github.token }}
 "#;
         let pipeline = r#"
-ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 Get-V4ReleaseMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue make_latest is string enum false for create and publish target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
+ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 v4_release_draft_lookup.ps1 Select-V4ReleaseByTag --paginate --slurp releases?per_page=100 existing draft source does not match the requested source draft release could not be removed by release id Get-V4ReleaseMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue make_latest is string enum false for create and publish target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
 function Invoke-BuildCandidate {
   & pwsh -File orchestrate_v4_production_release.ps1
 }
@@ -3815,6 +3842,7 @@ function Invoke-FinalVerify { FinalVerify }
 "#;
         let regression = r#"
 function Test-StrictModeEmptyFreshUserSongs { Set-StrictMode -Version Latest; freshUserSongs = @(); $freshUserSongs.Count -ne 0 }
+function Test-DraftLookupFallback { by-tag-404; paginated releases collection; duplicate releases use the requested tag }
 class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$UploadedThroughReleaseUrl = $false; [bool]$ExactDownloadedBytes = $false; [bool]$immutable = $false; candidate rebuilt; promotion before immutable publication; BuildCount -ne 1; UploadedThroughReleaseUrl; ExactDownloadedBytes; immutable }
 "#;
         assert!(v4_release_pipeline_contract_source(workflow, pipeline, regression).is_ok());

--- a/scripts/cleanup_v4_draft_rehearsal.ps1
+++ b/scripts/cleanup_v4_draft_rehearsal.ps1
@@ -14,6 +14,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $canonicalRepository = "pumni/Sky-Auto-Player"
+. (Join-Path $PSScriptRoot "v4_release_draft_lookup.ps1")
 
 function Fail([string]$Message) {
     throw "V4 draft rehearsal cleanup failed closed: $Message"
@@ -114,13 +115,65 @@ function Assert-CleanupAuthorization([object]$Authorization) {
     }
 }
 
+function Read-CleanupState {
+    $path = Join-Path $script:isolatedStateRoot "release-state.json"
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+    try {
+        $state = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    } catch {
+        Fail "release state is not valid JSON"
+    }
+    if ([string](Get-PropertyValue $state "tag") -ne $Tag -or
+        [string](Get-PropertyValue $state "source_sha") -ne $SourceSha.ToLowerInvariant()) {
+        Fail "release state identity does not match the requested cleanup"
+    }
+    $releaseId = Get-PropertyValue $state "release_id"
+    if ($null -eq $releaseId -or [int64]$releaseId -le 0) {
+        Fail "release state does not contain a valid release id"
+    }
+    return $state
+}
+
+function Get-ReleaseCollection([string]$Repository) {
+    return @(Invoke-GitHubApi -Arguments @(
+        "api", "--paginate", "--slurp", "repos/$Repository/releases?per_page=100"
+    ))
+}
+
+function Get-ReleaseForTag([string]$Repository, [string]$RequestedTag) {
+    $direct = Invoke-GitHubApi -Arguments @(
+        "api", "repos/$Repository/releases/tags/$RequestedTag"
+    ) -AllowNotFound
+    $collection = if ($null -eq $direct) { Get-ReleaseCollection $Repository } else { @() }
+    return Select-V4ReleaseByTag -DirectRelease $direct -ReleaseCollection $collection -Tag $RequestedTag
+}
+
+function Get-ReleaseForCleanup([string]$Repository, [object]$State) {
+    if ($null -ne $State) {
+        $releaseId = [int64](Get-PropertyValue $State "release_id")
+        return Invoke-GitHubApi -Arguments @(
+            "api", "repos/$Repository/releases/$releaseId"
+        ) -AllowNotFound
+    }
+    return Get-ReleaseForTag $Repository $Tag
+}
+
 function Assert-DraftMatchesSource([object]$Release) {
+    $releaseId = Get-PropertyValue $Release "id"
+    if ($null -eq $releaseId -or [int64]$releaseId -le 0) {
+        Fail "draft release id is missing"
+    }
     if ([string](Get-PropertyValue $Release "tag_name") -ne $Tag) {
         Fail "draft release tag does not match the requested tag"
     }
     if (-not [bool](Get-PropertyValue $Release "draft") -or
         -not [string]::IsNullOrWhiteSpace([string](Get-PropertyValue $Release "published_at"))) {
         Fail "refusing to delete a published release"
+    }
+    $targetCommitish = [string](Get-PropertyValue $Release "target_commitish")
+    if ($targetCommitish -notmatch '^[0-9a-fA-F]{40}$' -or
+        $targetCommitish.ToLowerInvariant() -ne $SourceSha.ToLowerInvariant()) {
+        Fail "refusing to delete a draft with a mismatched source"
     }
     $body = [string](Get-PropertyValue $Release "body")
     $source = $SourceSha.ToLowerInvariant()
@@ -142,8 +195,9 @@ $script:isolatedStateRoot = Get-IsolatedStateRoot
 Assert-CanonicalRepository
 Assert-SourceIdentity
 $authorization = Read-CleanupAuthorization
+$state = Read-CleanupState
 $repository = $env:GITHUB_REPOSITORY
-$release = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/tags/$Tag") -AllowNotFound
+$release = Get-ReleaseForCleanup $repository $state
 $tagRef = Invoke-GitHubApi -Arguments @("api", "repos/$repository/git/ref/tags/$Tag") -AllowNotFound
 
 if ($null -eq $authorization -and ($null -ne $release -or $null -ne $tagRef)) {
@@ -160,7 +214,11 @@ if ($null -ne $release) {
     Invoke-GitHubApi -Arguments @(
         "api", "--method", "DELETE", "repos/$repository/releases/$releaseId"
     ) -AllowNotFound | Out-Null
-    $remainingRelease = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/tags/$Tag") -AllowNotFound
+    $remainingReleaseById = Invoke-GitHubApi -Arguments @(
+        "api", "repos/$repository/releases/$releaseId"
+    ) -AllowNotFound
+    if ($null -ne $remainingReleaseById) { Fail "draft release could not be removed by release id" }
+    $remainingRelease = Get-ReleaseForTag $repository $Tag
     if ($null -ne $remainingRelease) { Fail "draft release could not be removed" }
     $draftDeleted = $true
 }

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -15,6 +15,7 @@ $topologyWorkflowPath = Join-Path $repoRoot ".github/workflows/rehearse-v4-produ
 $draftWorkflowPath = Join-Path $repoRoot ".github/workflows/rehearse-v4-draft.yml"
 $draftCleanupPath = Join-Path $PSScriptRoot "cleanup_v4_draft_rehearsal.ps1"
 $externalStatePath = Join-Path $PSScriptRoot "v4_draft_rehearsal_external_state.ps1"
+$draftLookupPath = Join-Path $PSScriptRoot "v4_release_draft_lookup.ps1"
 $pipeline = Get-Content -LiteralPath $pipelinePath -Raw
 $topologyRehearsal = Get-Content -LiteralPath $topologyRehearsalPath -Raw
 $fixtureWrapper = Get-Content -LiteralPath $fixtureWrapperPath -Raw
@@ -25,6 +26,7 @@ $topologyWorkflow = Get-Content -LiteralPath $topologyWorkflowPath -Raw
 $draftWorkflow = Get-Content -LiteralPath $draftWorkflowPath -Raw
 $draftCleanup = Get-Content -LiteralPath $draftCleanupPath -Raw
 $externalState = Get-Content -LiteralPath $externalStatePath -Raw
+$draftLookup = Get-Content -LiteralPath $draftLookupPath -Raw
 $testHarness = Get-Content -LiteralPath $PSCommandPath -Raw
 
 foreach ($source in @(
@@ -35,7 +37,8 @@ foreach ($source in @(
     [pscustomobject]@{ Name = "legacy Latest guard"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1") -Raw) },
     [pscustomobject]@{ Name = "controlled draft rehearsal workflow"; Text = $draftWorkflow },
     [pscustomobject]@{ Name = "controlled draft cleanup"; Text = $draftCleanup },
-    [pscustomobject]@{ Name = "controlled draft external-state check"; Text = $externalState }
+    [pscustomobject]@{ Name = "controlled draft external-state check"; Text = $externalState },
+    [pscustomobject]@{ Name = "release draft lookup"; Text = $draftLookup }
 )) {
     foreach ($forbidden in @(
         "Sky-Auto-Player-Releases",
@@ -108,11 +111,45 @@ foreach ($forbidden in @(
     }
 }
 
+. $draftLookupPath
+
+function Test-DraftLookupFallback {
+    $draft = [pscustomobject]@{
+        id = 386002301
+        tag_name = 'v4.0.1'
+        draft = $true
+        published_at = $null
+    }
+    $selected = Select-V4ReleaseByTag -DirectRelease $null -ReleaseCollection @($draft) -Tag 'v4.0.1'
+    if ($null -eq $selected -or [int64]$selected.id -ne 386002301) {
+        Fail "release lookup did not find a draft hidden from the by-tag endpoint"
+    }
+
+    try {
+        $null = Select-V4ReleaseByTag -DirectRelease $null -ReleaseCollection @($draft, $draft) -Tag 'v4.0.1'
+        Fail "release lookup accepted duplicate tag candidates"
+    } catch {
+        if ($_.Exception.Message -notmatch 'duplicate releases use the requested tag') { throw }
+    }
+
+    try {
+        $null = Select-V4ReleaseByTag -DirectRelease ([pscustomobject]@{ tag_name = 'v4.0.0' }) -ReleaseCollection @() -Tag 'v4.0.1'
+        Fail "release lookup accepted a direct tag mismatch"
+    } catch {
+        if ($_.Exception.Message -notmatch 'direct release tag does not match') { throw }
+    }
+}
+
+Test-DraftLookupFallback
+
 foreach ($marker in @(
     'RUNNER_TEMP', 'GITHUB_WORKSPACE', 'StateRoot must be a child of RUNNER_TEMP',
     'source_sha', 'published_at', 'git/ref/tags', '--method', 'DELETE',
     'remainingRelease', 'remainingTag', 'draft-cleanup-authorized.json',
-    'refusing to delete a published release', 'mismatched source'
+    'release-state.json', 'releases/$releaseId', 'v4_release_draft_lookup.ps1',
+    'Select-V4ReleaseByTag', '--paginate', '--slurp', 'releases?per_page=100',
+    'refusing to delete a published release', 'mismatched source',
+    'draft release could not be removed by release id'
 )) {
     if (-not $draftCleanup.Contains($marker)) {
         Fail "controlled draft cleanup marker is missing: $marker"
@@ -130,7 +167,9 @@ foreach ($marker in @(
     'raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json',
     'releases/latest', '^v3\.', 'AllowAutoRedirect', 'Headers.Authorization',
     'StatusCode', 'sha256', 'external-state-before.json', 'external-state-after.json',
-    'GITHUB_REPOSITORY', 'target_release_absent', 'target_tag_absent'
+    'GITHUB_REPOSITORY', 'target_release_absent', 'target_tag_absent',
+    'v4_release_draft_lookup.ps1', 'Select-V4ReleaseByTag', '--paginate',
+    '--slurp', 'releases?per_page=100'
 )) {
     if (-not $externalState.Contains($marker)) {
         Fail "controlled draft external-state marker is missing: $marker"

--- a/scripts/v4_draft_rehearsal_external_state.ps1
+++ b/scripts/v4_draft_rehearsal_external_state.ps1
@@ -19,6 +19,7 @@ $metadataEndpoints = [ordered]@{
     stable = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json"
     beta = "https://raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json"
 }
+. (Join-Path $PSScriptRoot "v4_release_draft_lookup.ps1")
 
 function Fail([string]$Message) {
     throw "V4 draft rehearsal external-state check failed closed: $Message"
@@ -82,6 +83,20 @@ function Invoke-ReadOnlyGitHubApi {
     } finally {
         Remove-Item -LiteralPath $errorPath -Force -ErrorAction SilentlyContinue
     }
+}
+
+function Get-ReleaseCollection([string]$Repository) {
+    return @(Invoke-ReadOnlyGitHubApi -Arguments @(
+        "api", "--paginate", "--slurp", "repos/$Repository/releases?per_page=100"
+    ))
+}
+
+function Get-ReleaseForTag([string]$Repository, [string]$RequestedTag) {
+    $direct = Invoke-ReadOnlyGitHubApi -Arguments @(
+        "api", "repos/$Repository/releases/tags/$RequestedTag"
+    ) -AllowNotFound
+    $collection = if ($null -eq $direct) { Get-ReleaseCollection $Repository } else { @() }
+    return Select-V4ReleaseByTag -DirectRelease $direct -ReleaseCollection $collection -Tag $RequestedTag
 }
 
 function Assert-CanonicalRepository {
@@ -178,9 +193,7 @@ function Get-RawMetadataSnapshot([string]$Channel) {
 }
 
 function Get-TargetResidue {
-    $release = Invoke-ReadOnlyGitHubApi -Arguments @(
-        "api", "repos/$env:GITHUB_REPOSITORY/releases/tags/$Tag"
-    ) -AllowNotFound
+    $release = Get-ReleaseForTag $env:GITHUB_REPOSITORY $Tag
     $tagRef = Invoke-ReadOnlyGitHubApi -Arguments @(
         "api", "repos/$env:GITHUB_REPOSITORY/git/ref/tags/$Tag"
     ) -AllowNotFound

--- a/scripts/v4_release_draft_lookup.ps1
+++ b/scripts/v4_release_draft_lookup.ps1
@@ -1,0 +1,28 @@
+function Select-V4ReleaseByTag {
+    param(
+        [AllowNull()]
+        [object]$DirectRelease,
+
+        [AllowNull()]
+        [object[]]$ReleaseCollection,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Tag
+    )
+
+    if ($null -ne $DirectRelease) {
+        if ([string]$DirectRelease.tag_name -ne $Tag) {
+            throw "V4 release lookup failed closed: direct release tag does not match the requested tag"
+        }
+        return $DirectRelease
+    }
+
+    $matches = @($ReleaseCollection | Where-Object { [string]$_.tag_name -eq $Tag })
+    if ($matches.Count -gt 1) {
+        throw "V4 release lookup failed closed: duplicate releases use the requested tag"
+    }
+    if ($matches.Count -eq 1) {
+        return $matches[0]
+    }
+    return $null
+}

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -54,6 +54,7 @@ $summaryName = "TAURI_ARTIFACT_SUMMARY.json"
 $sbomName = "SBOM.spdx.json"
 . (Join-Path $PSScriptRoot "v4_release_asset_upload.ps1")
 . (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
+. (Join-Path $PSScriptRoot "v4_release_draft_lookup.ps1")
 
 function Fail([string]$Message) {
     throw "V4 release pipeline failed closed: $Message"
@@ -536,18 +537,56 @@ function Get-State {
     return $state
 }
 
+function Get-ReleaseCollection([string]$Repository) {
+    return @(Invoke-GitHubApi -Arguments @(
+        "api", "--paginate", "--slurp", "repos/$Repository/releases?per_page=100"
+    ))
+}
+
+function Get-ReleaseForTag([string]$Repository, [string]$RequestedTag) {
+    $direct = Invoke-GitHubApi -Arguments @(
+        "api", "repos/$Repository/releases/tags/$RequestedTag"
+    ) -AllowNotFound
+    $collection = if ($null -eq $direct) { Get-ReleaseCollection $Repository } else { @() }
+    return Select-V4ReleaseByTag -DirectRelease $direct -ReleaseCollection $collection -Tag $RequestedTag
+}
+
+function Assert-ExistingUnpublishedDraftMatchesRequest([object]$Release) {
+    if ([string]$Release.tag_name -ne $Tag) {
+        Fail "existing release tag does not match the requested tag"
+    }
+    if (-not [bool]$Release.draft -or
+        -not [string]::IsNullOrWhiteSpace([string]$Release.published_at)) {
+        Fail "repository already contains published release/tag $Tag; published releases and tags are immutable"
+    }
+    $source = $SourceSha.ToLowerInvariant()
+    $targetCommitish = [string]$Release.target_commitish
+    if ($targetCommitish -notmatch '^[0-9a-fA-F]{40}$' -or
+        $targetCommitish.ToLowerInvariant() -ne $source) {
+        Fail "existing draft source does not match the requested source"
+    }
+    $body = [string]$Release.body
+    if ($body -notmatch "(?m)^source_sha:\s*$([regex]::Escape($source))\s*$") {
+        Fail "existing draft body source does not match the requested source"
+    }
+}
+
 function Assert-NoExistingReleaseTag {
     $repository = Get-CanonicalRepository
-    $release = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/tags/$Tag") -AllowNotFound
+    $release = Get-ReleaseForTag $repository $Tag
     if ($null -ne $release) {
-        $publishedAt = [string]$release.published_at
-        if (-not [bool]$release.draft -or -not [string]::IsNullOrWhiteSpace($publishedAt)) {
-            Fail "repository already contains published release/tag $Tag; published releases and tags are immutable"
-        }
+        Assert-ExistingUnpublishedDraftMatchesRequest $release
         $releaseId = [int64]$release.id
+        if ($releaseId -le 0) { Fail "existing draft release id is missing" }
         Invoke-GitHubApi -Arguments @(
             "api", "--method", "DELETE", "repos/$repository/releases/$releaseId"
         ) -AllowNotFound | Out-Null
+        $remainingReleaseById = Invoke-GitHubApi -Arguments @(
+            "api", "repos/$repository/releases/$releaseId"
+        ) -AllowNotFound
+        if ($null -ne $remainingReleaseById) { Fail "draft release could not be removed by release id" }
+        $remainingRelease = Get-ReleaseForTag $repository $Tag
+        if ($null -ne $remainingRelease) { Fail "draft release could not be removed" }
         $runId = if ([string]::IsNullOrWhiteSpace($env:GITHUB_RUN_ID)) { "local" } else { $env:GITHUB_RUN_ID }
         Write-Host "V4 unpublished draft reuse: deleted prior unpublished draft for $Tag (source_sha=$($SourceSha.ToLowerInvariant()), run_id=$runId)"
     }


### PR DESCRIPTION
## Summary
- detect unpublished drafts through the paginated releases collection when the by-tag endpoint returns 404
- use the recorded release ID for cleanup when release state exists, then verify deletion by ID and by tag/collection
- require exact tag, source SHA, draft, and unpublished identity before deleting or reusing a release
- share the fail-closed selector with production preflight, rehearsal cleanup, and external-state verification
- add an executable hidden-draft, duplicate, and mismatch regression fixture

## Verification
- pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_release_pipeline.ps1
- cargo test --manifest-path rust/Cargo.toml -p sky_xtask --locked (78 passed)
- cargo xtask check static
- git diff --check

Refs #165

No rehearsal or release was dispatched. Post-publication legacy-Latest ordering remains a separate follow-up.