### PR TITLE
fix(v4): guard legacy latest before metadata promotion

### DIFF
--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -244,6 +244,11 @@ jobs:
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT
 
+      - name: Verify legacy GitHub Latest before metadata promotion
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/ci_v4_release_latest_guard.ps1
+
       - name: Mint release-metadata GitHub App token
         id: metadata-app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -903,6 +903,8 @@ fn v4_release_pipeline_contract_source(
         "Qualify downloaded exact candidate bytes and packaged update",
         "RecordAttestations",
         "PublishDraft",
+        "Verify legacy GitHub Latest before metadata promotion",
+        "scripts/ci_v4_release_latest_guard.ps1",
         "PromoteMetadata",
         "FinalVerify",
     ] {
@@ -964,6 +966,34 @@ fn v4_release_pipeline_contract_source(
         );
     }
     validate_metadata_app_token_scope(&workflow)?;
+
+    let publish_step = workflow
+        .find("- name: Publish the already-qualified draft immutably")
+        .ok_or("v4 release workflow is missing the publication step")?;
+    let legacy_latest_step = workflow
+        .find("- name: Verify legacy GitHub Latest before metadata promotion")
+        .ok_or("v4 release workflow is missing the post-publication legacy Latest guard")?;
+    let metadata_token_step = workflow
+        .find("- name: Mint release-metadata GitHub App token")
+        .ok_or("v4 release workflow is missing the metadata App token step")?;
+    if publish_step >= legacy_latest_step || legacy_latest_step >= metadata_token_step {
+        return Err(
+            "legacy Latest guard must run after PublishDraft and before the metadata App token"
+                .into(),
+        );
+    }
+    let legacy_latest_end = workflow[legacy_latest_step..]
+        .find("\n      - name:")
+        .map_or(workflow.len(), |relative| legacy_latest_step + relative);
+    let legacy_latest_block = &workflow[legacy_latest_step..legacy_latest_end];
+    if !legacy_latest_block.contains("GH_TOKEN: ${{ github.token }}")
+        || !legacy_latest_block.contains("scripts/ci_v4_release_latest_guard.ps1")
+    {
+        return Err(
+            "post-publication legacy Latest guard must be read-only and use the repository token"
+                .into(),
+        );
+    }
 
     if pipeline
         .matches("orchestrate_v4_production_release.ps1")
@@ -3789,6 +3819,10 @@ jobs:
       - name: Publish the already-qualified draft immutably
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Verify legacy GitHub Latest before metadata promotion
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci_v4_release_latest_guard.ps1
       - name: Mint release-metadata GitHub App token
         id: metadata-app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -591,6 +591,8 @@ foreach ($marker in @(
     'repositories: ${{ github.event.repository.name }}',
     'permission-contents: write',
     'GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}',
+    'Verify legacy GitHub Latest before metadata promotion',
+    'scripts/ci_v4_release_latest_guard.ps1',
     'Verify isolated production runner boundary',
     'verify_v4_release_runner.ps1',
     'cleanup_v4_release_state.ps1',
@@ -607,6 +609,20 @@ $metadataPrivateKeyMarker = 'secrets.V4_RELEASE_METADATA_APP_PRIVATE_KEY'
 $metadataPrivateKeyUses = ([regex]::Matches($workflow, [regex]::Escape($metadataPrivateKeyMarker))).Count
 if ($metadataPrivateKeyUses -ne 1) {
     Fail "metadata App private key must be consumed exactly once by the token-mint action"
+}
+$publishStep = $workflow.IndexOf('- name: Publish the already-qualified draft immutably', [StringComparison]::Ordinal)
+$legacyLatestStep = $workflow.IndexOf('- name: Verify legacy GitHub Latest before metadata promotion', [StringComparison]::Ordinal)
+$metadataTokenStep = $workflow.IndexOf('- name: Mint release-metadata GitHub App token', [StringComparison]::Ordinal)
+if ($publishStep -lt 0 -or $legacyLatestStep -lt 0 -or $metadataTokenStep -lt 0 -or
+    $publishStep -ge $legacyLatestStep -or $legacyLatestStep -ge $metadataTokenStep) {
+    Fail "legacy Latest guard must run after PublishDraft and before the metadata App token"
+}
+$legacyLatestStepEnd = $workflow.IndexOf("`n      - name:", $legacyLatestStep + 1, [StringComparison]::Ordinal)
+if ($legacyLatestStepEnd -lt 0) { $legacyLatestStepEnd = $workflow.Length }
+$legacyLatestBlock = $workflow.Substring($legacyLatestStep, $legacyLatestStepEnd - $legacyLatestStep)
+if (-not $legacyLatestBlock.Contains('GH_TOKEN: ${{ github.token }}') -or
+    -not $legacyLatestBlock.Contains('scripts/ci_v4_release_latest_guard.ps1')) {
+    Fail "post-publication legacy Latest guard must be read-only and use the repository token"
 }
 $promotionStart = $workflow.IndexOf('- name: Promote release metadata only after immutable publication', [StringComparison]::Ordinal)
 if ($promotionStart -lt 0) { Fail "metadata promotion step is missing" }


### PR DESCRIPTION
## Summary
- run the existing read-only legacy GitHub Latest guard immediately after PublishDraft
- require it to execute before minting the release-metadata GitHub App token and before PromoteMetadata
- add PowerShell and Rust contract regressions for step ordering, repository-token scope, and guard presence

## Verification
- pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_release_pipeline.ps1
- cargo test --manifest-path rust/Cargo.toml -p sky_xtask --locked (78 passed)
- cargo xtask check static
- git diff --check

Refs #165

No rehearsal or release was dispatched.