### PR TITLE
ci: build current candidate once and fan out qualification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Run CI classifier self-tests
         run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_ci_classify.ps1
 
+      - name: Run current-candidate contract self-tests
+        run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_ci_validate_candidate.ps1
+
       - name: Install pinned Rust toolchain
         run: rustup toolchain install 1.98.0 --profile minimal
 
@@ -167,7 +170,7 @@ jobs:
           bun-version: 1.4.0
 
       - name: Verify release contract test tools
-        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,bunx
+        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,bunx,signtool.exe
 
       - name: Install pinned desktop dependencies for release contract tests
         working-directory: desktop
@@ -189,6 +192,30 @@ jobs:
 
       - name: Run V4 updater private-key verifier secret-output regression
         run: pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_updater_private_key.ps1
+
+      - name: Prepare bounded ephemeral Authenticode test certificate
+        timeout-minutes: 2
+        shell: pwsh
+        run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
+
+      - name: Run Authenticode tamper regression on bounded system PE fixture
+        shell: pwsh
+        run: |
+          $source = Join-Path $env:SystemRoot "System32/notepad.exe"
+          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { throw "System PE fixture is unavailable: $source" }
+          pwsh scripts/test_v4_authenticode_integrity.ps1 -Source $source
+          if ($LASTEXITCODE -ne 0) { throw "Authenticode tamper regression failed with exit code $LASTEXITCODE" }
+
+      - name: Clean up Authenticode test certificate
+        if: always()
+        shell: pwsh
+        run: pwsh scripts/cleanup_v4_test_signing.ps1
+
+      - name: Run V4 production signing contract test
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_production_signing_contract.ps1
+          if ($LASTEXITCODE -ne 0) { throw "V4 production signing contract test failed with exit code $LASTEXITCODE" }
 
       - name: Report CI timing
         if: always()
@@ -402,9 +429,155 @@ jobs:
         if: always()
         run: pwsh scripts/ci_job_timing.ps1 -Mode finish -Job validate -CacheHit "${{ steps.rust-cache.outputs.cache-hit }}"
 
+  candidate:
+    name: Build current Tauri candidate
+    needs: changes
+    if: needs.changes.outputs.package_required == 'true' || needs.changes.outputs.updater_required == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      SCCACHE_GHA_VERSION: sky-ci-v1
+      SKY_CI_SOURCE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    steps:
+      - name: Start CI timing
+        run: |
+          "SKY_CI_JOB_STARTED_CANDIDATE=$([DateTimeOffset]::UtcNow.ToString('o'))" | Add-Content $env:GITHUB_ENV -Encoding ASCII
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          fetch-tags: false
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Rust — install pinned stable toolchain for current candidate
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: rustup toolchain install 1.98.0 --profile minimal --target x86_64-pc-windows-msvc --component rustfmt --component clippy
+
+      - name: Rust — verify current-candidate compiler
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          $version = (rustc --version)
+          if ($version -notmatch '^rustc 1\.98\.0\s') {
+            throw "Expected stable Rust 1.98.0 for current candidate, got: $version"
+          }
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: "v0.17.0"
+
+      - name: Rust cache
+        id: rust-cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: "rust -> target"
+          cache-targets: false
+          cache-on-failure: true
+          save-if: ${{ github.event_name != 'pull_request' }}
+
+      - name: Set up Bun for current candidate
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Fail fast on current-candidate dependencies
+        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,bunx,sccache
+
+      - name: Install pinned desktop dependencies
+        working-directory: desktop
+        run: bun install --frozen-lockfile
+
+      - name: Build pinned desktop frontend once
+        working-directory: desktop
+        run: bun run build
+
+      - name: Build exactly one current Tauri candidate
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          $keyPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate.key"
+          $publicKeyPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate.pub"
+          $configPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate-updater.json"
+          $bundleDir = Join-Path $env:GITHUB_WORKSPACE "rust/target/dist/bundle/nsis"
+          if (Test-Path -LiteralPath $bundleDir) {
+            Remove-Item -LiteralPath $bundleDir -Recurse -Force
+          }
+          try {
+            Push-Location desktop
+            try {
+              bun run tauri signer generate --ci --password "" --force -w $keyPath
+              if ($LASTEXITCODE -ne 0) { throw "Tauri updater signer generation failed with exit code $LASTEXITCODE" }
+              Copy-Item -LiteralPath "$keyPath.pub" -Destination $publicKeyPath -Force
+              $privateKey = (Get-Content -LiteralPath $keyPath -Raw).Trim()
+              $testPublicKey = (Get-Content -LiteralPath $publicKeyPath -Raw).Trim()
+              [ordered]@{
+                plugins = [ordered]@{
+                  updater = [ordered]@{
+                    pubkey = $testPublicKey
+                    endpoints = @("https://example.invalid/sky-auto-player/{{target}}/{{arch}}/{{current_version}}")
+                  }
+                }
+              } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $configPath -Encoding utf8
+              $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
+              $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
+              $env:SKY_AUTHENTICODE_MODE = "unsigned-zero-budget"
+              bun run tauri build --ci --config $configPath -- --profile dist
+              if ($LASTEXITCODE -ne 0) { throw "Current Tauri candidate build failed with exit code $LASTEXITCODE" }
+            } finally {
+              Pop-Location
+            }
+          } finally {
+            Remove-Item -LiteralPath $keyPath, "$keyPath.pub", $configPath -Force -ErrorAction SilentlyContinue
+            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
+            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD -ErrorAction SilentlyContinue
+            Remove-Item Env:SKY_AUTHENTICODE_MODE -ErrorAction SilentlyContinue
+          }
+          "SKY_CANDIDATE_BUNDLE=$bundleDir" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_PUBLIC_KEY=$publicKeyPath" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+
+      - name: Create exact current-candidate contract
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          $candidateRoot = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate"
+          pwsh scripts/ci_validate_candidate.ps1 `
+            -Mode Create `
+            -BundleDir $env:SKY_CANDIDATE_BUNDLE `
+            -PublicKeyPath $env:SKY_CANDIDATE_PUBLIC_KEY `
+            -OutputRoot $candidateRoot `
+            -SourceSha $env:SKY_CI_SOURCE_SHA
+          if ($LASTEXITCODE -ne 0) { throw "Current-candidate contract creation failed with exit code $LASTEXITCODE" }
+          $files = @(Get-ChildItem -LiteralPath $candidateRoot -File)
+          if ($files.Count -ne 4 -or $files.Name -contains "sky-auto-player-current-candidate.key") {
+            throw "Current-candidate artifact contains an unexpected file set"
+          }
+          "SKY_CANDIDATE_ROOT=$candidateRoot" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+
+      - name: Upload exact current-candidate contract
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sky-auto-player-current-candidate-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ runner.temp }}/sky-auto-player-current-candidate
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Report CI timing
+        if: always()
+        run: pwsh scripts/ci_job_timing.ps1 -Mode finish -Job candidate -CacheHit "${{ steps.rust-cache.outputs.cache-hit }}"
+
   updater_e2e:
     name: Updater fixture qualification
-    needs: [changes, static]
+    needs: [changes, static, candidate]
     if: needs.changes.outputs.updater_required == 'true'
     runs-on: windows-latest
     timeout-minutes: 90
@@ -426,6 +599,26 @@ jobs:
           fetch-tags: false
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download current candidate from this workflow run
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: sky-auto-player-current-candidate-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ runner.temp }}/sky-auto-player-current-candidate
+
+      - name: Validate and bind exact current candidate
+        run: |
+          $candidateRoot = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate"
+          pwsh scripts/ci_validate_candidate.ps1 `
+            -Mode Validate `
+            -CandidateRoot $candidateRoot `
+            -SourceSha "${{ github.event.pull_request.head.sha || github.sha }}"
+          if ($LASTEXITCODE -ne 0) { throw "Downloaded current-candidate contract validation failed with exit code $LASTEXITCODE" }
+          $metadata = Get-Content -LiteralPath (Join-Path $candidateRoot "candidate.json") -Raw | ConvertFrom-Json
+          "SKY_CANDIDATE_INSTALLER=$(Join-Path $candidateRoot $metadata.installer)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_SIGNATURE=$(Join-Path $candidateRoot $metadata.updater_signature)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_PUBLIC_KEY=$(Join-Path $candidateRoot $metadata.updater_public_key)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_VERSION=$($metadata.version)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
 
       - name: Rust — install pinned stable toolchain for updater fixture
         env:
@@ -486,7 +679,12 @@ jobs:
           # Packaged Tauri updater rotation: ci_tauri_update_e2e.ps1 sets SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS
           # separately for the bridge [old,new] and cutover [new] tauri-update-fixture builds.
           # Its generated configs alone enable dangerousInsecureTransportProtocol on loopback.
-          pwsh scripts/ci_tauri_update_e2e.ps1 -FixtureTargetDir $fixtureTarget
+          pwsh scripts/ci_tauri_update_e2e.ps1 `
+            -FixtureTargetDir $fixtureTarget `
+            -CandidateInstallerPath $env:SKY_CANDIDATE_INSTALLER `
+            -CandidateSignaturePath $env:SKY_CANDIDATE_SIGNATURE `
+            -CandidateVersion $env:SKY_CANDIDATE_VERSION `
+            -CandidatePublicKeyPath $env:SKY_CANDIDATE_PUBLIC_KEY
 
       - name: Clean up ephemeral Authenticode test certificate
         if: always()
@@ -502,15 +700,12 @@ jobs:
 
   packaged:
     name: Packaged v4 Tauri NSIS qualification
-    needs: [changes, static]
+    needs: [changes, static, candidate]
     if: needs.changes.outputs.package_required == 'true'
     runs-on: windows-latest
     timeout-minutes: 90
     permissions:
       contents: read
-      id-token: write
-      attestations: write
-      artifact-metadata: write
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
@@ -529,6 +724,37 @@ jobs:
           fetch-tags: false
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download current candidate from this workflow run
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: sky-auto-player-current-candidate-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ runner.temp }}/sky-auto-player-current-candidate
+
+      - name: Validate and stage exact current candidate
+        run: |
+          $candidateRoot = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate"
+          pwsh scripts/ci_validate_candidate.ps1 `
+            -Mode Validate `
+            -CandidateRoot $candidateRoot `
+            -SourceSha "${{ github.event.pull_request.head.sha || github.sha }}"
+          if ($LASTEXITCODE -ne 0) { throw "Downloaded current-candidate contract validation failed with exit code $LASTEXITCODE" }
+          $metadata = Get-Content -LiteralPath (Join-Path $candidateRoot "candidate.json") -Raw | ConvertFrom-Json
+          $bundleDir = Join-Path $env:GITHUB_WORKSPACE "rust/target/dist/bundle/nsis"
+          if (Test-Path -LiteralPath $bundleDir) {
+            Remove-Item -LiteralPath $bundleDir -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
+          $installer = Join-Path $candidateRoot $metadata.installer
+          $signature = Join-Path $candidateRoot $metadata.updater_signature
+          Copy-Item -LiteralPath $installer -Destination (Join-Path $bundleDir $metadata.installer) -Force
+          Copy-Item -LiteralPath $signature -Destination (Join-Path $bundleDir $metadata.updater_signature) -Force
+          "SKY_TAURI_BUNDLE=$bundleDir" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_ROOT=$candidateRoot" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_INSTALLER=$installer" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_SIGNATURE=$signature" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_PUBLIC_KEY=$(Join-Path $candidateRoot $metadata.updater_public_key)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_VERSION=$($metadata.version)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
 
       - name: Rust — install pinned stable toolchain for packaged build
         env:
@@ -561,104 +787,8 @@ jobs:
           # Main/manual runs remain the cache population path.
           save-if: ${{ github.event_name != 'pull_request' }}
 
-      - name: Set up Bun for production frontend build
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.4.0
-
-      - name: Fail fast on packaged build dependencies
-        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,bun,bunx,sccache,signtool.exe
-
-      - name: Resolve GitHub CLI for artifact attestation verification
-        run: |
-          $ghCommand = Get-Command gh.exe -CommandType Application -ErrorAction Stop
-          $ghPath = [IO.Path]::GetFullPath($ghCommand.Source)
-          if (-not (Test-Path -LiteralPath $ghPath -PathType Leaf)) {
-            throw "GitHub CLI executable is not a regular file: $ghPath"
-          }
-          "SKY_GH_PATH=$ghPath" | Add-Content $env:GITHUB_ENV -Encoding UTF8
-
-      - name: Install pinned desktop dependencies
-        working-directory: desktop
-        run: bun install --frozen-lockfile
-
-      - name: Build pinned desktop frontend
-        working-directory: desktop
-        run: bun run build
-
-      - name: Build and sign canonical Tauri NSIS artifact
-        env:
-          RUSTUP_TOOLCHAIN: 1.98.0
-        run: |
-          $keyPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-test.key"
-          $configPath = Join-Path $env:RUNNER_TEMP "sky-auto-player-v4-test-updater.json"
-          $preBuildCargoHash = (Get-FileHash -LiteralPath "desktop/src-tauri/Cargo.toml" -Algorithm SHA256).Hash
-          try {
-            Push-Location desktop
-            try {
-              bun run tauri signer generate --ci --password "" --force -w $keyPath
-              if ($LASTEXITCODE -ne 0) { throw "Tauri updater signer generation failed with exit code $LASTEXITCODE" }
-              $privateKey = (Get-Content -LiteralPath $keyPath -Raw).Trim()
-              $testPublicKey = (Get-Content -LiteralPath "$keyPath.pub" -Raw).Trim()
-              [ordered]@{
-                plugins = [ordered]@{
-                  updater = [ordered]@{
-                    pubkey = $testPublicKey
-                    endpoints = @("https://example.invalid/sky-auto-player/{{target}}/{{arch}}/{{current_version}}")
-                  }
-                }
-              } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $configPath -Encoding utf8
-              $env:TAURI_SIGNING_PRIVATE_KEY = $privateKey
-              $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD = ""
-              $env:SKY_AUTHENTICODE_MODE = "unsigned-zero-budget"
-              bun run tauri build --ci --config $configPath -- --profile dist
-              if ($LASTEXITCODE -ne 0) { throw "Tauri build failed with exit code $LASTEXITCODE" }
-            } finally {
-              Pop-Location
-            }
-            $bundleDir = Join-Path $env:GITHUB_WORKSPACE 'rust/target/dist/bundle/nsis'
-            "SKY_TAURI_BUNDLE=$bundleDir" | Add-Content $env:GITHUB_ENV -Encoding UTF8
-            $installers = @(Get-ChildItem -LiteralPath $bundleDir -Filter '*-setup.exe' -File)
-            if ($installers.Count -ne 1) {
-              throw "Expected exactly one freshly built Tauri NSIS installer, found $($installers.Count)"
-            }
-          } finally {
-            Remove-Item -LiteralPath $keyPath, "$keyPath.pub", $configPath -Force -ErrorAction SilentlyContinue
-            Remove-Item Env:TAURI_SIGNING_PRIVATE_KEY -ErrorAction SilentlyContinue
-            $postPackagingDirty = @(& git status --porcelain | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-            if ($postPackagingDirty.Count -gt 0) {
-              $postBuildCargoHash = (Get-FileHash -LiteralPath "desktop/src-tauri/Cargo.toml" -Algorithm SHA256).Hash
-              Write-Host "Pre-build Cargo.toml SHA256:  $preBuildCargoHash"
-              Write-Host "Post-build Cargo.toml SHA256: $postBuildCargoHash"
-              Write-Host "=== git status --porcelain ==="
-              & git status --porcelain
-              Write-Host "=== git diff --no-ext-diff -- desktop/src-tauri/Cargo.toml ==="
-              & git diff --no-ext-diff -- desktop/src-tauri/Cargo.toml
-              Write-Host "=== git diff --check -- desktop/src-tauri/Cargo.toml ==="
-              & git diff --check -- desktop/src-tauri/Cargo.toml
-              throw "Packaged build left working tree dirty: $($postPackagingDirty -join ', ')"
-            }
-          }
-
-      - name: Prepare bounded ephemeral Authenticode test certificate
-        timeout-minutes: 2
-        run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
-
-      - name: Run Authenticode tamper regression
-        env:
-          RUSTUP_TOOLCHAIN: 1.98.0
-        run: |
-          # CI self-signed credentials remain test-only; canonical package evidence is unsigned.
-          pwsh scripts/test_v4_authenticode_integrity.ps1 `
-            -Source rust/target/dist/sky_desktop_shell.exe
-          if ($LASTEXITCODE -ne 0) { throw "Authenticode tamper regression failed with exit code $LASTEXITCODE" }
-
-      - name: Run V4 production signing contract test
-        env:
-          RUSTUP_TOOLCHAIN: 1.98.0
-        run: |
-          pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_production_signing_contract.ps1
-          if ($LASTEXITCODE -ne 0) { throw "V4 production signing contract test failed with exit code $LASTEXITCODE" }
+      - name: Fail fast on package qualification dependencies
+        run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,sccache
 
       - name: Verify Tauri Authenticode signature
         env:
@@ -780,6 +910,8 @@ jobs:
             evidence_type = "tauri-nsis-qualified-release"
             qualified = $true
             qualification = "install-launch-uninstall"
+            source_sha = (Get-Content -LiteralPath (Join-Path $env:SKY_CANDIDATE_ROOT "candidate.json") -Raw | ConvertFrom-Json).source_sha
+            candidate_contract = "candidate.json"
             product_name = $summary.product_name
             identifier = $summary.identifier
             version = $summary.version
@@ -791,6 +923,7 @@ jobs:
             signature_size = $summary.signature_size
             installer_sha256 = $summary.installer_sha256
             updater_signature_sha256 = $summary.updater_signature_sha256
+            updater_public_key_sha256 = (Get-FileHash -LiteralPath $env:SKY_CANDIDATE_PUBLIC_KEY -Algorithm SHA256).Hash.ToLowerInvariant()
             authenticode_mode = "unsigned-zero-budget"
             authenticode_evidence = "TAURI_AUTHENTICODE_EVIDENCE.json"
             authenticode_evidence_sha256 = (Get-FileHash -LiteralPath rust/target/dist/TAURI_AUTHENTICODE_EVIDENCE.json -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -798,52 +931,6 @@ jobs:
             sbom_sha256 = (Get-FileHash -LiteralPath rust/target/dist/SBOM.spdx.json -Algorithm SHA256).Hash.ToLowerInvariant()
           }
           $evidence | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath rust/target/dist/V4_QUALIFICATION_EVIDENCE.json -Encoding utf8
-
-      - name: Clean up ephemeral Authenticode test certificate
-        if: always()
-        run: pwsh scripts/cleanup_v4_test_signing.ps1
-
-      - name: Attest exact Tauri NSIS artifact set
-        if: github.event_name != 'pull_request'
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-path: |
-            ${{ github.workspace }}/rust/target/dist/bundle/nsis/*.exe
-            ${{ github.workspace }}/rust/target/dist/bundle/nsis/*.sig
-
-      - name: Attest exact Tauri SPDX SBOM
-        if: github.event_name != 'pull_request'
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-path: ${{ github.workspace }}/rust/target/dist/bundle/nsis/*.exe
-          sbom-path: ${{ github.workspace }}/rust/target/dist/SBOM.spdx.json
-
-      - name: Verify exact GitHub artifact attestations
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:SKY_GH_PATH) -or
-              -not (Test-Path -LiteralPath $env:SKY_GH_PATH -PathType Leaf)) {
-            throw "GitHub CLI absolute path is unavailable for attestation verification"
-          }
-          if ([string]::IsNullOrWhiteSpace($env:GH_TOKEN)) {
-            throw "GH_TOKEN is unavailable for attestation verification"
-          }
-          $attestationHelp = (& $env:SKY_GH_PATH attestation verify --help 2>&1 | Out-String)
-          if ($attestationHelp -notmatch '--source-digest' -or
-              $attestationHelp -notmatch '--signer-workflow') {
-            throw "Installed GitHub CLI lacks the required exact-source attestation options"
-          }
-          $installer = Join-Path $env:SKY_TAURI_BUNDLE (Get-ChildItem -LiteralPath $env:SKY_TAURI_BUNDLE -Filter '*-setup.exe' -File).Name
-          $signature = "$installer.sig"
-          $signerWorkflow = "$env:GITHUB_REPOSITORY/.github/workflows/ci.yml"
-          & $env:SKY_GH_PATH attestation verify $installer -R $env:GITHUB_REPOSITORY --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
-          if ($LASTEXITCODE -ne 0) { throw "Installer attestation verification failed with exit code $LASTEXITCODE" }
-          & $env:SKY_GH_PATH attestation verify $signature -R $env:GITHUB_REPOSITORY --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
-          if ($LASTEXITCODE -ne 0) { throw "Updater signature attestation verification failed with exit code $LASTEXITCODE" }
-          & $env:SKY_GH_PATH attestation verify $installer -R $env:GITHUB_REPOSITORY --predicate-type https://spdx.dev/Document/v2.3 --source-digest $env:GITHUB_SHA --signer-workflow $signerWorkflow
-          if ($LASTEXITCODE -ne 0) { throw "SBOM attestation verification failed with exit code $LASTEXITCODE" }
 
       - name: Upload exact Tauri NSIS release candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -890,7 +977,7 @@ jobs:
   status:
     name: Sky Auto Player — required CI gate
     if: always()
-    needs: [changes, static, release_contract, supply_chain, validate, updater_e2e, packaged, site]
+    needs: [changes, static, release_contract, supply_chain, validate, candidate, updater_e2e, packaged, site]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -913,10 +1000,12 @@ jobs:
           SUPPLY_CHAIN_REQUIRED: ${{ needs.changes.outputs.supply_chain_required }}
           SITE_REQUIRED: ${{ needs.changes.outputs.site_required }}
           STATIC_REQUIRED: ${{ needs.changes.outputs.static_required }}
+          CANDIDATE_REQUIRED: ${{ needs.changes.outputs.package_required == 'true' || needs.changes.outputs.updater_required == 'true' }}
           STATIC_RESULT: ${{ needs.static.result }}
           RELEASE_CONTRACT_RESULT: ${{ needs.release_contract.result }}
           SUPPLY_CHAIN_RESULT: ${{ needs.supply_chain.result }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
+          CANDIDATE_RESULT: ${{ needs.candidate.result }}
           UPDATER_E2E_RESULT: ${{ needs.updater_e2e.result }}
           PACKAGED_RESULT: ${{ needs.packaged.result }}
           SITE_RESULT: ${{ needs.site.result }}
@@ -939,6 +1028,7 @@ jobs:
             [[ "$SUPPLY_CHAIN_RESULT" == "skipped" ]]
           fi
           if [[ "$RUST_REQUIRED" == "true" || "$DESKTOP_REQUIRED" == "true" ]]; then [[ "$VALIDATE_RESULT" == "success" ]]; else [[ "$VALIDATE_RESULT" == "skipped" ]]; fi
+          if [[ "$CANDIDATE_REQUIRED" == "true" ]]; then [[ "$CANDIDATE_RESULT" == "success" ]]; else [[ "$CANDIDATE_RESULT" == "skipped" ]]; fi
           if [[ "$UPDATER_REQUIRED" == "true" ]]; then [[ "$UPDATER_E2E_RESULT" == "success" ]]; else [[ "$UPDATER_E2E_RESULT" == "skipped" ]]; fi
           if [[ "$PACKAGE_REQUIRED" == "true" ]]; then
             [[ "$PACKAGED_RESULT" == "success" ]]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,13 +198,55 @@ jobs:
         shell: pwsh
         run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
 
-      - name: Run Authenticode tamper regression on bounded system PE fixture
+      - name: Build bounded unsigned Authenticode PE fixture
+        env:
+          RUSTUP_TOOLCHAIN: 1.98.0
+        run: |
+          $fixtureRoot = Join-Path $env:RUNNER_TEMP "sky-v4-authenticode-unsigned-fixture"
+          if (Test-Path -LiteralPath $fixtureRoot) {
+            Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $fixtureRoot -Force | Out-Null
+          $source = Join-Path $fixtureRoot "main.rs"
+          $binary = Join-Path $fixtureRoot "sky-v4-authenticode-unsigned-fixture.exe"
+          Set-Content -LiteralPath $source -Value "fn main() {}" -Encoding utf8
+          rustc --edition 2021 --target x86_64-pc-windows-msvc --crate-name sky_v4_authenticode_unsigned -o $binary $source
+          if ($LASTEXITCODE -ne 0) { throw "Pinned Rust compiler failed to create the Authenticode fixture (exit $LASTEXITCODE)" }
+          if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) { throw "Pinned Rust compiler did not create the expected PE fixture: $binary" }
+          $signature = Get-AuthenticodeSignature -LiteralPath $binary
+          if ([string]$signature.Status -ne "NotSigned") {
+            throw "Controlled Authenticode fixture must start unsigned; observed status: $($signature.Status)"
+          }
+          "SKY_AUTHENTICODE_FIXTURE=$binary" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+
+      - name: Run Authenticode tamper regression on controlled unsigned PE fixture
         shell: pwsh
         run: |
-          $source = Join-Path $env:SystemRoot "System32/notepad.exe"
-          if (-not (Test-Path -LiteralPath $source -PathType Leaf)) { throw "System PE fixture is unavailable: $source" }
-          pwsh scripts/test_v4_authenticode_integrity.ps1 -Source $source
+          if ([string]::IsNullOrWhiteSpace($env:SKY_AUTHENTICODE_FIXTURE) -or
+              -not (Test-Path -LiteralPath $env:SKY_AUTHENTICODE_FIXTURE -PathType Leaf)) {
+            throw "Controlled unsigned Authenticode fixture is unavailable"
+          }
+          pwsh scripts/test_v4_authenticode_integrity.ps1 -Source $env:SKY_AUTHENTICODE_FIXTURE
           if ($LASTEXITCODE -ne 0) { throw "Authenticode tamper regression failed with exit code $LASTEXITCODE" }
+
+      - name: Clean up controlled Authenticode PE fixture
+        if: always()
+        shell: pwsh
+        run: |
+          $fixture = ([string]$env:SKY_AUTHENTICODE_FIXTURE).Trim()
+          $runnerTemp = [IO.Path]::GetFullPath(([string]$env:RUNNER_TEMP).Trim()).TrimEnd('\', '/')
+          if (-not [string]::IsNullOrWhiteSpace($fixture)) {
+            $resolved = [IO.Path]::GetFullPath($fixture)
+            $prefix = $runnerTemp + [IO.Path]::DirectorySeparatorChar
+            if (-not $resolved.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase) -or
+                [IO.Path]::GetFileName($resolved) -cne 'sky-v4-authenticode-unsigned-fixture.exe') {
+              throw "Refusing to remove an Authenticode fixture outside RUNNER_TEMP: $resolved"
+            }
+            $fixtureRoot = Split-Path -Parent $resolved
+            if (Test-Path -LiteralPath $fixtureRoot) {
+              Remove-Item -LiteralPath $fixtureRoot -Recurse -Force
+            }
+          }
 
       - name: Clean up Authenticode test certificate
         if: always()
@@ -731,7 +773,7 @@ jobs:
           name: sky-auto-player-current-candidate-${{ github.event.pull_request.head.sha || github.sha }}
           path: ${{ runner.temp }}/sky-auto-player-current-candidate
 
-      - name: Validate and stage exact current candidate
+      - name: Validate exact current candidate contract
         run: |
           $candidateRoot = Join-Path $env:RUNNER_TEMP "sky-auto-player-current-candidate"
           pwsh scripts/ci_validate_candidate.ps1 `
@@ -740,21 +782,15 @@ jobs:
             -SourceSha "${{ github.event.pull_request.head.sha || github.sha }}"
           if ($LASTEXITCODE -ne 0) { throw "Downloaded current-candidate contract validation failed with exit code $LASTEXITCODE" }
           $metadata = Get-Content -LiteralPath (Join-Path $candidateRoot "candidate.json") -Raw | ConvertFrom-Json
-          $bundleDir = Join-Path $env:GITHUB_WORKSPACE "rust/target/dist/bundle/nsis"
-          if (Test-Path -LiteralPath $bundleDir) {
-            Remove-Item -LiteralPath $bundleDir -Recurse -Force
-          }
-          New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
           $installer = Join-Path $candidateRoot $metadata.installer
           $signature = Join-Path $candidateRoot $metadata.updater_signature
-          Copy-Item -LiteralPath $installer -Destination (Join-Path $bundleDir $metadata.installer) -Force
-          Copy-Item -LiteralPath $signature -Destination (Join-Path $bundleDir $metadata.updater_signature) -Force
-          "SKY_TAURI_BUNDLE=$bundleDir" | Add-Content $env:GITHUB_ENV -Encoding UTF8
           "SKY_CANDIDATE_ROOT=$candidateRoot" | Add-Content $env:GITHUB_ENV -Encoding UTF8
           "SKY_CANDIDATE_INSTALLER=$installer" | Add-Content $env:GITHUB_ENV -Encoding UTF8
           "SKY_CANDIDATE_SIGNATURE=$signature" | Add-Content $env:GITHUB_ENV -Encoding UTF8
           "SKY_CANDIDATE_PUBLIC_KEY=$(Join-Path $candidateRoot $metadata.updater_public_key)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
           "SKY_CANDIDATE_VERSION=$($metadata.version)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_INSTALLER_SHA256=$($metadata.installer_sha256)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
+          "SKY_CANDIDATE_SIGNATURE_SHA256=$($metadata.updater_signature_sha256)" | Add-Content $env:GITHUB_ENV -Encoding UTF8
 
       - name: Rust — install pinned stable toolchain for packaged build
         env:
@@ -789,6 +825,29 @@ jobs:
 
       - name: Fail fast on package qualification dependencies
         run: pwsh scripts/ci_require_windows_tools.ps1 -Tool cargo,rustc,rustup,git,sccache
+
+      - name: Stage and re-hash exact current candidate after Rust cache restore
+        run: |
+          $bundleDir = Join-Path $env:GITHUB_WORKSPACE "rust/target/dist/bundle/nsis"
+          if (Test-Path -LiteralPath $bundleDir) {
+            Remove-Item -LiteralPath $bundleDir -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
+          $metadata = Get-Content -LiteralPath (Join-Path $env:SKY_CANDIDATE_ROOT "candidate.json") -Raw | ConvertFrom-Json
+          $stagedInstaller = Join-Path $bundleDir $metadata.installer
+          $stagedSignature = Join-Path $bundleDir $metadata.updater_signature
+          Copy-Item -LiteralPath $env:SKY_CANDIDATE_INSTALLER -Destination $stagedInstaller -Force
+          Copy-Item -LiteralPath $env:SKY_CANDIDATE_SIGNATURE -Destination $stagedSignature -Force
+          $installerSha = (Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256).Hash.ToLowerInvariant()
+          $signatureSha = (Get-FileHash -LiteralPath $stagedSignature -Algorithm SHA256).Hash.ToLowerInvariant()
+          $publicKeySha = (Get-FileHash -LiteralPath $env:SKY_CANDIDATE_PUBLIC_KEY -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($installerSha -cne [string]$metadata.installer_sha256) { throw "Staged installer hash changed: expected=$($metadata.installer_sha256) observed=$installerSha" }
+          if ($signatureSha -cne [string]$metadata.updater_signature_sha256) { throw "Staged updater signature hash changed: expected=$($metadata.updater_signature_sha256) observed=$signatureSha" }
+          if ($publicKeySha -cne [string]$metadata.updater_public_key_sha256) { throw "Downloaded updater public-key hash changed: expected=$($metadata.updater_public_key_sha256) observed=$publicKeySha" }
+          if ($installerSha -cne $env:SKY_CANDIDATE_INSTALLER_SHA256 -or $signatureSha -cne $env:SKY_CANDIDATE_SIGNATURE_SHA256) {
+            throw "Staged candidate hashes do not match the validated candidate contract"
+          }
+          "SKY_TAURI_BUNDLE=$bundleDir" | Add-Content $env:GITHUB_ENV -Encoding UTF8
 
       - name: Verify Tauri Authenticode signature
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,7 @@ jobs:
         run: pwsh scripts/setup_v4_test_signing.ps1 -EnvFile $env:GITHUB_ENV -TimeoutSeconds 30
 
       - name: Build bounded unsigned Authenticode PE fixture
+        shell: pwsh
         env:
           RUSTUP_TOOLCHAIN: 1.98.0
         run: |

--- a/desktop/src-tauri/src/native_update.rs
+++ b/desktop/src-tauri/src/native_update.rs
@@ -458,8 +458,7 @@ fn fixture_public_keys(keys: &'static str, new_only: bool) -> Vec<Option<&'stati
     if new_only {
         return keys
             .split('|')
-            .filter(|key| !key.is_empty())
-            .next_back()
+            .rfind(|key| !key.is_empty())
             .map(|key| vec![Some(key)])
             .unwrap_or_else(|| vec![None]);
     }

--- a/desktop/src-tauri/src/native_update.rs
+++ b/desktop/src-tauri/src/native_update.rs
@@ -36,6 +36,8 @@ const V4_TAURI_UPDATER_PUBLIC_KEYS: &[&str] = &[V4_TAURI_UPDATER_PUBLIC_KEY];
 #[cfg(feature = "tauri-update-fixture")]
 const FIXTURE_TAURI_UPDATER_PUBLIC_KEYS: Option<&str> =
     option_env!("SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS");
+#[cfg(feature = "tauri-update-fixture")]
+const FIXTURE_NEW_ONLY_ARG: &str = "--selftest-update-fixture-new-only";
 const FIXTURE_TAURI_UPDATER_PORT: &str = match option_env!("SKY_TAURI_UPDATE_FIXTURE_PORT") {
     Some(port) => port,
     None => "invalid-fixture-port",
@@ -433,7 +435,7 @@ fn updater_public_keys() -> Vec<Option<&'static str>> {
     #[cfg(feature = "tauri-update-fixture")]
     {
         FIXTURE_TAURI_UPDATER_PUBLIC_KEYS
-            .map(|keys| keys.split('|').map(Some).collect())
+            .map(|keys| fixture_public_keys(keys, fixture_new_only_requested()))
             .unwrap_or_else(|| vec![None])
     }
     #[cfg(not(feature = "tauri-update-fixture"))]
@@ -444,6 +446,24 @@ fn updater_public_keys() -> Vec<Option<&'static str>> {
             .map(Some)
             .collect()
     }
+}
+
+#[cfg(feature = "tauri-update-fixture")]
+fn fixture_new_only_requested() -> bool {
+    std::env::args().any(|arg| arg == FIXTURE_NEW_ONLY_ARG)
+}
+
+#[cfg(feature = "tauri-update-fixture")]
+fn fixture_public_keys(keys: &'static str, new_only: bool) -> Vec<Option<&'static str>> {
+    if new_only {
+        return keys
+            .split('|')
+            .filter(|key| !key.is_empty())
+            .next_back()
+            .map(|key| vec![Some(key)])
+            .unwrap_or_else(|| vec![None]);
+    }
+    keys.split('|').map(Some).collect()
 }
 
 /// Try each `Update`'s own Tauri verification context until the downloaded
@@ -649,6 +669,19 @@ mod tests {
     use crate::app_state::ActivityReservationError;
     #[cfg(not(feature = "tauri-update-fixture"))]
     use crate::ui_events::UpdateChannel;
+
+    #[cfg(feature = "tauri-update-fixture")]
+    #[test]
+    fn fixture_new_only_mode_selects_only_the_last_compiled_root() {
+        assert_eq!(
+            super::fixture_public_keys("old-root|new-root", true),
+            vec![Some("new-root")]
+        );
+        assert_eq!(
+            super::fixture_public_keys("old-root|new-root", false),
+            vec![Some("old-root"), Some("new-root")]
+        );
+    }
 
     #[cfg(not(feature = "tauri-update-fixture"))]
     #[test]

--- a/docs/migration/ci-build-once-qualify-many-work-order.md
+++ b/docs/migration/ci-build-once-qualify-many-work-order.md
@@ -1,0 +1,270 @@
+# CI Build-Once / Qualify-Many — Codex Work Order
+
+## Goal
+
+Refactor the ordinary CI data plane so package qualification and updater qualification consume the same exact current-candidate bytes instead of independently building the current candidate.
+
+This is PR2 after the merged control-plane refactor. Keep the four-workflow architecture and the existing classifier taxonomy unchanged unless a narrowly required contract update is needed for this data-plane change.
+
+Core invariant:
+
+`ONE SOURCE SHA -> ONE CURRENT CANDIDATE BUILD -> many tests consume the same exact bytes -> ONE QUALIFIED BYTE SET`
+
+Production release/rehearsal remain separate and continue to own their production/rehearsal attestations and release authority.
+
+## Scope boundary
+
+This PR is about current-candidate artifact identity and fan-out only.
+
+Do not implement PR3 latency work:
+
+- do not move browser/frontend validation from Windows to Ubuntu
+- do not split the current validate job into new runner topology
+- do not perform broad cache redesign
+- do not add merge queue
+- do not weaken the Rust `profile.dist`
+- do not introduce a reusable release workflow abstraction
+- do not redesign the path classifier or its risk matrix
+- do not prebuild the updater bridge unless it is strictly required to preserve the existing updater contract; the bridge may continue to build once inside updater qualification
+
+Keep the required check name exactly:
+
+`Sky Auto Player — required CI gate`
+
+## Current problem
+
+Today the package lane builds the canonical current Tauri candidate itself, while the updater lane invokes the updater fixture without a provided current candidate and therefore builds a separate current candidate during updater qualification.
+
+The updater scripts already expose the required provided-candidate interface:
+
+- `CandidateInstallerPath`
+- `CandidateSignaturePath`
+- `CandidateVersion`
+- `CandidatePublicKeyPath`
+
+Use that interface rather than designing a parallel updater harness.
+
+## Required job topology
+
+Add one ordinary-CI current-candidate producer job in `.github/workflows/ci.yml`.
+
+Recommended job identity: `candidate` / `Build current Tauri candidate`.
+
+Run it when:
+
+`package_required == true || updater_required == true`
+
+The candidate producer must:
+
+1. check out the exact PR head / main SHA already selected by CI;
+2. install the pinned Rust/Bun/tooling needed to build the current Tauri candidate;
+3. build the desktop frontend once;
+4. generate one bounded ephemeral Tauri updater signing keypair for this CI candidate;
+5. build the current Tauri NSIS candidate exactly once with `--profile dist` and the existing unsigned-zero-budget Authenticode policy;
+6. verify that exactly one current installer and exactly one matching Tauri updater signature exist;
+7. compute and record exact SHA-256 digests;
+8. upload one workflow artifact containing the current candidate contract described below;
+9. delete the private updater test key before artifact upload / job completion and never include it in outputs, summaries, artifacts, or logs.
+
+Do not perform install/uninstall qualification or updater E2E in the producer. It is a producer, not another qualification lane.
+
+## Candidate artifact contract
+
+Upload one artifact tied to the exact source SHA, for example:
+
+`sky-auto-player-current-candidate-${source_sha}`
+
+Its extracted payload must contain exactly the current-candidate inputs needed by downstream qualification:
+
+- the single NSIS installer
+- the matching official Tauri updater `.sig`
+- the corresponding test updater public key only
+- `candidate.json`
+
+The private updater key is forbidden from the artifact.
+
+`candidate.json` must be small and deterministic enough for downstream validation. At minimum record:
+
+- schema version
+- exact `source_sha`
+- canonical application `version`
+- installer filename
+- installer SHA-256
+- updater-signature filename
+- updater-signature SHA-256
+- updater-public-key filename
+- updater-public-key SHA-256
+
+Use repository-relative/artifact-relative filenames, not runner-local absolute paths.
+
+Downstream jobs must re-hash all referenced files after download and fail closed on any filename, SHA, version, source-SHA, multiplicity, or path mismatch.
+
+Do not trust artifact names alone as identity.
+
+## Package qualification consumer
+
+Change the existing `packaged` lane from producer+consumer to consumer only.
+
+It must depend on the candidate job and download the exact artifact produced by that same workflow run.
+
+After download it must:
+
+- validate `candidate.json` against the current CI source SHA and source version;
+- recompute installer/signature/public-key hashes before using the files;
+- use the downloaded installer and signature as the only current candidate under package qualification;
+- preserve the existing package-specific checks that actually validate the candidate bytes, including unsigned-zero-budget Authenticode verification, SBOM generation/verification as applicable to the exact downloaded installer, exact-bundle identity checks, built-in catalog checks, current-user install/launch/uninstall, installed-tree verification, and qualification evidence;
+- ensure qualification evidence refers to the downloaded candidate hashes, not to a newly built artifact.
+
+The package job must not run `tauri build` for the current candidate.
+
+If existing xtask commands assume `rust/target/dist/bundle/nsis`, stage/copy the downloaded exact bytes into a bounded expected directory without modifying the bytes, or minimally extend the command to accept the downloaded location. Prefer the smaller change that preserves existing verification semantics.
+
+## Updater qualification consumer
+
+Change `updater_e2e` to depend on the candidate producer and download the exact same artifact from the same workflow run.
+
+Validate `candidate.json` and re-hash the exact files before updater testing.
+
+Invoke the existing updater harness with the provided-candidate contract:
+
+- `-CandidateInstallerPath <downloaded exact installer>`
+- `-CandidateSignaturePath <downloaded exact signature>`
+- `-CandidateVersion <candidate.json version>`
+- `-CandidatePublicKeyPath <downloaded public key>`
+
+The updater lane must not rebuild the current candidate.
+
+The previous-version bridge may still be built once inside updater qualification. Do not broaden this PR into bridge artifact caching/prebuild work.
+
+## Preserve old-root rejection without rebuilding current candidate
+
+Keep the updater key-rotation safety property.
+
+For the old-root rejection branch:
+
+- use the exact downloaded current-candidate installer bytes;
+- copy those bytes to a disposable path if needed for fixture isolation;
+- sign that copy with the fixture old updater root to create an old-root signature;
+- serve a synthetic higher-SemVer manifest that references those same candidate bytes with the old-root signature;
+- exercise the real updater download/verification path with the new-only client and require rejection;
+- never rebuild a second "current" candidate solely for this negative test.
+
+The byte identity of the installer used for new-root acceptance and old-root rejection must be demonstrably the same before signing metadata/signature differences are applied.
+
+Preserve existing user-data/built-in-catalog preservation checks and loopback HTTP evidence.
+
+## Authenticode/signing contract placement
+
+Ordinary package qualification should focus on the exact downloaded candidate.
+
+Move contract-only Authenticode regression/signing tests out of the package smoke critical path and into the existing Windows release/signing contract lane where practical:
+
+- `scripts/test_v4_authenticode_integrity.ps1`
+- `scripts/test_v4_production_signing_contract.ps1`
+
+These tests must not require building another application installer. A bounded disposable PE fixture/system PE copy is acceptable for the Authenticode integrity contract.
+
+Keep candidate-specific unsigned-zero-budget verification in package qualification.
+
+Do not weaken production signing fail-closed behavior.
+
+## Ordinary CI attestations
+
+Remove ordinary-CI GitHub artifact attestation creation/verification from the package lane after the build-once artifact flow is established.
+
+Specifically, ordinary CI does not need to create provenance attestations for every package-sensitive main/manual run merely to pass package smoke.
+
+Preserve:
+
+- exact SHA-256 identity in the candidate contract and qualification evidence
+- workflow-artifact transfer within the same CI run
+- production release attestations
+- controlled rehearsal attestations
+- production SBOM/provenance/release security invariants
+
+After removing ordinary CI attestations, remove now-unneeded `id-token: write` / `attestations: write` permissions from ordinary CI jobs. Keep only permissions actually required by their remaining actions.
+
+## Artifact and trust rules
+
+- Use the artifact from the current workflow run only; do not search previous runs by name.
+- Pin any new GitHub Action by full commit SHA, consistent with repository policy.
+- The candidate artifact is transport, not authority. Downstream consumers must validate source SHA, version, names and hashes from `candidate.json`.
+- No private updater/signing key may cross a job boundary.
+- Do not persist runner-local absolute paths in candidate metadata.
+- Do not mutate candidate installer bytes between producer upload and consumer qualification.
+
+## Required CI aggregate behavior
+
+Update `Sky Auto Player — required CI gate` dependencies/expected result logic for the new candidate job.
+
+Expected semantics:
+
+- if neither package nor updater is required, candidate is skipped;
+- if package or updater is required, candidate must succeed;
+- package and updater consumers may run in parallel after candidate succeeds;
+- package-only diffs build one candidate and run package qualification only;
+- updater-only diffs build one candidate and run updater qualification only;
+- package+updater diffs build one candidate and fan the same bytes to both consumers.
+
+Do not create another required branch-protection status.
+
+## Contract/self-test updates
+
+Update the existing repository static contracts in `rust/xtask/src/checks.rs` and PowerShell release/CI contract tests so they enforce the new architecture rather than just matching renamed steps.
+
+At minimum add fail-closed contract coverage that proves:
+
+- candidate job is required for `package || updater`;
+- both package and updater jobs depend on candidate;
+- package job does not contain the current-candidate `tauri build`;
+- updater job passes all four provided-candidate parameters;
+- candidate artifact metadata includes exact source/version/hash identity;
+- candidate private key is not uploaded;
+- ordinary CI attestation steps/permissions are gone;
+- production/rehearsal attestation markers remain present;
+- aggregate required gate accounts for candidate success/skipped state.
+
+Where practical, make candidate metadata validation a small reusable script with direct self-tests rather than duplicating fragile inline parsing in multiple jobs. Do not create a framework; one focused PowerShell helper plus tests is enough if needed.
+
+## Acceptance cases
+
+The implementation is accepted only if all of these hold:
+
+1. A package+updater-sensitive PR builds the current candidate exactly once.
+2. Both downstream lanes download the same current-run artifact and verify the same installer SHA-256.
+3. Package qualification performs no second current `tauri build`.
+4. Updater qualification performs no second current `tauri build`.
+5. Updater bridge construction remains bounded to the updater lane and does not become another current-candidate producer.
+6. New-root updater acceptance uses the exact candidate artifact.
+7. Old-root rejection uses the same installer bytes and rejects the old-root signature through the real updater download/verification path.
+8. Candidate artifact contains no private key or secret signing material.
+9. Package smoke still covers install/launch/uninstall and candidate-specific Authenticode/bundle integrity.
+10. Authenticode/signing contract tests remain covered outside the package critical path.
+11. Ordinary CI attestation creation/verification is removed; production/rehearsal attestations are unchanged.
+12. Required gate name remains exactly `Sky Auto Player — required CI gate`.
+13. Existing classifier taxonomy and four-workflow control plane remain unchanged.
+14. No PR3 runner/cache/latency redesign is introduced.
+15. Full CI is green on this PR, including package and updater lanes consuming the shared candidate.
+
+## Validation expectations
+
+Because this PR modifies `.github/workflows/ci.yml` and CI contracts, it should classify itself as full validation.
+
+Before merge, require green evidence for:
+
+- classifier/static contracts
+- Rust/native validation
+- desktop/browser validation
+- supply chain
+- release/signing contract lane including moved Authenticode contracts
+- current-candidate producer
+- package consumer
+- updater consumer including old-root rejection
+- site validation
+- aggregate required gate
+
+During review, inspect the workflow logs/artifacts to prove one current build and matching SHA-256 identity across both consumers; do not accept job names alone as evidence.
+
+## Follow-up after this PR
+
+Only after this data-plane PR is green and merged should PR3 optimize critical-path latency: move frontend/browser coverage to Ubuntu, split native/frontend validation where measured, benchmark caches/tool setup, and consider prebuilding the updater bridge only if measurements justify it.

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -453,7 +453,7 @@ fn release_metadata_contract(root: &Path) -> Result<()> {
         "V4_QUALIFICATION_EVIDENCE.json",
         "RELEASE_REQUIRED",
         "SUPPLY_CHAIN_REQUIRED",
-        "needs: [changes, static, release_contract, supply_chain, validate, updater_e2e, packaged, site]",
+        "needs: [changes, static, release_contract, supply_chain, validate, candidate, updater_e2e, packaged, site]",
     ] {
         if !ci.contains(marker) {
             return Err(
@@ -1525,6 +1525,160 @@ fn v4_release_pipeline_contract(root: &Path) -> Result<()> {
 }
 
 fn packaged_ci_contract_source(source: &str) -> Result<()> {
+    if source.replace("\r\n", "\n").contains("\n  candidate:\n") {
+        return packaged_ci_build_once_contract_source(source);
+    }
+    packaged_ci_contract_source_legacy(source)
+}
+
+fn packaged_ci_build_once_contract_source(source: &str) -> Result<()> {
+    let normalized = source.replace("\r\n", "\n");
+    if normalized.matches("actions/attest@").count() != 0
+        || normalized.contains("id-token: write")
+        || normalized.contains("attestations: write")
+        || normalized.contains("artifact-metadata: write")
+    {
+        return Err("ordinary CI must not create or verify GitHub attestations or request attestation permissions".into());
+    }
+
+    let candidate_start = normalized
+        .find("  candidate:\n")
+        .ok_or("CI workflow is missing the current-candidate producer job")?;
+    let candidate_end = normalized[candidate_start..]
+        .find("\n  updater_e2e:\n")
+        .map(|offset| candidate_start + offset)
+        .ok_or("current-candidate producer must precede the updater consumer")?;
+    let candidate = &normalized[candidate_start..candidate_end];
+    for marker in [
+        "name: Build current Tauri candidate",
+        "needs: changes",
+        "if: needs.changes.outputs.package_required == 'true' || needs.changes.outputs.updater_required == 'true'",
+        "bun run build",
+        "bun run tauri build --ci --config",
+        "--profile dist",
+        "scripts/ci_validate_candidate.ps1",
+        "-Mode Create",
+        "-BundleDir",
+        "-PublicKeyPath",
+        "-OutputRoot",
+        "-SourceSha",
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        "path: ${{ runner.temp }}/sky-auto-player-current-candidate",
+    ] {
+        if !candidate.contains(marker) {
+            return Err(format!(
+                "current-candidate producer is missing its required marker: {marker}"
+            )
+            .into());
+        }
+    }
+    let cleanup_position = candidate
+        .find("Remove-Item -LiteralPath $keyPath, \"$keyPath.pub\", $configPath")
+        .ok_or("current-candidate producer must delete its private key and build config")?;
+    let upload_position = candidate
+        .find("actions/upload-artifact@")
+        .ok_or("current-candidate producer must upload one workflow artifact")?;
+    if cleanup_position >= upload_position {
+        return Err("current-candidate private key cleanup must precede artifact upload".into());
+    }
+
+    let updater_start = candidate_end;
+    let updater_end = normalized[updater_start..]
+        .find("\n  packaged:\n")
+        .map(|offset| updater_start + offset)
+        .ok_or("CI workflow updater consumer must precede the packaged consumer")?;
+    let updater = &normalized[updater_start..updater_end];
+    for marker in [
+        "name: Updater fixture qualification",
+        "needs: [changes, static, candidate]",
+        "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+        "scripts/ci_validate_candidate.ps1",
+        "-Mode Validate",
+        "-CandidateInstallerPath",
+        "-CandidateSignaturePath",
+        "-CandidateVersion",
+        "-CandidatePublicKeyPath",
+        "scripts/ci_tauri_update_e2e.ps1",
+    ] {
+        if !updater.contains(marker) {
+            return Err(
+                format!("updater consumer is missing its required marker: {marker}").into(),
+            );
+        }
+    }
+    if updater.contains("bun run tauri build") {
+        return Err("updater consumer must not build a current candidate".into());
+    }
+
+    let package_start = updater_end;
+    let package_end = normalized[package_start..]
+        .find("\n  site:\n")
+        .map(|offset| package_start + offset)
+        .ok_or("CI workflow packaged consumer must precede the site job")?;
+    let packaged = &normalized[package_start..package_end];
+    for marker in [
+        "name: Packaged v4 Tauri NSIS qualification",
+        "needs: [changes, static, candidate]",
+        "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+        "scripts/ci_validate_candidate.ps1",
+        "-Mode Validate",
+        "cargo xtask verify-tauri-bundle",
+        "cargo xtask sbom generate",
+        "cargo xtask sbom verify",
+        "-Mode unsigned-zero-budget",
+        "current-user install, launch, and uninstall",
+        "cargo xtask builtin-catalog verify-installed",
+        "installer_sha256",
+        "updater_signature_sha256",
+        "updater_public_key_sha256",
+        "actions/upload-artifact@",
+    ] {
+        if !packaged.contains(marker) {
+            return Err(
+                format!("packaged consumer is missing its required marker: {marker}").into(),
+            );
+        }
+    }
+    for forbidden in [
+        "bun run tauri build",
+        "TAURI_SIGNING_PRIVATE_KEY",
+        "scripts/test_v4_authenticode_integrity.ps1",
+        "scripts/test_v4_production_signing_contract.ps1",
+        "actions/attest@",
+        "id-token: write",
+        "attestations: write",
+        "name: Resolve GitHub CLI for artifact attestation verification",
+    ] {
+        if packaged.contains(forbidden) {
+            return Err(format!(
+                "packaged consumer contains forbidden producer/attestation work: {forbidden}"
+            )
+            .into());
+        }
+    }
+
+    for marker in [
+        "Run Authenticode tamper regression on bounded system PE fixture",
+        "scripts/test_v4_authenticode_integrity.ps1",
+        "scripts/test_v4_production_signing_contract.ps1",
+        "scripts/setup_v4_test_signing.ps1",
+        "scripts/cleanup_v4_test_signing.ps1",
+        "needs: [changes, static, release_contract, supply_chain, validate, candidate, updater_e2e, packaged, site]",
+        "CANDIDATE_REQUIRED",
+        "CANDIDATE_RESULT",
+        "name: Sky Auto Player — required CI gate",
+    ] {
+        if !normalized.contains(marker) {
+            return Err(format!(
+                "CI build-once control-plane contract is missing its marker: {marker}"
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+fn packaged_ci_contract_source_legacy(source: &str) -> Result<()> {
     let normalized = source.replace("\r\n", "\n");
     let package_needs = "needs: [changes, static]";
     let fixture_start = normalized
@@ -1748,6 +1902,29 @@ fn packaged_ci_contract(root: &Path) -> Result<()> {
     let path = root.join(".github/workflows/ci.yml");
     packaged_ci_contract_source(&fs::read_to_string(&path)?)
         .map_err(|error| format!("{}: {error}", path.display()))?;
+    let validator = fs::read_to_string(root.join("scripts/ci_validate_candidate.ps1"))?;
+    for marker in [
+        "schema_version",
+        "source_sha",
+        "installer_sha256",
+        "updater_signature_sha256",
+        "updater_public_key_sha256",
+        "Get-FileHash",
+        "updater-public-key.pub",
+        "PRIVATE KEY",
+        "candidate artifact must contain exactly four files",
+    ] {
+        if !validator.contains(marker) {
+            return Err(format!(
+                "current-candidate validator is missing its fail-closed marker: {marker}"
+            )
+            .into());
+        }
+    }
+    let validator_test = root.join("scripts/test_ci_validate_candidate.ps1");
+    if !validator_test.exists() {
+        return Err("current-candidate validator self-test is missing".into());
+    }
     println!("[xtask] canonical v4 packaged CI Tauri contract: PASS");
     Ok(())
 }
@@ -1825,7 +2002,7 @@ fn ci_control_plane_contract(root: &Path) -> Result<()> {
         "name: Website validation",
         "if: needs.changes.outputs.site_required == 'true'",
         "name: Sky Auto Player — required CI gate",
-        "needs: [changes, static, release_contract, supply_chain, validate, updater_e2e, packaged, site]",
+        "needs: [changes, static, release_contract, supply_chain, validate, candidate, updater_e2e, packaged, site]",
     ] {
         if !ci.contains(marker) {
             return Err(
@@ -2019,15 +2196,26 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "TimeoutSeconds 30",
         "SKY_TAURI_UPDATE_FIXTURE_PUBLIC_KEYS",
         "Packaged Tauri updater rotation",
+        "scripts/ci_validate_candidate.ps1",
+        "CandidateInstallerPath",
+        "CandidateSignaturePath",
+        "CandidateVersion",
+        "CandidatePublicKeyPath",
         "cargo xtask sbom generate",
         "cargo xtask sbom verify",
         "workflow_dispatch:",
-        "actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6",
-        "Verify exact GitHub artifact attestations",
     ] {
         if !ci.contains(marker) {
             return Err(format!("v4 trust CI is missing its required marker: {marker}").into());
         }
+    }
+    if ci.contains("actions/attest@")
+        || ci.contains("id-token: write")
+        || ci.contains("attestations: write")
+    {
+        return Err(
+            "ordinary CI must not retain artifact attestation creation or permissions".into(),
+        );
     }
     let updater_fixture = fs::read_to_string(root.join("scripts/ci_tauri_update_e2e_core.ps1"))?;
     for marker in [
@@ -2047,6 +2235,11 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "Clear-FixtureResourceStaging",
         "source_tree_restore",
         "cargo xtask builtin-catalog verify-installed --root $candidateBuiltinRoot",
+        "candidateInstallerSha256",
+        "oldSigningInstallerSha256",
+        "Get-HigherSemVer",
+        "old-root",
+        "old_root_rejection_copy_matches",
     ] {
         if !updater_fixture.contains(marker) {
             return Err(format!(
@@ -4074,6 +4267,12 @@ class MockReleaseApi { [int]$BuildCount = 0; [string]$UploadUrl = ''; [bool]$Upl
             "        env:\n          app-id:",
         );
         assert!(validate_metadata_app_token_scope(&private_key_in_env).is_err());
+    }
+
+    #[test]
+    fn packaged_ci_build_once_contract_accepts_locked_workflow() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        packaged_ci_contract(&root).expect("locked build-once CI contract must pass");
     }
 
     #[test]

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -1657,8 +1657,41 @@ fn packaged_ci_build_once_contract_source(source: &str) -> Result<()> {
         }
     }
 
+    let validate_position = packaged
+        .find("name: Validate exact current candidate contract")
+        .ok_or("packaged consumer must validate candidate.json before qualification")?;
+    let cache_position = packaged
+        .find("name: Rust cache")
+        .ok_or("packaged consumer must restore Rust cache before staging")?;
+    let stage_position = packaged
+        .find("name: Stage and re-hash exact current candidate after Rust cache restore")
+        .ok_or("packaged consumer must stage the candidate after Rust cache restore")?;
+    if validate_position >= cache_position || stage_position <= cache_position {
+        return Err(
+            "packaged candidate validation/staging order does not preserve the restored target tree"
+                .into(),
+        );
+    }
     for marker in [
-        "Run Authenticode tamper regression on bounded system PE fixture",
+        "Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256",
+        "Get-FileHash -LiteralPath $stagedSignature -Algorithm SHA256",
+        "Get-FileHash -LiteralPath $env:SKY_CANDIDATE_PUBLIC_KEY -Algorithm SHA256",
+        "Staged candidate hashes do not match the validated candidate contract",
+    ] {
+        if !packaged.contains(marker) {
+            return Err(format!(
+                "packaged consumer is missing post-cache staging hash verification: {marker}"
+            )
+            .into());
+        }
+    }
+
+    for marker in [
+        "Build bounded unsigned Authenticode PE fixture",
+        "rustc --edition 2021 --target x86_64-pc-windows-msvc",
+        "Get-AuthenticodeSignature",
+        "SKY_AUTHENTICODE_FIXTURE",
+        "Run Authenticode tamper regression on controlled unsigned PE fixture",
         "scripts/test_v4_authenticode_integrity.ps1",
         "scripts/test_v4_production_signing_contract.ps1",
         "scripts/setup_v4_test_signing.ps1",
@@ -1671,6 +1704,14 @@ fn packaged_ci_build_once_contract_source(source: &str) -> Result<()> {
         if !normalized.contains(marker) {
             return Err(format!(
                 "CI build-once control-plane contract is missing its marker: {marker}"
+            )
+            .into());
+        }
+    }
+    for forbidden in ["SystemRoot", "notepad.exe"] {
+        if normalized.contains(forbidden) {
+            return Err(format!(
+                "release contract Authenticode fixture must not depend on a system PE: {forbidden}"
             )
             .into());
         }
@@ -2217,6 +2258,21 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
             "ordinary CI must not retain artifact attestation creation or permissions".into(),
         );
     }
+    for marker in [
+        "#[cfg(feature = \"tauri-update-fixture\")]",
+        "FIXTURE_NEW_ONLY_ARG",
+        "fixture_new_only_requested",
+        "fixture_public_keys",
+        "next_back()",
+        "fixture_new_only_mode_selects_only_the_last_compiled_root",
+    ] {
+        if !native.contains(marker) {
+            return Err(format!(
+                "fixture-only updater new-root runtime seam is missing its required marker: {marker}"
+            )
+            .into());
+        }
+    }
     let updater_fixture = fs::read_to_string(root.join("scripts/ci_tauri_update_e2e_core.ps1"))?;
     for marker in [
         "Updater N-to-N+1 preservation",
@@ -2238,6 +2294,12 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "candidateInstallerSha256",
         "oldSigningInstallerSha256",
         "Get-HigherSemVer",
+        "preservedBridgeRoot",
+        "--selftest-update-fixture-new-only",
+        "negativeRequestStart",
+        "negativeManifestRequests",
+        "negativeCandidateRequests",
+        "n_to_n_plus_1_installer_sha256",
         "old-root",
         "old_root_rejection_copy_matches",
     ] {

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -2263,7 +2263,7 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
         "FIXTURE_NEW_ONLY_ARG",
         "fixture_new_only_requested",
         "fixture_public_keys",
-        "next_back()",
+        "rfind(|key| !key.is_empty())",
         "fixture_new_only_mode_selects_only_the_last_compiled_root",
     ] {
         if !native.contains(marker) {

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -69,7 +69,16 @@ if ($providedCandidate) {
   }
 }
 $candidateVersion = if ($providedCandidate) { $CandidateVersion } else { '4.0.0-alpha.2' }
-$cutoverVersion = '4.0.0-alpha.3'
+
+function Get-HigherSemVer([string]$Version) {
+  $match = [regex]::Match($Version, '^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$')
+  if (-not $match.Success) { throw "Cannot derive a higher synthetic updater version from $Version" }
+  $patch = [int64]$match.Groups[3].Value
+  if ($patch -eq [int64]::MaxValue) { throw 'Synthetic updater version patch component overflowed' }
+  return "$($match.Groups[1].Value).$($match.Groups[2].Value).$($patch + 1)"
+}
+
+$cutoverVersion = Get-HigherSemVer $candidateVersion
 $requestLogPath = Join-Path $fixtureRoot 'http-requests.jsonl'
 $httpEvidencePath = if ([string]::IsNullOrWhiteSpace($EvidencePath)) {
   Join-Path $fixtureRoot 'fixture-http-evidence.json'
@@ -443,21 +452,24 @@ try {
   $signatureText = ([IO.File]::ReadAllText($candidateSignature.FullName)).Trim()
   if ([string]::IsNullOrWhiteSpace($signatureText)) { throw 'Candidate updater signature is empty' }
 
-  if (-not $providedCandidate) {
-    # Sign the exact candidate bytes with the old root only. This detached
-    # signature is used after cutover to prove the new-root-only client rejects
-    # an old-root artifact through its real Update::download path.
-    Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
-    Push-Location $desktopRoot
-    try {
-      bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath *> $null
-    } finally {
-      Pop-Location
-    }
-    Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
-    $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
-    if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
+  # Sign a disposable copy of the exact candidate bytes with the old root only.
+  # The copied bytes are hashed before and after signing so the old-root
+  # rejection path cannot quietly introduce a second current candidate.
+  $candidateInstallerSha256 = Get-ByteSha256 ([IO.File]::ReadAllBytes($candidateArchive.FullName))
+  Copy-Item -LiteralPath $candidateArchive.FullName -Destination $candidateForOldSigningPath -Force
+  $oldSigningInstallerSha256 = Get-ByteSha256 ([IO.File]::ReadAllBytes($candidateForOldSigningPath))
+  if ($oldSigningInstallerSha256 -ne $candidateInstallerSha256) {
+    throw "Old-root rejection copy changed the current candidate bytes: candidate=$candidateInstallerSha256 old-signing-copy=$oldSigningInstallerSha256"
   }
+  Push-Location $desktopRoot
+  try {
+    bun run tauri signer sign --private-key-path $oldKeyPath --password '' $candidateForOldSigningPath *> $null
+  } finally {
+    Pop-Location
+  }
+  Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
+  $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
+  if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
 
   $newManifest = [ordered]@{
     version = $candidateVersion
@@ -474,20 +486,18 @@ try {
     }
   }
   $newManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $manifestPath -Encoding utf8
-  if (-not $providedCandidate) {
-    $oldManifest = [ordered]@{
-      version = $cutoverVersion
-      notes = 'Old-root rejection candidate.'
-      pub_date = '2026-09-04T00:00:00Z'
-      platforms = [ordered]@{
-        'windows-x86_64' = [ordered]@{
-          signature = $oldSignatureText
-          url = "http://127.0.0.1:$port/candidate/update.exe"
-        }
+  $oldManifest = [ordered]@{
+    version = $cutoverVersion
+    notes = 'Old-root rejection candidate.'
+    pub_date = '2026-09-04T00:00:00Z'
+    platforms = [ordered]@{
+      'windows-x86_64' = [ordered]@{
+        signature = $oldSignatureText
+        url = "http://127.0.0.1:$port/candidate/update.exe"
       }
     }
-    $oldManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $oldManifestPath -Encoding utf8
   }
+  $oldManifest | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $oldManifestPath -Encoding utf8
 
   $archivePath = $candidateArchive.FullName
   $serverJob = Start-Job -ScriptBlock {
@@ -582,9 +592,15 @@ try {
     http = $manifestHttp
   }
   $candidateBytes = [IO.File]::ReadAllBytes($candidateArchive.FullName)
+  if ((Get-ByteSha256 $candidateBytes) -ne $candidateInstallerSha256) {
+    throw 'Candidate bytes changed before loopback qualification'
+  }
   $candidateResponse = Invoke-LoopbackHttpBytes $expectedCandidateUrl
   $candidateContract = [ordered]@{
     status = 'PASS'
+    installer_sha256 = $candidateInstallerSha256
+    old_root_rejection_copy_sha256 = $oldSigningInstallerSha256
+    old_root_rejection_copy_matches = ($candidateInstallerSha256 -eq $oldSigningInstallerSha256)
     http = Assert-ExactHttpResponse $candidateResponse $candidateBytes 'application/octet-stream' 'fixture candidate artifact'
   }
   Write-Host "Fixture HTTP manifest contract: PASS (status=200; content-type=application/json; content-length=$($manifestHttp.content_length); body-sha256=$($manifestHttp.body_sha256))"
@@ -690,24 +706,25 @@ try {
   Write-Host "Updater N-to-N+1 resource replacement: PASS (user_sha256=$userSongShaAfter; built_in_manifest_sha256_before=$($catalogBridgeEvidence.manifest_sha256); built_in_manifest_sha256_after=$candidateBuiltinManifestSha; selected_id=$($catalogCandidateEvidence.selected_id); selected_content_sha256_before=$($catalogBridgeEvidence.selected_content_sha256); selected_content_sha256_after=$($catalogCandidateEvidence.selected_content_sha256); source_tree_restore=$catalogSourceRestoreStatus)"
   Write-Host "Updater N-to-N+1 preservation: PASS (user_sha256=$userSongShaAfter; built_in_count=$candidateBuiltinCount; built_in_manifest_sha256=$candidateBuiltinManifestSha)"
 
+  # Switch only the server manifest. The installed candidate is the
+  # new-root-only client; it must reject the old-root signature over the same
+  # installer bytes through the real updater download/verification path.
+  Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
+  $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
+    '--selftest-desktop-update',
+    '--selftest-update-marker', $cutoverMarkerPath
+  ) -WindowStyle Hidden -PassThru
+  Wait-Process -Id $cutoverProcess.Id -Timeout 180
+  Wait-ForPath -Path $cutoverMarkerPath
+  $cutoverResult = ([IO.File]::ReadAllText($cutoverMarkerPath)).Trim()
+  if (-not $cutoverResult.StartsWith('update-failed:')) {
+    throw "Cutover client accepted an old-root artifact: $cutoverResult"
+  }
   if ($providedCandidate) {
-    "Packaged Tauri updater draft qualification: PASS (throwaway previous-v4 bridge applied the exact downloaded candidate $candidateVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
+    "Packaged Tauri updater draft qualification: PASS (throwaway previous-v4 bridge applied the exact downloaded candidate $candidateVersion; old-root rejection reused installer sha256=$candidateInstallerSha256 with synthetic higher version $cutoverVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
       Add-Content $summaryPath -Encoding UTF8
   } else {
-    # Switch only the server manifest. The restarted candidate is the cutover
-    # binary compiled with [new]; it must reject the old-only detached signature.
-    Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
-    $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
-      '--selftest-desktop-update',
-      '--selftest-update-marker', $cutoverMarkerPath
-    ) -WindowStyle Hidden -PassThru
-    Wait-Process -Id $cutoverProcess.Id -Timeout 180
-    Wait-ForPath -Path $cutoverMarkerPath
-    $cutoverResult = ([IO.File]::ReadAllText($cutoverMarkerPath)).Trim()
-    if (-not $cutoverResult.StartsWith('update-failed:')) {
-      throw "Cutover client accepted an old-root artifact: $cutoverResult"
-    }
-    "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; cutover [new] rejected old-root-only $cutoverVersion; safety phases=$($requiredPhases -join ', '))" |
+    "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; old-root rejection reused installer sha256=$candidateInstallerSha256 with synthetic higher version $cutoverVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
       Add-Content $summaryPath -Encoding UTF8
   }
   $fixtureStatus = 'PASS'

--- a/scripts/ci_tauri_update_e2e_core.ps1
+++ b/scripts/ci_tauri_update_e2e_core.ps1
@@ -37,6 +37,7 @@ $candidateTargetRoot = Join-Path $fixtureTargetRoot 'candidate'
 $bridgeBundleRoot = Join-Path $bridgeTargetRoot 'dist/bundle/nsis'
 $candidateBundleRoot = Join-Path $candidateTargetRoot 'dist/bundle/nsis'
 $installRoot = Join-Path $fixtureRoot 'installed'
+$preservedBridgeRoot = Join-Path $fixtureRoot 'preserved-bridge'
 $appDataRoot = Join-Path $fixtureRoot 'app-data'
 $userSongsRoot = Join-Path $appDataRoot 'songs'
 $userSongPath = Join-Path $userSongsRoot 'updater-preserved-user.json'
@@ -467,6 +468,10 @@ try {
   } finally {
     Pop-Location
   }
+  $oldSigningInstallerSha256 = Get-ByteSha256 ([IO.File]::ReadAllBytes($candidateForOldSigningPath))
+  if ($oldSigningInstallerSha256 -ne $candidateInstallerSha256) {
+    throw "Old-root signing changed the disposable installer bytes: candidate=$candidateInstallerSha256 old-signing-copy=$oldSigningInstallerSha256"
+  }
   Move-Item -LiteralPath "$candidateForOldSigningPath.sig" -Destination $oldSignaturePath -Force
   $oldSignatureText = ([IO.File]::ReadAllText($oldSignaturePath)).Trim()
   if ([string]::IsNullOrWhiteSpace($oldSignatureText)) { throw 'Old-root updater signature is empty' }
@@ -599,6 +604,7 @@ try {
   $candidateContract = [ordered]@{
     status = 'PASS'
     installer_sha256 = $candidateInstallerSha256
+    n_to_n_plus_1_installer_sha256 = $candidateInstallerSha256
     old_root_rejection_copy_sha256 = $oldSigningInstallerSha256
     old_root_rejection_copy_matches = ($candidateInstallerSha256 -eq $oldSigningInstallerSha256)
     http = Assert-ExactHttpResponse $candidateResponse $candidateBytes 'application/octet-stream' 'fixture candidate artifact'
@@ -620,6 +626,19 @@ try {
     $catalogBridgeEvidence.selected_content_sha256 -ne $catalogSentinelSongSha -or
     $catalogBridgeEvidence.selected_manifest_sha256 -ne $catalogSentinelSongSha) {
     throw 'Bridge installed built-in catalog did not contain the expected N sentinel bytes and hash'
+  }
+  $bridgeAppSha256 = Get-ByteSha256 ([IO.File]::ReadAllBytes($appPath))
+  New-Item -ItemType Directory -Path $preservedBridgeRoot -Force | Out-Null
+  foreach ($item in @(Get-ChildItem -LiteralPath $installRoot -Force)) {
+    Copy-Item -LiteralPath $item.FullName -Destination $preservedBridgeRoot -Recurse -Force
+  }
+  $preservedBridgeAppPath = Join-Path $preservedBridgeRoot 'sky_desktop_shell.exe'
+  if (-not (Test-Path -LiteralPath $preservedBridgeAppPath -PathType Leaf)) {
+    throw "Preserved updater fixture bridge binary is missing: $preservedBridgeAppPath"
+  }
+  $preservedBridgeAppSha256 = Get-ByteSha256 ([IO.File]::ReadAllBytes($preservedBridgeAppPath))
+  if ($preservedBridgeAppSha256 -ne $bridgeAppSha256) {
+    throw "Preserved updater fixture bridge bytes changed: original=$bridgeAppSha256 preserved=$preservedBridgeAppSha256"
   }
 
   $userSongBytes = [Text.Encoding]::UTF8.GetBytes('{"name":"Updater preserved user","songNotes":[{"time":0,"key":"1Key0"}]}')
@@ -706,13 +725,18 @@ try {
   Write-Host "Updater N-to-N+1 resource replacement: PASS (user_sha256=$userSongShaAfter; built_in_manifest_sha256_before=$($catalogBridgeEvidence.manifest_sha256); built_in_manifest_sha256_after=$candidateBuiltinManifestSha; selected_id=$($catalogCandidateEvidence.selected_id); selected_content_sha256_before=$($catalogBridgeEvidence.selected_content_sha256); selected_content_sha256_after=$($catalogCandidateEvidence.selected_content_sha256); source_tree_restore=$catalogSourceRestoreStatus)"
   Write-Host "Updater N-to-N+1 preservation: PASS (user_sha256=$userSongShaAfter; built_in_count=$candidateBuiltinCount; built_in_manifest_sha256=$candidateBuiltinManifestSha)"
 
-  # Switch only the server manifest. The installed candidate is the
-  # new-root-only client; it must reject the old-root signature over the same
-  # installer bytes through the real updater download/verification path.
+  if ([string]$candidateContract.http.body_sha256 -cne $candidateInstallerSha256) {
+    throw "N-to-N+1 served candidate SHA differs from the candidate installer SHA: served=$($candidateContract.http.body_sha256) candidate=$candidateInstallerSha256"
+  }
+  $negativeRequestStart = @(Get-Content -LiteralPath $requestLogPath -ErrorAction Stop).Count
+  # Switch only the server manifest. The preserved bridge is the same
+  # tauri-update-fixture binary that accepted the candidate with old+new roots;
+  # its fixture-only runtime seam now selects only the last (new) root.
   Copy-Item -LiteralPath $oldManifestPath -Destination $manifestPath -Force
-  $cutoverProcess = Start-Process -FilePath $appPath -ArgumentList @(
+  $cutoverProcess = Start-Process -FilePath $preservedBridgeAppPath -WorkingDirectory $preservedBridgeRoot -ArgumentList @(
     '--selftest-desktop-update',
-    '--selftest-update-marker', $cutoverMarkerPath
+    '--selftest-update-marker', $cutoverMarkerPath,
+    '--selftest-update-fixture-new-only'
   ) -WindowStyle Hidden -PassThru
   Wait-Process -Id $cutoverProcess.Id -Timeout 180
   Wait-ForPath -Path $cutoverMarkerPath
@@ -720,11 +744,35 @@ try {
   if (-not $cutoverResult.StartsWith('update-failed:')) {
     throw "Cutover client accepted an old-root artifact: $cutoverResult"
   }
+  $negativeRequests = @(
+    Get-Content -LiteralPath $requestLogPath -ErrorAction Stop |
+      Select-Object -Skip $negativeRequestStart |
+      Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_) } |
+      ForEach-Object { $_ | ConvertFrom-Json }
+  )
+  $negativeManifestRequests = @($negativeRequests | Where-Object { [string]$_.path -eq '/stable' })
+  $negativeCandidateRequests = @($negativeRequests | Where-Object { [string]$_.path -eq '/candidate/update.exe' })
+  if ($negativeManifestRequests.Count -lt 1 -or $negativeCandidateRequests.Count -lt 1) {
+    throw "Old-root rejection did not reach both fixture manifest and candidate download paths: manifest=$($negativeManifestRequests.Count) candidate=$($negativeCandidateRequests.Count)"
+  }
+  foreach ($request in $negativeCandidateRequests) {
+    if ([string]$request.body_sha256 -cne $candidateInstallerSha256) {
+      throw "Old-root rejection served a candidate SHA different from N-to-N+1: served=$($request.body_sha256) candidate=$candidateInstallerSha256"
+    }
+  }
+  $candidateContract['old_root_rejection'] = [ordered]@{
+    status = 'PASS'
+    manifest_requests = $negativeManifestRequests.Count
+    candidate_requests = $negativeCandidateRequests.Count
+    served_candidate_sha256 = [string]$negativeCandidateRequests[0].body_sha256
+    matches_n_to_n_plus_1 = ([string]$negativeCandidateRequests[0].body_sha256 -ceq [string]$candidateContract.n_to_n_plus_1_installer_sha256)
+    update_result = $cutoverResult
+  }
   if ($providedCandidate) {
-    "Packaged Tauri updater draft qualification: PASS (throwaway previous-v4 bridge applied the exact downloaded candidate $candidateVersion; old-root rejection reused installer sha256=$candidateInstallerSha256 with synthetic higher version $cutoverVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
+    "Packaged Tauri updater draft qualification: PASS (preserved fixture bridge applied exact downloaded candidate $candidateVersion; N-to-N+1/old-root-rejection installer sha256=$candidateInstallerSha256; old-root manifest requests=$($negativeManifestRequests.Count); old-root candidate requests=$($negativeCandidateRequests.Count); synthetic higher version $cutoverVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
       Add-Content $summaryPath -Encoding UTF8
   } else {
-    "Packaged Tauri updater rotation: PASS (bridge [old,new] applied new-root-only $candidateVersion; old-root rejection reused installer sha256=$candidateInstallerSha256 with synthetic higher version $cutoverVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
+    "Packaged Tauri updater rotation: PASS (preserved fixture bridge applied new-root-only $candidateVersion; N-to-N+1/old-root-rejection installer sha256=$candidateInstallerSha256; old-root manifest requests=$($negativeManifestRequests.Count); old-root candidate requests=$($negativeCandidateRequests.Count); synthetic higher version $cutoverVersion; user data preserved across N-to-N+1; built-in count=$candidateBuiltinCount; safety phases=$($requiredPhases -join ', '))" |
       Add-Content $summaryPath -Encoding UTF8
   }
   $fixtureStatus = 'PASS'

--- a/scripts/ci_validate_candidate.ps1
+++ b/scripts/ci_validate_candidate.ps1
@@ -1,0 +1,236 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet("Create", "Validate")]
+    [string]$Mode,
+
+    [string]$BundleDir,
+    [string]$PublicKeyPath,
+    [string]$OutputRoot,
+    [string]$CandidateRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$SourceSha,
+    [string]$RepositoryRoot = (Get-Location).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$semVerPattern = '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$'
+$shaPattern = '^[0-9a-fA-F]{64}$'
+$commitPattern = '^[0-9a-fA-F]{40}$'
+$publicKeyFileName = "updater-public-key.pub"
+
+function Fail([string]$Message) {
+    throw "CI candidate contract failed: $Message"
+}
+
+function Assert-CommitSha([string]$Value, [string]$Name) {
+    if ($Value -notmatch $commitPattern -or $Value -match '^0{40}$') {
+        Fail "$Name must be a non-zero 40-character commit SHA"
+    }
+    return $Value.ToLowerInvariant()
+}
+
+function Get-ProjectVersion([string]$Root) {
+    $manifestPath = Join-Path $Root "desktop/src-tauri/Cargo.toml"
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        Fail "canonical desktop manifest is missing: $manifestPath"
+    }
+    $source = Get-Content -LiteralPath $manifestPath -Raw
+    $matches = [regex]::Matches($source, '(?m)^version\s*=\s*"([^"]+)"\s*$')
+    if ($matches.Count -ne 1) {
+        Fail "canonical desktop manifest must contain exactly one package version"
+    }
+    $version = $matches[0].Groups[1].Value
+    if ($version -notmatch $semVerPattern) {
+        Fail "canonical desktop package version is not SemVer: $version"
+    }
+    return $version
+}
+
+function Assert-SafeFileName([string]$Name, [string]$Field) {
+    if ([string]::IsNullOrWhiteSpace($Name) -or $Name.Length -gt 260 -or
+        [IO.Path]::IsPathRooted($Name) -or [IO.Path]::GetFileName($Name) -cne $Name -or
+        $Name.Contains("..") -or $Name.Contains([char]0)) {
+        Fail "$Field is not a safe artifact-relative filename: $Name"
+    }
+}
+
+function Get-DirectFiles([string]$Root) {
+    if (-not (Test-Path -LiteralPath $Root -PathType Container)) {
+        Fail "candidate directory is missing: $Root"
+    }
+    $items = @(Get-ChildItem -LiteralPath $Root -Force)
+    foreach ($item in $items) {
+        if ($item.PSIsContainer -or (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0)) {
+            Fail "candidate directory contains an unexpected directory or reparse point: $($item.Name)"
+        }
+    }
+    return @($items | Where-Object { -not $_.PSIsContainer })
+}
+
+function Get-Sha256([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        Fail "candidate file is missing: $Path"
+    }
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Validate-PublicKey([string]$Path) {
+    $item = Get-Item -LiteralPath $Path -ErrorAction Stop
+    if ($item.Length -le 0 -or $item.Length -gt 4096) {
+        Fail "candidate public key is empty or unbounded"
+    }
+    $value = ([IO.File]::ReadAllText($Path)).Trim()
+    if ([string]::IsNullOrWhiteSpace($value) -or $value -match 'PRIVATE KEY') {
+        Fail "candidate public key is missing or contains private key material"
+    }
+    if ($value -notmatch '^[A-Za-z0-9+/=\s]+$') {
+        Fail "candidate public key contains unexpected material"
+    }
+}
+
+function Read-CandidateContract([string]$Root, [string]$ExpectedSourceSha, [string]$ExpectedVersion) {
+    $rootPath = (Resolve-Path -LiteralPath $Root -ErrorAction Stop).Path
+    $files = Get-DirectFiles $rootPath
+    $metadataPath = Join-Path $rootPath "candidate.json"
+    if (-not (Test-Path -LiteralPath $metadataPath -PathType Leaf)) {
+        Fail "candidate.json is missing"
+    }
+    if ($files.Count -ne 4) {
+        Fail "candidate artifact must contain exactly four files; found $($files.Count)"
+    }
+
+    $metadata = Get-Content -LiteralPath $metadataPath -Raw | ConvertFrom-Json
+    $requiredFields = @(
+        "schema_version", "source_sha", "version", "installer", "installer_sha256",
+        "updater_signature", "updater_signature_sha256", "updater_public_key",
+        "updater_public_key_sha256"
+    )
+    $observedFields = @($metadata.PSObject.Properties.Name)
+    if (($observedFields -join "|") -cne ($requiredFields -join "|")) {
+        Fail "candidate.json fields are not the locked contract: $($observedFields -join ', ')"
+    }
+    if ([int]$metadata.schema_version -ne 1) {
+        Fail "unsupported candidate contract schema: $($metadata.schema_version)"
+    }
+    $expectedSource = Assert-CommitSha $ExpectedSourceSha "expected source SHA"
+    if ([string]$metadata.source_sha -ine $expectedSource) {
+        Fail "candidate source SHA does not match the checked-out source"
+    }
+    if ([string]$metadata.version -cne $ExpectedVersion -or [string]$metadata.version -notmatch $semVerPattern) {
+        Fail "candidate version does not match the checked-out source version"
+    }
+
+    foreach ($field in @("installer", "updater_signature", "updater_public_key")) {
+        Assert-SafeFileName ([string]$metadata.$field) $field
+    }
+    if ([string]$metadata.installer -notmatch '-setup\.exe$') {
+        Fail "candidate installer is not an NSIS setup executable"
+    }
+    if ([string]$metadata.updater_signature -cne "$($metadata.installer).sig") {
+        Fail "candidate updater signature is not the exact installer pair"
+    }
+    if ([string]$metadata.updater_public_key -cne $publicKeyFileName) {
+        Fail "candidate public key filename is not the locked public-key filename"
+    }
+    foreach ($field in @("installer_sha256", "updater_signature_sha256", "updater_public_key_sha256")) {
+        if ([string]$metadata.$field -notmatch $shaPattern) {
+            Fail "$field is not a SHA-256 digest"
+        }
+    }
+
+    $installerPath = Join-Path $rootPath ([string]$metadata.installer)
+    $signaturePath = Join-Path $rootPath ([string]$metadata.updater_signature)
+    $publicKeyPath = Join-Path $rootPath ([string]$metadata.updater_public_key)
+    foreach ($path in @($installerPath, $signaturePath, $publicKeyPath)) {
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            Fail "candidate.json references a missing artifact file: $path"
+        }
+    }
+    $expectedNames = @("candidate.json", [string]$metadata.installer, [string]$metadata.updater_signature, $publicKeyFileName)
+    $observedNames = @($files | ForEach-Object { $_.Name } | Sort-Object)
+    $sortedExpectedNames = @($expectedNames | Sort-Object)
+    if (($observedNames -join "|") -cne ($sortedExpectedNames -join "|")) {
+        Fail "candidate artifact contains unexpected files: $($observedNames -join ', ')"
+    }
+
+    $installerSha = Get-Sha256 $installerPath
+    $signatureSha = Get-Sha256 $signaturePath
+    $publicKeySha = Get-Sha256 $publicKeyPath
+    if ($installerSha -ine [string]$metadata.installer_sha256) { Fail "installer SHA-256 does not match candidate.json" }
+    if ($signatureSha -ine [string]$metadata.updater_signature_sha256) { Fail "updater signature SHA-256 does not match candidate.json" }
+    if ($publicKeySha -ine [string]$metadata.updater_public_key_sha256) { Fail "updater public-key SHA-256 does not match candidate.json" }
+    Validate-PublicKey $publicKeyPath
+
+    return [pscustomobject]@{
+        Root = $rootPath
+        MetadataPath = $metadataPath
+        InstallerPath = $installerPath
+        SignaturePath = $signaturePath
+        PublicKeyPath = $publicKeyPath
+        Version = [string]$metadata.version
+        SourceSha = ([string]$metadata.source_sha).ToLowerInvariant()
+        InstallerSha256 = $installerSha
+        SignatureSha256 = $signatureSha
+        PublicKeySha256 = $publicKeySha
+    }
+}
+
+function New-CandidateContract {
+    if ([string]::IsNullOrWhiteSpace($BundleDir) -or [string]::IsNullOrWhiteSpace($PublicKeyPath) -or
+        [string]::IsNullOrWhiteSpace($OutputRoot)) {
+        Fail "Create mode requires BundleDir, PublicKeyPath, and OutputRoot"
+    }
+    $sourceSha = Assert-CommitSha $SourceSha "source SHA"
+    $version = Get-ProjectVersion $RepositoryRoot
+    $bundlePath = (Resolve-Path -LiteralPath $BundleDir -ErrorAction Stop).Path
+    $bundleFiles = Get-DirectFiles $bundlePath
+    $installers = @($bundleFiles | Where-Object { $_.Name -match '-setup\.exe$' })
+    if ($installers.Count -ne 1 -or $bundleFiles.Count -ne 2) {
+        Fail "candidate bundle must contain exactly one installer and one signature"
+    }
+    $installer = $installers[0]
+    $signature = Get-Item -LiteralPath (Join-Path $bundlePath "$($installer.Name).sig") -ErrorAction Stop
+    if ($signature.PSIsContainer) { Fail "candidate updater signature is not a regular file" }
+    $publicKey = (Resolve-Path -LiteralPath $PublicKeyPath -ErrorAction Stop).Path
+    Validate-PublicKey $publicKey
+    if (Test-Path -LiteralPath $OutputRoot) {
+        Fail "candidate output directory already exists: $OutputRoot"
+    }
+    New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+    Copy-Item -LiteralPath $installer.FullName -Destination (Join-Path $OutputRoot $installer.Name)
+    Copy-Item -LiteralPath $signature.FullName -Destination (Join-Path $OutputRoot $signature.Name)
+    Copy-Item -LiteralPath $publicKey -Destination (Join-Path $OutputRoot $publicKeyFileName)
+    $installerPath = Join-Path $OutputRoot $installer.Name
+    $signaturePath = Join-Path $OutputRoot $signature.Name
+    $publicKeyOutputPath = Join-Path $OutputRoot $publicKeyFileName
+    $metadata = [ordered]@{
+        schema_version = 1
+        source_sha = $sourceSha
+        version = $version
+        installer = $installer.Name
+        installer_sha256 = Get-Sha256 $installerPath
+        updater_signature = $signature.Name
+        updater_signature_sha256 = Get-Sha256 $signaturePath
+        updater_public_key = $publicKeyFileName
+        updater_public_key_sha256 = Get-Sha256 $publicKeyOutputPath
+    }
+    [IO.File]::WriteAllText(
+        (Join-Path $OutputRoot "candidate.json"),
+        ($metadata | ConvertTo-Json -Compress),
+        [Text.UTF8Encoding]::new($false))
+    return Read-CandidateContract $OutputRoot $sourceSha $version
+}
+
+if ($Mode -eq "Create") {
+    $contract = New-CandidateContract
+} else {
+    if ([string]::IsNullOrWhiteSpace($CandidateRoot)) {
+        Fail "Validate mode requires CandidateRoot"
+    }
+    $contract = Read-CandidateContract $CandidateRoot $SourceSha (Get-ProjectVersion $RepositoryRoot)
+}
+
+Write-Output "CI candidate contract: PASS (source=$($contract.SourceSha); version=$($contract.Version); installer=$($contract.InstallerSha256); signature=$($contract.SignatureSha256); public_key=$($contract.PublicKeySha256))"

--- a/scripts/test_ci_validate_candidate.ps1
+++ b/scripts/test_ci_validate_candidate.ps1
@@ -1,0 +1,76 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$validator = Join-Path $PSScriptRoot "ci_validate_candidate.ps1"
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ("sky-ci-candidate-" + [guid]::NewGuid().ToString("N"))
+$sourceSha = "1234567890abcdef1234567890abcdef12345678"
+
+function Fail([string]$Message) { throw "CI candidate contract self-test failed: $Message" }
+
+function Invoke-Validator([string[]]$Arguments) {
+    $output = @(& pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $validator @Arguments 2>&1)
+    return [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = ($output -join "`n") }
+}
+
+function Assert-Fails([string]$Name, [string[]]$Arguments) {
+    $result = Invoke-Validator $Arguments
+    if ($result.ExitCode -eq 0) { Fail "$Name unexpectedly passed" }
+}
+
+try {
+    New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+    $bundle = Join-Path $tempRoot "bundle"
+    $candidate = Join-Path $tempRoot "candidate"
+    New-Item -ItemType Directory -Path $bundle -Force | Out-Null
+    $installerName = "Sky Auto Player_4.0.1_x64-setup.exe"
+    [IO.File]::WriteAllBytes((Join-Path $bundle $installerName), [byte[]](0..31))
+    [IO.File]::WriteAllText((Join-Path $bundle "$installerName.sig"), "official test updater signature`n")
+    $publicKey = Join-Path $tempRoot "test-public-key.pub"
+    [IO.File]::WriteAllText($publicKey, "dGVzdC1wdWJsaWMta2V5")
+
+    $create = Invoke-Validator @(
+        "-Mode", "Create", "-BundleDir", $bundle, "-PublicKeyPath", $publicKey,
+        "-OutputRoot", $candidate, "-SourceSha", $sourceSha, "-RepositoryRoot", $repoRoot
+    )
+    if ($create.ExitCode -ne 0) { Fail "Create mode failed: $($create.Output)" }
+    $validate = Invoke-Validator @(
+        "-Mode", "Validate", "-CandidateRoot", $candidate, "-SourceSha", $sourceSha,
+        "-RepositoryRoot", $repoRoot
+    )
+    if ($validate.ExitCode -ne 0) { Fail "Validate mode failed: $($validate.Output)" }
+    $metadata = Get-Content -LiteralPath (Join-Path $candidate "candidate.json") -Raw | ConvertFrom-Json
+    if ([string]$metadata.version -ne "4.0.1" -or [string]$metadata.source_sha -ne $sourceSha) {
+        Fail "created candidate metadata did not bind version and source SHA"
+    }
+    if (@(Get-ChildItem -LiteralPath $candidate -File).Count -ne 4) {
+        Fail "created candidate artifact did not contain exactly four files"
+    }
+
+    $installerPath = Join-Path $candidate $installerName
+    Add-Content -LiteralPath $installerPath -Value "tampered" -Encoding utf8
+    Assert-Fails "installer tamper" @(
+        "-Mode", "Validate", "-CandidateRoot", $candidate, "-SourceSha", $sourceSha,
+        "-RepositoryRoot", $repoRoot
+    )
+    [IO.File]::WriteAllBytes($installerPath, [byte[]](0..31))
+
+    Assert-Fails "source mismatch" @(
+        "-Mode", "Validate", "-CandidateRoot", $candidate,
+        "-SourceSha", ("a" * 40), "-RepositoryRoot", $repoRoot
+    )
+    [IO.File]::WriteAllText((Join-Path $candidate "updater-public-key.pub"), "PRIVATE KEY")
+    Assert-Fails "private key material" @(
+        "-Mode", "Validate", "-CandidateRoot", $candidate, "-SourceSha", $sourceSha,
+        "-RepositoryRoot", $repoRoot
+    )
+
+    Write-Output "CI candidate contract self-tests: PASS"
+} finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Intent

PR2 of the CI simplification sequence: change the ordinary CI data plane from duplicate current-candidate builds to **build once / qualify many**.

Authoritative implementation spec:

`docs/migration/ci-build-once-qualify-many-work-order.md`

## Locked architecture

- one current-candidate producer when `package_required || updater_required`
- artifact contains installer, matching Tauri updater signature, updater **public** test key, and `candidate.json`
- no private updater key crosses the producer job boundary
- package and updater lanes consume and re-hash the same exact artifact bytes
- updater uses the existing provided-candidate interface rather than another harness
- preserve old-root rejection using the same installer bytes; do not rebuild a second current candidate
- move contract-only Authenticode/signing tests out of package smoke where practical
- remove ordinary-CI attestations; preserve production/rehearsal attestations
- preserve the exact required gate name `Sky Auto Player — required CI gate`

## Hard boundaries

Do not include PR3 latency work: no Ubuntu browser migration, validate-job runner split, broad cache redesign, prebuilt updater bridge unless strictly necessary, merge queue, dist-profile weakening, classifier redesign, or reusable release workflow abstraction.

Keep this PR Draft until the full CI matrix proves the package and updater consumers used the same candidate SHA-256 from a single current build.