### PR TITLE
feat(v4): retire legacy Latest coexistence policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         working-directory: desktop
         run: bun install --frozen-lockfile
 
-      - name: Read-only legacy GitHub Latest guard
+      - name: Read-only GitHub Latest baseline guard
         env:
           GH_TOKEN: ${{ github.token }}
         run: pwsh scripts/ci_v4_release_latest_guard.ps1

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -231,6 +231,11 @@ jobs:
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT
 
+      - name: Snapshot GitHub Latest before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/ci_v4_release_latest_guard.ps1 -Mode Capture -StateRoot $env:V4_RELEASE_STATE_ROOT
+
       - name: Publish the already-qualified draft immutably
         env:
           GH_TOKEN: ${{ github.token }}
@@ -244,10 +249,15 @@ jobs:
             -WorkflowSha $env:V4_RELEASE_WORKFLOW_SHA `
             -StateRoot $env:V4_RELEASE_STATE_ROOT
 
-      - name: Verify legacy GitHub Latest before metadata promotion
+      - name: Verify GitHub Latest channel policy before metadata promotion
         env:
           GH_TOKEN: ${{ github.token }}
-        run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/ci_v4_release_latest_guard.ps1
+        run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/ci_v4_release_latest_guard.ps1 `
+          -Mode Verify `
+          -Channel $env:V4_RELEASE_CHANNEL `
+          -ExpectedTag $env:V4_RELEASE_TAG `
+          -ExpectedSourceSha $env:V4_RELEASE_SOURCE_SHA `
+          -StateRoot $env:V4_RELEASE_STATE_ROOT
 
       - name: Mint release-metadata GitHub App token
         id: metadata-app-token

--- a/docs/adr/ADR-0007-single-repository-v4-release-architecture.md
+++ b/docs/adr/ADR-0007-single-repository-v4-release-architecture.md
@@ -15,9 +15,11 @@ the supported architecture depend on a second repository, a cross-repository cre
 publication authority, and a compatibility boundary that would have to be maintained indefinitely.
 
 The implementation work completed for the first official v4 release now provides the required
-isolation without a second repository. The source repository can keep the legacy v3 Latest contract
-while publishing v4 releases with `make_latest=false`, and the v4 runtime can consume a separate
-protected metadata branch in that same repository.
+isolation without a second repository. The source repository can publish v4 releases with
+channel-specific GitHub Latest behavior, and the v4 runtime can consume a separate protected
+metadata branch in that same repository. The temporary v3 Latest coexistence policy is retired by
+[ADR-0008](ADR-0008-v4-github-latest-policy.md); the one-time promotion of the already immutable
+`v4.0.1` release remains a separate owner/admin gate in issue #187.
 
 ## Decision
 
@@ -50,14 +52,16 @@ The same-repository production pipeline is draft-first and builds the exact sour
 ```text
 ValidateRequest -> ValidateRepository -> BuildCandidate -> CreateDraft
   -> DownloadDraft -> QualifyDownloaded -> RecordAttestations
-  -> PublishDraft -> PromoteMetadata -> FinalVerify
+  -> PublishDraft -> Assert-ImmutableRelease -> Latest policy guard
+  -> PromoteMetadata -> FinalVerify
 ```
 
-`ValidateRepository` checks the canonical repository, `main`, immutable-release policy, and
-metadata-branch readiness before `CreateDraft`. Publication uses the canonical repository
-`GITHUB_TOKEN` and `make_latest=false` while v3 coexistence remains required. Metadata promotion
-occurs only after immutable publication. `FinalVerify` checks the public release and the exact
-unauthenticated raw metadata endpoint used by the client.
+`ValidateRepository` checks the canonical repository, `main`, and metadata-branch readiness before
+`CreateDraft`. Stable publication uses the canonical repository `GITHUB_TOKEN` with
+`make_latest="true"`; beta publication uses `make_latest="false"`. The read-only Latest policy
+guard runs after publication and immutable verification, and before minting the metadata App
+token. Metadata promotion occurs only after that guard. `FinalVerify` checks the public release
+and the exact unauthenticated raw metadata endpoint used by the client.
 
 ## Security properties retained
 
@@ -84,6 +88,6 @@ bounded metadata branch. Operators no longer need a dedicated release-authority 
 compatibility path. The former repository can be removed as an owner/admin cutover action after the
 rehearsal and final release gate in issue #165.
 
-The v3 Latest namespace remains protected by explicit `make_latest=false` release behavior until
-v3 coexistence is retired. A future change to that boundary requires a new ADR and release-gate
-evidence.
+The temporary v3 Latest coexistence namespace is historical context only. ADR-0008 defines the
+current channel-aware Latest policy, while issue #187 separately gates the one-time promotion of
+the immutable `v4.0.1` release without rebuilding or changing its tag, assets, or metadata.

--- a/docs/adr/ADR-0008-v4-github-latest-policy.md
+++ b/docs/adr/ADR-0008-v4-github-latest-policy.md
@@ -25,6 +25,10 @@ The canonical same-repository release pipeline uses the GitHub Release API enum 
 - stable releases: `make_latest="true"`;
 - beta releases: `make_latest="false"`.
 
+Draft creation always uses `make_latest="false"` for both channels because GitHub does not allow
+a draft or prerelease release to become Latest. The stable/beta values above apply only to the
+publication PATCH that turns the qualified draft into a published release.
+
 `draft` remains a JSON boolean. The release workflow keeps the following fail-closed order:
 
 ```text

--- a/docs/adr/ADR-0008-v4-github-latest-policy.md
+++ b/docs/adr/ADR-0008-v4-github-latest-policy.md
@@ -1,0 +1,58 @@
+# ADR-0008: V4 GitHub Latest Policy
+
+Status: accepted
+
+Date: 2026-09-10
+
+Supersedes: the temporary GitHub Latest coexistence clause in [ADR-0007](ADR-0007-single-repository-v4-release-architecture.md)
+
+## Context
+
+The single-repository v4 architecture initially published v4 with `make_latest="false"` so the
+legacy v3.5.0 GitHub Latest release could remain discoverable during the owner/admin cutover.
+That temporary coexistence policy is no longer the desired release contract for future v4
+publication. GitHub Latest must now follow the v4 stable channel while beta releases remain
+explicitly outside Latest.
+
+The already published `v4.0.1` release is immutable. Its one-time promotion to GitHub Latest is
+handled separately by issue #187 and must not rebuild, retag, replace assets, or rewrite release
+metadata.
+
+## Decision
+
+The canonical same-repository release pipeline uses the GitHub Release API enum strings:
+
+- stable releases: `make_latest="true"`;
+- beta releases: `make_latest="false"`.
+
+`draft` remains a JSON boolean. The release workflow keeps the following fail-closed order:
+
+```text
+PublishDraft
+  -> Assert-ImmutableRelease
+  -> channel-aware Latest policy guard
+  -> mint release-metadata GitHub App token
+  -> PromoteMetadata
+  -> FinalVerify
+```
+
+Before publication, the workflow captures the read-only GitHub Latest identity. After publication,
+the policy guard requires a stable release to be the exact published tag, source SHA, and release
+identity returned by GitHub. For beta, it requires the pre-publication stable Latest identity to
+remain unchanged and rejects a beta release becoming Latest. The guard uses the repository token
+only for read operations; it does not mutate releases, tags, or metadata.
+
+The CI baseline guard is transition-aware and accepts the current published stable namespace while
+the one-time #187 cutover is pending. This read-only compatibility observation does not restore a
+second repository, a v4 bridge, or a legacy release authority.
+
+## Consequences
+
+Future stable v4 releases become GitHub Latest as part of their immutable publication transaction;
+beta releases never displace the stable Latest release. Metadata promotion remains after the
+Latest policy guard, so a release cannot advance updater metadata until its public release
+semantics have been verified.
+
+The initial `v4.0.1` publication record remains historically accurate: it was first published with
+`make_latest="false"`. Issue #187 is the only authorized one-time cutover for that immutable
+release.

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -7,8 +7,10 @@
 - Canonical repository: `pumni/Sky-Auto-Player`
 - Canonical tag: `v4.0.1`
 - Release channel: stable
-- GitHub Latest policy: v4 releases use `make_latest=false` so the legacy v3
-  `v3.5.0` Latest release remains available during the coexistence period
+- Initial GitHub publication policy: `make_latest="false"`; `v3.5.0` remained Latest during the
+  temporary coexistence window
+- A separate one-time operation in issue #187 may promote this immutable release to GitHub Latest
+  without changing its tag, assets, binary digests, or stable metadata
 
 ## Distribution and update contract
 

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -89,20 +89,23 @@ canonical repository token for same-repository release operations. Its transacti
 ```text
 ValidateRequest -> ValidateRepository -> BuildCandidate -> CreateDraft
   -> DownloadDraft -> QualifyDownloaded -> RecordAttestations
-  -> PublishDraft -> PromoteMetadata -> FinalVerify
+  -> Snapshot GitHub Latest -> PublishDraft -> Assert-ImmutableRelease
+  -> Latest policy guard -> PromoteMetadata -> FinalVerify
 ```
 
 The ordering is security-critical:
 
-1. Validate the canonical repository, `main` source ref, immutable-release policy, and
-   `release-metadata` branch readiness before creating a draft.
+1. Validate the canonical repository, `main` source ref, and `release-metadata` branch readiness
+   before creating a draft; immutable status is verified on the published release itself.
 2. Build the exact source SHA once and create a draft in the official repository.
 3. Re-download the draft installer and signature, then qualify those exact bytes.
 4. Record SBOM and provenance/attestation evidence bound to the exact source and artifacts.
-5. Publish the already-qualified draft immutably with `make_latest=false` while the v3 Latest
-   contract remains protected.
-6. Generate, validate, and promote only the selected stable/beta metadata file after publication.
-7. Re-fetch the public release and verify the exact unauthenticated `raw.githubusercontent.com`
+5. Snapshot the current GitHub Latest identity, then publish the already-qualified draft
+   immutably with `make_latest="true"` for stable or `make_latest="false"` for beta.
+6. Verify the channel-aware Latest policy before minting the metadata App token; stable must be
+   the exact new release and beta must leave the captured stable Latest unchanged.
+7. Generate, validate, and promote only the selected stable/beta metadata file after the guard.
+8. Re-fetch the public release and verify the exact unauthenticated `raw.githubusercontent.com`
    endpoint used by the client.
 
 Published release assets and tags are never repaired in place. A failed unpublished draft may be

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -97,7 +97,8 @@ The ordering is security-critical:
 
 1. Validate the canonical repository, `main` source ref, and `release-metadata` branch readiness
    before creating a draft; immutable status is verified on the published release itself.
-2. Build the exact source SHA once and create a draft in the official repository.
+2. Build the exact source SHA once and create a draft in the official repository with
+   `make_latest="false"`; the channel-specific Latest value is applied only at publication.
 3. Re-download the draft installer and signature, then qualify those exact bytes.
 4. Record SBOM and provenance/attestation evidence bound to the exact source and artifacts.
 5. Snapshot the current GitHub Latest identity, then publish the already-qualified draft

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -365,8 +365,9 @@ It executes `ValidateRequest -> ValidateRepository -> BuildCandidate -> CreateDr
 matching unpublished draft/tag. Its OIDC and SPDX attestations are verified against the
 exact downloaded bytes before `RecordAttestations`; `PublishDraft`, metadata promotion,
 and final public-release verification are intentionally unreachable in this workflow.
-The rehearsal snapshots and compares legacy v3 GitHub Latest plus both public
-`release-metadata` channel endpoints before and after cleanup.
+The rehearsal snapshots and compares the current GitHub Latest identity plus both public
+`release-metadata` channel endpoints before and after cleanup. It does not publish or promote
+anything, so it remains valid both before and after the one-time `v4.0.1` Latest operation.
 
 ```powershell
 pwsh scripts/test_v4_production_topology_rehearsal.ps1 -CandidateStateRoot $candidateStateRoot -StateRoot (Join-Path $env:RUNNER_TEMP "sky-v4-production-topology-rehearsal") -Version $version -Channel $channel -Tag "v$version" -SourceSha $sourceSha -WorkflowSha $sourceSha

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1062,8 +1062,9 @@ fn v4_release_pipeline_contract_source(
         "draft = $true",
         "draft = $false",
         "Get-V4ReleaseMakeLatestValue",
-        "make_latest = Get-V4ReleaseMakeLatestValue",
-        "make_latest is string enum true for stable and false for beta",
+        "Get-V4ReleaseDraftMakeLatestValue",
+        "make_latest = Get-V4ReleaseDraftMakeLatestValue",
+        "draft false; stable publish true; beta publish false",
         "target_commitish = $SourceSha.ToLowerInvariant()",
         "branch = \"release-metadata\"",
         "validate-monotonic",
@@ -1135,12 +1136,16 @@ fn v4_release_pipeline_contract_source(
         .find("function Invoke-PromoteMetadata")
         .ok_or("v4 release coordinator is missing the metadata promotion state")?;
     if !pipeline[create_draft_position..publish_position]
-        .contains("make_latest = Get-V4ReleaseMakeLatestValue")
+        .contains("make_latest = Get-V4ReleaseDraftMakeLatestValue")
+        || pipeline[create_draft_position..publish_position]
+            .contains("make_latest = Get-V4ReleaseMakeLatestValue $Channel")
         || !pipeline[publish_position..promote_position]
-            .contains("make_latest = Get-V4ReleaseMakeLatestValue")
+            .contains("make_latest = Get-V4ReleaseMakeLatestValue $Channel")
+        || pipeline[publish_position..promote_position]
+            .contains("make_latest = Get-V4ReleaseDraftMakeLatestValue")
     {
         return Err(
-            "CreateDraft and PublishDraft must use the GitHub make_latest string enum helper"
+            "CreateDraft must use draft-safe make_latest=false and PublishDraft must use the channel-aware helper"
                 .into(),
         );
     }
@@ -3893,15 +3898,15 @@ jobs:
     GH_TOKEN: ${{ github.token }}
 "#;
         let pipeline = r#"
-ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 v4_release_draft_lookup.ps1 Select-V4ReleaseByTag --paginate --slurp releases?per_page=100 existing draft source does not match the requested source draft release could not be removed by release id Get-V4ReleaseMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue make_latest is string enum true for stable and false for beta target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
+ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 v4_release_draft_lookup.ps1 Select-V4ReleaseByTag --paginate --slurp releases?per_page=100 existing draft source does not match the requested source draft release could not be removed by release id Get-V4ReleaseMakeLatestValue Get-V4ReleaseDraftMakeLatestValue make_latest = Get-V4ReleaseDraftMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue $Channel draft false; stable publish true; beta publish false target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
 function Invoke-BuildCandidate {
   & pwsh -File orchestrate_v4_production_release.ps1
 }
-function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum true for stable and false for beta; GitHub's successful DELETE endpoints return an empty body }
+function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; Get-V4ReleaseDraftMakeLatestValue; make_latest = Get-V4ReleaseDraftMakeLatestValue; draft payload make_latest false; GitHub's successful DELETE endpoints return an empty body }
 function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
 function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; cargo xtask builtin-catalog verify-installed; SKY_BUILTIN_CATALOG_FRESH_SELFTEST; installed-built-in-catalog-exact-manifest-file-set-sha-parseability; manifest_validated; file_set_exact; sha256_verified; songs_parseable; fresh-appdata-built-in-user-composition; freshUserSongs = @(; Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue; previousAppDataRoot; previousFreshSelfTest; if ($null -eq $previousAppDataRoot); Remove-Item Env:SKY_APP_DATA_ROOT; if ($null -eq $previousFreshSelfTest); Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST; selftest-update-active-playback; ci_v4_release_latest_guard.ps1; promote_v4_metadata.ps1; release-metadata; published_at; Start-MpScan; scan_performed }
 function Invoke-RecordAttestations { GH_TOKEN }
-function Invoke-PublishDraft { draft = $false; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum true for stable and false for beta; Assert-ImmutableRelease $published; repository release is not marked immutable }
+function Invoke-PublishDraft { draft = $false; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue $Channel; draft false; stable publish true; beta publish false; Assert-ImmutableRelease $published; repository release is not marked immutable }
 function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication; branch = "release-metadata"; GITHUB_REPOSITORY; Invoke-GitHubApi }
 function Invoke-FinalVerify { FinalVerify }
 "#;

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -368,11 +368,13 @@ fn release_metadata_contract(root: &Path) -> Result<()> {
     let acceptance_path = root.join("scripts/ci_v4_release_latest_guard.ps1");
     let acceptance = fs::read_to_string(&acceptance_path)?;
     for marker in [
-        "legacy Latest guard",
+        "V4 GitHub Latest policy guard",
         "$canonicalRepository = \"pumni/Sky-Auto-Player\"",
         "releases/latest",
-        "make_latest=false",
+        "make_latest=$(if ($Channel -eq \"stable\") { \"true\" } else { \"false\" })",
         "read_only=true",
+        "ExpectedSourceSha",
+        "github-latest-before.json",
     ] {
         if !acceptance.contains(marker) {
             return Err(format!(
@@ -903,7 +905,8 @@ fn v4_release_pipeline_contract_source(
         "Qualify downloaded exact candidate bytes and packaged update",
         "RecordAttestations",
         "PublishDraft",
-        "Verify legacy GitHub Latest before metadata promotion",
+        "Snapshot GitHub Latest before publication",
+        "Verify GitHub Latest channel policy before metadata promotion",
         "scripts/ci_v4_release_latest_guard.ps1",
         "PromoteMetadata",
         "FinalVerify",
@@ -967,30 +970,52 @@ fn v4_release_pipeline_contract_source(
     }
     validate_metadata_app_token_scope(&workflow)?;
 
+    let capture_latest_step = workflow
+        .find("- name: Snapshot GitHub Latest before publication")
+        .ok_or("v4 release workflow is missing the pre-publication Latest snapshot")?;
     let publish_step = workflow
         .find("- name: Publish the already-qualified draft immutably")
         .ok_or("v4 release workflow is missing the publication step")?;
-    let legacy_latest_step = workflow
-        .find("- name: Verify legacy GitHub Latest before metadata promotion")
-        .ok_or("v4 release workflow is missing the post-publication legacy Latest guard")?;
+    let latest_policy_step = workflow
+        .find("- name: Verify GitHub Latest channel policy before metadata promotion")
+        .ok_or("v4 release workflow is missing the post-publication Latest policy guard")?;
     let metadata_token_step = workflow
         .find("- name: Mint release-metadata GitHub App token")
         .ok_or("v4 release workflow is missing the metadata App token step")?;
-    if publish_step >= legacy_latest_step || legacy_latest_step >= metadata_token_step {
+    if capture_latest_step >= publish_step
+        || publish_step >= latest_policy_step
+        || latest_policy_step >= metadata_token_step
+    {
         return Err(
-            "legacy Latest guard must run after PublishDraft and before the metadata App token"
+            "GitHub Latest capture and policy guard must surround PublishDraft before the metadata App token"
                 .into(),
         );
     }
-    let legacy_latest_end = workflow[legacy_latest_step..]
+    let capture_latest_end = workflow[capture_latest_step..]
         .find("\n      - name:")
-        .map_or(workflow.len(), |relative| legacy_latest_step + relative);
-    let legacy_latest_block = &workflow[legacy_latest_step..legacy_latest_end];
-    if !legacy_latest_block.contains("GH_TOKEN: ${{ github.token }}")
-        || !legacy_latest_block.contains("scripts/ci_v4_release_latest_guard.ps1")
+        .map_or(workflow.len(), |relative| capture_latest_step + relative);
+    let capture_latest_block = &workflow[capture_latest_step..capture_latest_end];
+    if !capture_latest_block.contains("GH_TOKEN: ${{ github.token }}")
+        || !capture_latest_block.contains("scripts/ci_v4_release_latest_guard.ps1")
+        || !capture_latest_block.contains("-Mode Capture")
+        || !capture_latest_block.contains("-StateRoot")
     {
         return Err(
-            "post-publication legacy Latest guard must be read-only and use the repository token"
+            "pre-publication Latest snapshot must be read-only and use the isolated state root"
+                .into(),
+        );
+    }
+    let latest_policy_end = workflow[latest_policy_step..]
+        .find("\n      - name:")
+        .map_or(workflow.len(), |relative| latest_policy_step + relative);
+    let latest_policy_block = &workflow[latest_policy_step..latest_policy_end];
+    if !latest_policy_block.contains("GH_TOKEN: ${{ github.token }}")
+        || !latest_policy_block.contains("scripts/ci_v4_release_latest_guard.ps1")
+        || !latest_policy_block.contains("-Mode Verify")
+        || !latest_policy_block.contains("-ExpectedSourceSha")
+    {
+        return Err(
+            "post-publication Latest policy guard must be read-only and verify exact source identity"
                 .into(),
         );
     }
@@ -1038,7 +1063,7 @@ fn v4_release_pipeline_contract_source(
         "draft = $false",
         "Get-V4ReleaseMakeLatestValue",
         "make_latest = Get-V4ReleaseMakeLatestValue",
-        "make_latest is string enum false for create and publish",
+        "make_latest is string enum true for stable and false for beta",
         "target_commitish = $SourceSha.ToLowerInvariant()",
         "branch = \"release-metadata\"",
         "validate-monotonic",
@@ -1320,7 +1345,7 @@ fn v4_draft_rehearsal_contract_source(
         "raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json",
         "raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json",
         "releases/latest",
-        "^v3\\.",
+        "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
         "AllowAutoRedirect",
         "Headers.Authorization",
         "StatusCode",
@@ -3619,13 +3644,15 @@ fn production_metadata_endpoints_are_fixed_and_channel_isolated() {}
         assert!(!native.contains("api.github.com/repos/pumni/Sky-Auto-Player/releases"));
 
         let acceptance = r#"
-# This is the read-only legacy Latest guard.
+# This is the read-only GitHub Latest policy guard.
 $canonicalRepository = "pumni/Sky-Auto-Player"
 releases/latest
-make_latest=false
+make_latest=$(if ($Channel -eq "stable") { "true" } else { "false" })
 read_only=true
+ExpectedSourceSha
+github-latest-before.json
 "#;
-        assert!(acceptance.contains("legacy Latest guard"));
+        assert!(acceptance.contains("GitHub Latest policy guard"));
         assert!(acceptance.contains("releases/latest"));
         assert!(!acceptance.contains("gh release create"));
     }
@@ -3816,13 +3843,17 @@ jobs:
       - name: Create exact candidate draft in canonical repository
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Snapshot GitHub Latest before publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/ci_v4_release_latest_guard.ps1 -Mode Capture -StateRoot $env:V4_RELEASE_STATE_ROOT
       - name: Publish the already-qualified draft immutably
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Verify legacy GitHub Latest before metadata promotion
+      - name: Verify GitHub Latest channel policy before metadata promotion
         env:
           GH_TOKEN: ${{ github.token }}
-        run: scripts/ci_v4_release_latest_guard.ps1
+        run: scripts/ci_v4_release_latest_guard.ps1 -Mode Verify -Channel $env:V4_RELEASE_CHANNEL -ExpectedTag $env:V4_RELEASE_TAG -ExpectedSourceSha $env:V4_RELEASE_SOURCE_SHA -StateRoot $env:V4_RELEASE_STATE_ROOT
       - name: Mint release-metadata GitHub App token
         id: metadata-app-token
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
@@ -3862,15 +3893,15 @@ jobs:
     GH_TOKEN: ${{ github.token }}
 "#;
         let pipeline = r#"
-ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 v4_release_draft_lookup.ps1 Select-V4ReleaseByTag --paginate --slurp releases?per_page=100 existing draft source does not match the requested source draft release could not be removed by release id Get-V4ReleaseMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue make_latest is string enum false for create and publish target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
+ValidateRequest ValidateRepository BuildCandidate CreateDraft DownloadDraft QualifyDownloaded RecordAttestations PublishDraft PromoteMetadata FinalVerify canonical repository main is not initialized refs/heads/main release-metadata branch is not initialized Assert-MetadataBranchReadiness metadataBootstrapContract release-metadata readiness upload_url immutable-releases Assert-ImmutableRelease scripts/ci_tauri_update_e2e.ps1 CandidateInstallerPath CandidateSignaturePath CandidatePublicKeyPath export-public-key Start-MpScan scan_performed selftest-update-active-playback scan_v4_defender_exact.ps1 v4_updater_credential_broker.ps1 v4_release_draft_lookup.ps1 Select-V4ReleaseByTag --paginate --slurp releases?per_page=100 existing draft source does not match the requested source draft release could not be removed by release id Get-V4ReleaseMakeLatestValue make_latest = Get-V4ReleaseMakeLatestValue make_latest is string enum true for stable and false for beta target_commitish = $SourceSha.ToLowerInvariant() branch = "release-metadata" validate-monotonic Write-RepositoryContentFile Get-PublicMetadataDocument raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json AllowAutoRedirect Headers.Authorization GITHUB_REPOSITORY Invoke-GitHubApi v4_release_asset_upload.ps1
 function Invoke-BuildCandidate {
   & pwsh -File orchestrate_v4_production_release.ps1
 }
-function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum false for create and publish; GitHub's successful DELETE endpoints return an empty body }
+function Invoke-CreateDraft { draft = $true; refs/heads/main; repository already contains published release/tag; unpublished draft reuse; published tags are immutable; git/refs/tags/$Tag; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum true for stable and false for beta; GitHub's successful DELETE endpoints return an empty body }
 function Invoke-DownloadDraft { downloaded; Get-FileHash; unsigned-zero-budget }
 function Invoke-QualifyDownloaded { verify-signature; verify-tauri-bundle; current-user; active-playback-install-rejected; previous-v4-to-exact-downloaded-candidate-update; cargo xtask builtin-catalog verify-installed; SKY_BUILTIN_CATALOG_FRESH_SELFTEST; installed-built-in-catalog-exact-manifest-file-set-sha-parseability; manifest_validated; file_set_exact; sha256_verified; songs_parseable; fresh-appdata-built-in-user-composition; freshUserSongs = @(; Get-ChildItem -LiteralPath $freshSongsRoot -File -Recurse -ErrorAction SilentlyContinue; previousAppDataRoot; previousFreshSelfTest; if ($null -eq $previousAppDataRoot); Remove-Item Env:SKY_APP_DATA_ROOT; if ($null -eq $previousFreshSelfTest); Remove-Item Env:SKY_BUILTIN_CATALOG_FRESH_SELFTEST; selftest-update-active-playback; ci_v4_release_latest_guard.ps1; promote_v4_metadata.ps1; release-metadata; published_at; Start-MpScan; scan_performed }
 function Invoke-RecordAttestations { GH_TOKEN }
-function Invoke-PublishDraft { draft = $false; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum false for create and publish; Assert-ImmutableRelease $published; repository release is not marked immutable }
+function Invoke-PublishDraft { draft = $false; Get-V4ReleaseMakeLatestValue; make_latest = Get-V4ReleaseMakeLatestValue; make_latest is string enum true for stable and false for beta; Assert-ImmutableRelease $published; repository release is not marked immutable }
 function Invoke-PromoteMetadata { metadata promotion is forbidden before immutable publication; branch = "release-metadata"; GITHUB_REPOSITORY; Invoke-GitHubApi }
 function Invoke-FinalVerify { FinalVerify }
 "#;

--- a/scripts/ci_v4_release_latest_guard.ps1
+++ b/scripts/ci_v4_release_latest_guard.ps1
@@ -1,51 +1,169 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Baseline", "Capture", "Verify")]
+    [string]$Mode = "Baseline",
+
+    [ValidateSet("stable", "beta")]
+    [string]$Channel,
+
+    [string]$ExpectedTag,
+    [string]$ExpectedSourceSha,
+    [string]$StateRoot
+)
+
+Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 $canonicalRepository = "pumni/Sky-Auto-Player"
+
+function Fail([string]$Message) {
+    throw "V4 GitHub Latest policy guard failed closed: $Message"
+}
+
 if ([string]::IsNullOrWhiteSpace($env:GITHUB_REPOSITORY) -or
     $env:GITHUB_REPOSITORY -ne $canonicalRepository) {
-    throw "legacy Latest guard requires the canonical repository identity"
+    Fail "guard requires the canonical repository identity"
 }
 
 function Get-GitHubJson([string]$Path) {
     $payload = & gh api $Path --header "Accept: application/vnd.github+json"
     if ($LASTEXITCODE -ne 0) {
-        throw "GitHub read failed for $Path"
+        Fail "GitHub read failed for $Path"
     }
     return ($payload -join "`n") | ConvertFrom-Json
 }
 
-$latest = Get-GitHubJson "repos/$canonicalRepository/releases/latest"
-if ($latest.url -notlike "https://api.github.com/repos/$canonicalRepository/releases/*") {
-    throw "Unexpected canonical repository in GitHub Latest response: $($latest.url)"
-}
-if ($latest.draft -or $latest.prerelease) {
-    throw "The legacy GitHub Latest release must be published and non-prerelease: $($latest.tag_name)"
-}
-if ($latest.tag_name -notmatch '^v(?<version>3\.\d+\.\d+)$') {
-    throw "v4 publication displaced the legacy GitHub Latest release: $($latest.tag_name)"
+function Get-LatestRelease {
+    $latest = Get-GitHubJson "repos/$canonicalRepository/releases/latest"
+    if ([string]$latest.url -notlike "https://api.github.com/repos/$canonicalRepository/releases/*") {
+        Fail "unexpected repository in GitHub Latest response: $($latest.url)"
+    }
+    if ([bool]$latest.draft -or [bool]$latest.prerelease -or
+        [string]::IsNullOrWhiteSpace([string]$latest.published_at)) {
+        Fail "GitHub Latest must be published and non-prerelease: $($latest.tag_name)"
+    }
+    if ([string]$latest.tag_name -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+        Fail "GitHub Latest is outside the supported stable transition namespace: $($latest.tag_name)"
+    }
+    return $latest
 }
 
-$version = $Matches.version
-$assetNames = @($latest.assets | ForEach-Object { $_.name })
-$requiredLegacyAssets = @(
-    "Sky-Auto-Player-v$version.zip",
-    "Sky-Auto-Player-v$version.zip.sha256",
-    "MANIFEST.json"
-)
-foreach ($asset in $requiredLegacyAssets) {
-    if ($assetNames -notcontains $asset) {
-        throw "The legacy GitHub Latest release is missing its canonical asset: $asset"
+function Get-LatestIdentity([object]$Release) {
+    return [ordered]@{
+        id = [int64]$Release.id
+        tag_name = [string]$Release.tag_name
+        target_commitish = [string]$Release.target_commitish
+        draft = [bool]$Release.draft
+        prerelease = [bool]$Release.prerelease
+        published_at = [string]$Release.published_at
     }
 }
-if ($assetNames | Where-Object { $_ -match '^Sky Auto Player_4(?:\.\d+|-)' }) {
-    throw "A canonical v4 Tauri artifact appeared in the legacy GitHub Latest release"
+
+function Get-GuardStateRoot {
+    if ([string]::IsNullOrWhiteSpace($StateRoot)) { Fail "StateRoot is required for $Mode mode" }
+    $full = [IO.Path]::GetFullPath($StateRoot)
+    New-Item -ItemType Directory -Path $full -Force | Out-Null
+    return $full
+}
+
+function Write-GuardJson([string]$Path, [object]$Value) {
+    $Value | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8NoBOM
+}
+
+if ($Mode -eq "Baseline") {
+    $latest = Get-LatestRelease
+    @"
+V4 GitHub Latest baseline guard: PASS
+repository=$canonicalRepository
+latest_tag=$($latest.tag_name)
+latest_release=$($latest.html_url)
+transition_compatible=true
+read_only=true
+"@ | Write-Host
+    exit 0
+}
+
+$guardRoot = Get-GuardStateRoot
+$beforePath = Join-Path $guardRoot "github-latest-before.json"
+
+if ($Mode -eq "Capture") {
+    $latest = Get-LatestRelease
+    Write-GuardJson $beforePath (Get-LatestIdentity $latest)
+    @"
+V4 GitHub Latest policy capture: PASS
+repository=$canonicalRepository
+captured_tag=$($latest.tag_name)
+read_only=true
+"@ | Write-Host
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($Channel) -or
+    [string]::IsNullOrWhiteSpace($ExpectedTag) -or
+    [string]::IsNullOrWhiteSpace($ExpectedSourceSha)) {
+    Fail "Verify mode requires channel, expected tag, and expected source SHA"
+}
+if ($ExpectedTag -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+    Fail "expected tag is not canonical"
+}
+if ($ExpectedSourceSha -notmatch '^[0-9a-fA-F]{40}$') {
+    Fail "expected source SHA is not an exact commit SHA"
+}
+$statePath = Join-Path $guardRoot "release-state.json"
+if (-not (Test-Path -LiteralPath $statePath -PathType Leaf)) {
+    Fail "release-state.json is required for Verify mode"
+}
+$state = Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+if ($null -eq $state.release_id) { Fail "release-state.json has no release_id" }
+
+$latest = Get-LatestRelease
+$latestIdentity = Get-LatestIdentity $latest
+$published = Get-GitHubJson "repos/$canonicalRepository/releases/tags/$ExpectedTag"
+if ([int64]$published.id -ne [int64]$state.release_id -or
+    [string]$published.tag_name -ne $ExpectedTag -or
+    [string]$published.target_commitish -ne $ExpectedSourceSha.ToLowerInvariant()) {
+    Fail "published release identity does not match the exact requested source/tag"
+}
+if ([bool]$published.draft -or
+    [string]::IsNullOrWhiteSpace([string]$published.published_at)) {
+    Fail "published release is still draft or unpublished"
+}
+if (($Channel -eq "stable" -and [bool]$published.prerelease) -or
+    ($Channel -eq "beta" -and -not [bool]$published.prerelease)) {
+    Fail "published release prerelease state does not match channel $Channel"
+}
+if ($null -eq $published.immutable -or -not [bool]$published.immutable) {
+    Fail "published release is not marked immutable before Latest policy verification"
+}
+
+if ($Channel -eq "stable") {
+    if ([int64]$latestIdentity.id -ne [int64]$published.id -or
+        $latestIdentity.tag_name -ne $ExpectedTag -or
+        $latestIdentity.target_commitish -ne $ExpectedSourceSha.ToLowerInvariant()) {
+        Fail "stable publication did not become the exact GitHub Latest release"
+    }
+} else {
+    if (-not (Test-Path -LiteralPath $beforePath -PathType Leaf)) {
+        Fail "beta verification requires the pre-publication GitHub Latest snapshot"
+    }
+    $before = Get-Content -LiteralPath $beforePath -Raw | ConvertFrom-Json
+    foreach ($property in @("id", "tag_name", "target_commitish", "draft", "prerelease", "published_at")) {
+        if ([string]$latestIdentity[$property] -ne [string]$before.$property) {
+            Fail "beta publication changed GitHub Latest identity: $property"
+        }
+    }
+    if ($latestIdentity.tag_name -eq $ExpectedTag -or [bool]$latestIdentity.prerelease) {
+        Fail "beta publication displaced GitHub Latest"
+    }
 }
 
 @"
-V4 legacy GitHub Latest guard: PASS
+V4 GitHub Latest policy guard: PASS
 repository=$canonicalRepository
-legacy_latest_tag=$($latest.tag_name)
-legacy_latest_release=$($latest.html_url)
-make_latest=false
+channel=$Channel
+latest_tag=$($latest.tag_name)
+published_tag=$ExpectedTag
+published_release=$($published.html_url)
+make_latest=$(if ($Channel -eq "stable") { "true" } else { "false" })
 read_only=true
 "@ | Write-Host

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -28,13 +28,15 @@ $draftCleanup = Get-Content -LiteralPath $draftCleanupPath -Raw
 $externalState = Get-Content -LiteralPath $externalStatePath -Raw
 $draftLookup = Get-Content -LiteralPath $draftLookupPath -Raw
 $testHarness = Get-Content -LiteralPath $PSCommandPath -Raw
+$latestGuardPath = Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1"
+$latestGuard = Get-Content -LiteralPath $latestGuardPath -Raw
 
 foreach ($source in @(
     [pscustomobject]@{ Name = "release workflow"; Text = $workflow },
     [pscustomobject]@{ Name = "release pipeline"; Text = $pipeline },
     [pscustomobject]@{ Name = "metadata promotion"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "promote_v4_metadata.ps1") -Raw) },
     [pscustomobject]@{ Name = "asset upload"; Text = $uploadHelper },
-    [pscustomobject]@{ Name = "legacy Latest guard"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1") -Raw) },
+    [pscustomobject]@{ Name = "GitHub Latest policy guard"; Text = (Get-Content -LiteralPath (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1") -Raw) },
     [pscustomobject]@{ Name = "controlled draft rehearsal workflow"; Text = $draftWorkflow },
     [pscustomobject]@{ Name = "controlled draft cleanup"; Text = $draftCleanup },
     [pscustomobject]@{ Name = "controlled draft external-state check"; Text = $externalState },
@@ -54,6 +56,24 @@ foreach ($source in @(
             Fail "$($source.Name) retains forbidden two-repository marker: $forbidden"
         }
     }
+}
+
+foreach ($marker in @(
+    'ValidateSet("Baseline", "Capture", "Verify")',
+    'Get-GitHubJson "repos/$canonicalRepository/releases/latest"',
+    'github-latest-before.json',
+    'ExpectedTag', 'ExpectedSourceSha',
+    'make_latest=$(if ($Channel -eq "stable") { "true" } else { "false" })',
+    'stable publication did not become the exact GitHub Latest release',
+    'beta publication changed GitHub Latest identity',
+    'read_only=true'
+)) {
+    if (-not $latestGuard.Contains($marker)) {
+        Fail "GitHub Latest policy guard marker is missing: $marker"
+    }
+}
+if ($latestGuard.Contains('^v3\.')) {
+    Fail "GitHub Latest policy guard still hard-codes the retired v3-only namespace"
 }
 
 function Fail([string]$Message) { throw "FAILED: $Message" }
@@ -165,7 +185,7 @@ foreach ($marker in @(
     'Capture', 'Verify',
     'raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/stable/latest.json',
     'raw.githubusercontent.com/pumni/Sky-Auto-Player/release-metadata/channels/beta/latest.json',
-    'releases/latest', '^v3\.', 'AllowAutoRedirect', 'Headers.Authorization',
+    'releases/latest', '^v[0-9]+\.[0-9]+\.[0-9]+$', 'AllowAutoRedirect', 'Headers.Authorization',
     'StatusCode', 'sha256', 'external-state-before.json', 'external-state-after.json',
     'GITHUB_REPOSITORY', 'target_release_absent', 'target_tag_absent',
     'v4_release_draft_lookup.ps1', 'Select-V4ReleaseByTag', '--paginate',
@@ -421,7 +441,7 @@ foreach ($marker in @(
     'V4 immutable publication guard self-test', 'immutable=false rejected',
     'Get-V4ReleaseMakeLatestValue',
     'V4 GitHub release payload self-test',
-    'make_latest is string enum false for create and publish',
+    'make_latest is string enum true for stable and false for beta',
     'Start-MpScan',
     'previous-v4-to-exact-downloaded-candidate-update',
     'selftest-update-active-playback', 'scan_performed',
@@ -451,7 +471,7 @@ $pipelineSelfTestOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Byp
 if ($LASTEXITCODE -ne 0 -or $pipelineSelfTestOutput -notmatch 'immutable=false rejected; immutable=true accepted') {
     Fail "pipeline immutable publication guard self-test did not reject immutable=false"
 }
-if ($pipelineSelfTestOutput -notmatch 'make_latest is string enum false for create and publish') {
+if ($pipelineSelfTestOutput -notmatch 'make_latest is string enum true for stable and false for beta') {
     Fail "pipeline GitHub release payload self-test did not verify the make_latest JSON enum type"
 }
 foreach ($marker in @(
@@ -591,7 +611,8 @@ foreach ($marker in @(
     'repositories: ${{ github.event.repository.name }}',
     'permission-contents: write',
     'GH_TOKEN: ${{ steps.metadata-app-token.outputs.token }}',
-    'Verify legacy GitHub Latest before metadata promotion',
+    'Snapshot GitHub Latest before publication',
+    'Verify GitHub Latest channel policy before metadata promotion',
     'scripts/ci_v4_release_latest_guard.ps1',
     'Verify isolated production runner boundary',
     'verify_v4_release_runner.ps1',
@@ -610,19 +631,31 @@ $metadataPrivateKeyUses = ([regex]::Matches($workflow, [regex]::Escape($metadata
 if ($metadataPrivateKeyUses -ne 1) {
     Fail "metadata App private key must be consumed exactly once by the token-mint action"
 }
+$captureLatestStep = $workflow.IndexOf('- name: Snapshot GitHub Latest before publication', [StringComparison]::Ordinal)
 $publishStep = $workflow.IndexOf('- name: Publish the already-qualified draft immutably', [StringComparison]::Ordinal)
-$legacyLatestStep = $workflow.IndexOf('- name: Verify legacy GitHub Latest before metadata promotion', [StringComparison]::Ordinal)
+$latestPolicyStep = $workflow.IndexOf('- name: Verify GitHub Latest channel policy before metadata promotion', [StringComparison]::Ordinal)
 $metadataTokenStep = $workflow.IndexOf('- name: Mint release-metadata GitHub App token', [StringComparison]::Ordinal)
-if ($publishStep -lt 0 -or $legacyLatestStep -lt 0 -or $metadataTokenStep -lt 0 -or
-    $publishStep -ge $legacyLatestStep -or $legacyLatestStep -ge $metadataTokenStep) {
-    Fail "legacy Latest guard must run after PublishDraft and before the metadata App token"
+if ($captureLatestStep -lt 0 -or $publishStep -lt 0 -or $latestPolicyStep -lt 0 -or $metadataTokenStep -lt 0 -or
+    $captureLatestStep -ge $publishStep -or $publishStep -ge $latestPolicyStep -or $latestPolicyStep -ge $metadataTokenStep) {
+    Fail "GitHub Latest capture/policy guard ordering is not fail-closed"
 }
-$legacyLatestStepEnd = $workflow.IndexOf("`n      - name:", $legacyLatestStep + 1, [StringComparison]::Ordinal)
-if ($legacyLatestStepEnd -lt 0) { $legacyLatestStepEnd = $workflow.Length }
-$legacyLatestBlock = $workflow.Substring($legacyLatestStep, $legacyLatestStepEnd - $legacyLatestStep)
-if (-not $legacyLatestBlock.Contains('GH_TOKEN: ${{ github.token }}') -or
-    -not $legacyLatestBlock.Contains('scripts/ci_v4_release_latest_guard.ps1')) {
-    Fail "post-publication legacy Latest guard must be read-only and use the repository token"
+$latestPolicyStepEnd = $workflow.IndexOf("`n      - name:", $latestPolicyStep + 1, [StringComparison]::Ordinal)
+if ($latestPolicyStepEnd -lt 0) { $latestPolicyStepEnd = $workflow.Length }
+$latestPolicyBlock = $workflow.Substring($latestPolicyStep, $latestPolicyStepEnd - $latestPolicyStep)
+$captureLatestStepEnd = $workflow.IndexOf("`n      - name:", $captureLatestStep + 1, [StringComparison]::Ordinal)
+if ($captureLatestStepEnd -lt 0) { $captureLatestStepEnd = $workflow.Length }
+$captureLatestBlock = $workflow.Substring($captureLatestStep, $captureLatestStepEnd - $captureLatestStep)
+if (-not $captureLatestBlock.Contains('GH_TOKEN: ${{ github.token }}') -or
+    -not $captureLatestBlock.Contains('scripts/ci_v4_release_latest_guard.ps1') -or
+    -not $captureLatestBlock.Contains('-Mode Capture') -or
+    -not $captureLatestBlock.Contains('-StateRoot')) {
+    Fail "pre-publication Latest snapshot must be read-only and use the isolated state root"
+}
+if (-not $latestPolicyBlock.Contains('GH_TOKEN: ${{ github.token }}') -or
+    -not $latestPolicyBlock.Contains('scripts/ci_v4_release_latest_guard.ps1') -or
+    -not $latestPolicyBlock.Contains('-Mode Verify') -or
+    -not $latestPolicyBlock.Contains('-ExpectedSourceSha')) {
+    Fail "post-publication Latest policy guard must be read-only and verify exact source identity"
 }
 $promotionStart = $workflow.IndexOf('- name: Promote release metadata only after immutable publication', [StringComparison]::Ordinal)
 if ($promotionStart -lt 0) { Fail "metadata promotion step is missing" }

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -440,8 +440,10 @@ foreach ($marker in @(
     'Assert-ImmutableRelease $published', 'repository release is not marked immutable',
     'V4 immutable publication guard self-test', 'immutable=false rejected',
     'Get-V4ReleaseMakeLatestValue',
+    'Get-V4ReleaseDraftMakeLatestValue',
+    'make_latest = Get-V4ReleaseDraftMakeLatestValue',
     'V4 GitHub release payload self-test',
-    'make_latest is string enum true for stable and false for beta',
+    'draft false; stable publish true; beta publish false',
     'Start-MpScan',
     'previous-v4-to-exact-downloaded-candidate-update',
     'selftest-update-active-playback', 'scan_performed',
@@ -471,8 +473,26 @@ $pipelineSelfTestOutput = & pwsh -NoProfile -NonInteractive -ExecutionPolicy Byp
 if ($LASTEXITCODE -ne 0 -or $pipelineSelfTestOutput -notmatch 'immutable=false rejected; immutable=true accepted') {
     Fail "pipeline immutable publication guard self-test did not reject immutable=false"
 }
-if ($pipelineSelfTestOutput -notmatch 'make_latest is string enum true for stable and false for beta') {
+if ($pipelineSelfTestOutput -notmatch 'draft false; stable publish true; beta publish false') {
     Fail "pipeline GitHub release payload self-test did not verify the make_latest JSON enum type"
+}
+$createDraftBody = $pipeline.Substring(
+    $pipeline.IndexOf('function Invoke-CreateDraft', [StringComparison]::Ordinal),
+    $pipeline.IndexOf('function Invoke-DownloadDraft', [StringComparison]::Ordinal) -
+        $pipeline.IndexOf('function Invoke-CreateDraft', [StringComparison]::Ordinal)
+)
+$publishDraftBody = $pipeline.Substring(
+    $pipeline.IndexOf('function Invoke-PublishDraft', [StringComparison]::Ordinal),
+    $pipeline.IndexOf('function Invoke-RecordAttestations', [StringComparison]::Ordinal) -
+        $pipeline.IndexOf('function Invoke-PublishDraft', [StringComparison]::Ordinal)
+)
+if (-not $createDraftBody.Contains('make_latest = Get-V4ReleaseDraftMakeLatestValue') -or
+    $createDraftBody.Contains('make_latest = Get-V4ReleaseMakeLatestValue $Channel')) {
+    Fail "CreateDraft must always use the draft-safe make_latest=false helper"
+}
+if (-not $publishDraftBody.Contains('make_latest = Get-V4ReleaseMakeLatestValue $Channel') -or
+    $publishDraftBody.Contains('Get-V4ReleaseDraftMakeLatestValue')) {
+    Fail "PublishDraft must use the channel-aware publication make_latest helper"
 }
 foreach ($marker in @(
     'function Get-SanitizedReleaseProbeOutput',

--- a/scripts/v4_draft_rehearsal_external_state.ps1
+++ b/scripts/v4_draft_rehearsal_external_state.ps1
@@ -111,13 +111,15 @@ function Assert-TagIdentity {
     }
 }
 
-function Get-LegacyLatestSnapshot {
+function Get-GitHubLatestSnapshot {
     $release = Invoke-ReadOnlyGitHubApi -Arguments @(
         "api", "repos/$env:GITHUB_REPOSITORY/releases/latest"
     )
-    if ($null -eq $release) { Fail "legacy GitHub Latest release is unavailable" }
+    if ($null -eq $release) { Fail "GitHub Latest release is unavailable" }
     $tagName = [string](Get-PropertyValue $release "tag_name")
-    if ($tagName -notmatch '^v3\.') { Fail "GitHub Latest is not the expected immutable legacy v3 release" }
+    if ($tagName -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+$') {
+        Fail "GitHub Latest is not a supported published stable release"
+    }
     if ([bool](Get-PropertyValue $release "draft") -or
         [string]::IsNullOrWhiteSpace([string](Get-PropertyValue $release "published_at"))) {
         Fail "GitHub Latest is not a published non-draft release"
@@ -208,7 +210,7 @@ function Get-ExternalSnapshot {
     return [ordered]@{
         schema_version = 1
         repository = $env:GITHUB_REPOSITORY
-        legacy_latest = Get-LegacyLatestSnapshot
+        github_latest = Get-GitHubLatestSnapshot
         metadata = [ordered]@{
             stable = Get-RawMetadataSnapshot "stable"
             beta = Get-RawMetadataSnapshot "beta"
@@ -256,7 +258,7 @@ if ($Mode -eq "Capture") {
         source_sha = [string]$env:V4_DRAFT_REHEARSAL_SOURCE_SHA
         captured_utc = [DateTime]::UtcNow.ToString("o")
     })
-    Write-Host "V4 draft rehearsal external-state capture: PASS (legacy Latest and stable/beta metadata snapshotted)"
+    Write-Host "V4 draft rehearsal external-state capture: PASS (GitHub Latest and stable/beta metadata snapshotted)"
     exit 0
 }
 
@@ -274,7 +276,7 @@ $afterJson = Convert-SnapshotToJson $after
 $beforeHash = Get-JsonSha256 $beforeJson
 $afterHash = Get-JsonSha256 $afterJson
 if ($beforeJson -ne $afterJson) {
-    Fail "legacy Latest or stable/beta metadata changed during controlled draft rehearsal"
+    Fail "GitHub Latest or stable/beta metadata changed during controlled draft rehearsal"
 }
 Write-JsonFile $verificationPath ([ordered]@{
     schema_version = 1
@@ -283,10 +285,10 @@ Write-JsonFile $verificationPath ([ordered]@{
     tag = $Tag
     target_release_absent = $true
     target_tag_absent = $true
-    legacy_latest_unchanged = $true
+    github_latest_unchanged = $true
     stable_metadata_unchanged = $true
     beta_metadata_unchanged = $true
     before_sha256 = $beforeHash
     after_sha256 = $afterHash
 })
-Write-Host "V4 draft rehearsal external-state verification: PASS (draft/tag absent; legacy Latest and stable/beta metadata unchanged)"
+Write-Host "V4 draft rehearsal external-state verification: PASS (draft/tag absent; GitHub Latest and stable/beta metadata unchanged)"

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -90,6 +90,12 @@ function Get-V4ReleaseMakeLatestValue([string]$ReleaseChannel) {
     Fail "release channel is required to select make_latest"
 }
 
+function Get-V4ReleaseDraftMakeLatestValue {
+    # GitHub does not allow a draft or prerelease to become Latest. Keep draft
+    # creation independent from the eventual stable publication policy.
+    return "false"
+}
+
 function Read-JsonFile([string]$Path) {
     if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { Fail "Required state file is missing: $Path" }
     return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
@@ -622,7 +628,7 @@ function Invoke-CreateDraft {
         body = $body + ([IO.File]::ReadAllText($notesPath)).Trim()
         draft = $true
         prerelease = ($Channel -eq "beta")
-        make_latest = Get-V4ReleaseMakeLatestValue $Channel
+        make_latest = Get-V4ReleaseDraftMakeLatestValue
     })
     $release = Invoke-GitHubApi -Arguments @("api", "--method", "POST", "repos/$repository/releases", "--input", $payloadPath)
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "repository did not create the requested draft release" }
@@ -1134,24 +1140,34 @@ function Invoke-SelfTest {
     Write-Host "V4 immutable publication guard self-test: PASS (immutable=false rejected; immutable=true accepted)"
 
     foreach ($channelCase in @(
-        [pscustomobject]@{ Channel = "stable"; Expected = "true" },
-        [pscustomobject]@{ Channel = "beta"; Expected = "false" }
+        [pscustomobject]@{ Channel = "stable"; PublishExpected = "true" },
+        [pscustomobject]@{ Channel = "beta"; PublishExpected = "false" }
     )) {
-        foreach ($draftValue in @($true, $false)) {
-            $payload = [ordered]@{
-                draft = $draftValue
-                make_latest = Get-V4ReleaseMakeLatestValue $channelCase.Channel
-            }
-            $roundTrip = (($payload | ConvertTo-Json -Depth 20) | ConvertFrom-Json)
-            if ($roundTrip.make_latest -isnot [string] -or $roundTrip.make_latest -ne $channelCase.Expected) {
-                Fail "GitHub release payload make_latest must round-trip as the string enum $($channelCase.Expected) for $($channelCase.Channel)"
-            }
-            if ($roundTrip.draft -isnot [bool] -or [bool]$roundTrip.draft -ne $draftValue) {
-                Fail "GitHub release payload draft must remain a JSON boolean"
-            }
+        $draftPayload = [ordered]@{
+            draft = $true
+            make_latest = Get-V4ReleaseDraftMakeLatestValue
+        }
+        $draftRoundTrip = (($draftPayload | ConvertTo-Json -Depth 20) | ConvertFrom-Json)
+        if ($draftRoundTrip.make_latest -isnot [string] -or $draftRoundTrip.make_latest -ne "false") {
+            Fail "GitHub draft payload make_latest must round-trip as the string enum false"
+        }
+        if ($draftRoundTrip.draft -isnot [bool] -or -not [bool]$draftRoundTrip.draft) {
+            Fail "GitHub draft payload draft must remain the JSON boolean true"
+        }
+
+        $publishPayload = [ordered]@{
+            draft = $false
+            make_latest = Get-V4ReleaseMakeLatestValue $channelCase.Channel
+        }
+        $publishRoundTrip = (($publishPayload | ConvertTo-Json -Depth 20) | ConvertFrom-Json)
+        if ($publishRoundTrip.make_latest -isnot [string] -or $publishRoundTrip.make_latest -ne $channelCase.PublishExpected) {
+            Fail "GitHub publication payload make_latest must round-trip as the string enum $($channelCase.PublishExpected) for $($channelCase.Channel)"
+        }
+        if ($publishRoundTrip.draft -isnot [bool] -or [bool]$publishRoundTrip.draft) {
+            Fail "GitHub publication payload draft must remain the JSON boolean false"
         }
     }
-    Write-Host "V4 GitHub release payload self-test: PASS (make_latest is string enum true for stable and false for beta)"
+    Write-Host "V4 GitHub release payload self-test: PASS (draft false; stable publish true; beta publish false)"
 
     $mock.attested = $true
     $mock.published = $true

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -83,9 +83,11 @@ function Write-JsonFile([string]$Path, [object]$Value) {
     [IO.File]::WriteAllText($Path, $json + "`n", [Text.UTF8Encoding]::new($false))
 }
 
-function Get-V4ReleaseMakeLatestValue {
+function Get-V4ReleaseMakeLatestValue([string]$ReleaseChannel) {
     # GitHub's release API accepts an enum string here, not a JSON boolean.
-    return "false"
+    if ($ReleaseChannel -eq "stable") { return "true" }
+    if ($ReleaseChannel -eq "beta") { return "false" }
+    Fail "release channel is required to select make_latest"
 }
 
 function Read-JsonFile([string]$Path) {
@@ -620,7 +622,7 @@ function Invoke-CreateDraft {
         body = $body + ([IO.File]::ReadAllText($notesPath)).Trim()
         draft = $true
         prerelease = ($Channel -eq "beta")
-        make_latest = Get-V4ReleaseMakeLatestValue
+        make_latest = Get-V4ReleaseMakeLatestValue $Channel
     })
     $release = Invoke-GitHubApi -Arguments @("api", "--method", "POST", "repos/$repository/releases", "--input", $payloadPath)
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "repository did not create the requested draft release" }
@@ -959,7 +961,7 @@ function Invoke-PublishDraft {
         if ($downloadedHash -ne [string]$expected.sha256) { Fail "qualified downloaded digest changed before publication: $expectedReleaseName" }
     }
     $patchPath = Join-Path (Get-EffectiveStateRoot) "publish-release.json"
-    Write-JsonFile $patchPath ([ordered]@{ draft = $false; make_latest = Get-V4ReleaseMakeLatestValue })
+    Write-JsonFile $patchPath ([ordered]@{ draft = $false; make_latest = Get-V4ReleaseMakeLatestValue $Channel })
     $published = Invoke-GitHubApi -Arguments @("api", "--method", "PATCH", "repos/$repository/releases/$($state.release_id)", "--input", $patchPath)
     if ($published.draft -or [string]::IsNullOrWhiteSpace([string]$published.published_at)) { Fail "repository did not publish the already-qualified draft" }
     Assert-ImmutableRelease $published
@@ -1094,8 +1096,13 @@ function Invoke-FinalVerify {
     }
     Invoke-Checked "pwsh" @(
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
-        "-File", (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1")
-    ) "legacy GitHub Latest release was displaced"
+        "-File", (Join-Path $PSScriptRoot "ci_v4_release_latest_guard.ps1"),
+        "-Mode", "Verify",
+        "-Channel", $Channel,
+        "-ExpectedTag", $Tag,
+        "-ExpectedSourceSha", $SourceSha,
+        "-StateRoot", (Get-EffectiveStateRoot)
+    ) "GitHub Latest channel policy verification failed"
     Write-Host "V4 final public verification: PASS (published immutable assets and metadata are exact)"
 }
 
@@ -1126,20 +1133,25 @@ function Invoke-SelfTest {
     Assert-ImmutableRelease ([pscustomobject]@{ immutable = $true })
     Write-Host "V4 immutable publication guard self-test: PASS (immutable=false rejected; immutable=true accepted)"
 
-    foreach ($draftValue in @($true, $false)) {
-        $payload = [ordered]@{
-            draft = $draftValue
-            make_latest = Get-V4ReleaseMakeLatestValue
-        }
-        $roundTrip = (($payload | ConvertTo-Json -Depth 20) | ConvertFrom-Json)
-        if ($roundTrip.make_latest -isnot [string] -or $roundTrip.make_latest -ne "false") {
-            Fail "GitHub release payload make_latest must round-trip as the string enum false"
-        }
-        if ($roundTrip.draft -isnot [bool] -or [bool]$roundTrip.draft -ne $draftValue) {
-            Fail "GitHub release payload draft must remain a JSON boolean"
+    foreach ($channelCase in @(
+        [pscustomobject]@{ Channel = "stable"; Expected = "true" },
+        [pscustomobject]@{ Channel = "beta"; Expected = "false" }
+    )) {
+        foreach ($draftValue in @($true, $false)) {
+            $payload = [ordered]@{
+                draft = $draftValue
+                make_latest = Get-V4ReleaseMakeLatestValue $channelCase.Channel
+            }
+            $roundTrip = (($payload | ConvertTo-Json -Depth 20) | ConvertFrom-Json)
+            if ($roundTrip.make_latest -isnot [string] -or $roundTrip.make_latest -ne $channelCase.Expected) {
+                Fail "GitHub release payload make_latest must round-trip as the string enum $($channelCase.Expected) for $($channelCase.Channel)"
+            }
+            if ($roundTrip.draft -isnot [bool] -or [bool]$roundTrip.draft -ne $draftValue) {
+                Fail "GitHub release payload draft must remain a JSON boolean"
+            }
         }
     }
-    Write-Host "V4 GitHub release payload self-test: PASS (make_latest is string enum false for create and publish)"
+    Write-Host "V4 GitHub release payload self-test: PASS (make_latest is string enum true for stable and false for beta)"
 
     $mock.attested = $true
     $mock.published = $true


### PR DESCRIPTION
## Summary

- retire the v3-only GitHub Latest guard and adopt channel-aware stable/beta policy
- keep draft creation safe with `make_latest="false"` for both channels
- use `make_latest="true"` for stable publication and `make_latest="false"` for beta publication
- capture Latest before publication and verify exact release identity after immutable publication, before metadata App token minting
- update release contracts, rehearsal external-state semantics, ADR-0008, and active release documentation

## Invariants

- preserves `PublishDraft -> Assert-ImmutableRelease -> Latest policy guard -> metadata App token -> PromoteMetadata -> FinalVerify`
- beta publication must leave the captured stable Latest identity unchanged
- no runtime updater, second repository, bridge, PAT, permission expansion, or live release/tag/metadata mutation
- `v4.0.1` release notes remain historically accurate: initial publication used `make_latest="false"`; issue #187 remains the separate one-time promotion gate

## Verification

- `pwsh scripts/v4_release_pipeline.ps1 -State SelfTest`
- `pwsh scripts/test_v4_release_pipeline.ps1`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo test --manifest-path rust/Cargo.toml -p sky_xtask --locked`
- `cargo xtask check static`
- `git diff --check`

Closes #186