### PR TITLE
fix(rt): unify post-start focus pause transition

### DIFF
--- a/rust/crates/sky_player/src/engine/tests.rs
+++ b/rust/crates/sky_player/src/engine/tests.rs
@@ -2117,28 +2117,13 @@ fn first_final_foreground_loss_is_terminal_without_epoch_rebase() {
         sky_dispatch_core::clock::PlaybackClockState::new(epoch, DurationTicks::ZERO)
             .expect("playback clock");
     let original_epoch = clock_state.epoch;
-    let schedule =
-        sky_dispatch_core::compile::compile_runtime_intents(&[], &[0x15]).expect("empty schedule");
-    let mut coordinator =
-        sky_dispatch_core::coordinator::RuntimeDispatchCoordinator::try_new_ticks(
-            schedule,
-            0,
-            DurationTicks::ZERO,
-            |_| Ok(TimelineTicks::ZERO),
-        )
-        .expect("coordinator");
-    let mut backend = TrackedKeyState::new();
     let mut runtime = super::worker::WorkerRuntime::default();
-    let target = AtomicIsize::new(123);
     let progress_clock = super::shared::SharedProgressClock::default();
 
     let result = super::worker::handle_final_focus_loss(
         qpc_clock,
-        &mut backend,
-        &mut coordinator,
         &mut clock_state,
         &mut runtime,
-        &target,
         &progress_clock,
     );
 
@@ -2344,6 +2329,58 @@ fn authored_focus_pause_publishes_progress_anchor() {
             .expect("progress projection")
             .paused,
         "pre-roll focus loss must not enter a rebased pause"
+    );
+}
+
+#[test]
+fn authored_post_start_focus_loss_pauses_without_resumable_cleanup() {
+    use super::test_support::ProductionDispatchTestHarness;
+    use super::worker::dispatch::DispatchObservation;
+
+    let mut harness = ProductionDispatchTestHarness::new_deferred_release_with_unrelated_down();
+    let calls = harness.configure_send_counter();
+    harness.align_next_plan_to_future_for_test(500_000);
+    let seed_plan = harness.plan_current_dispatch();
+    let seed_step = harness.dispatch_due_from_plan_for_test(&seed_plan);
+    assert!(
+        matches!(seed_step, super::worker::DispatchStep::Dispatched),
+        "seed dispatch: {seed_step:?}"
+    );
+    harness.config.focus.require_focus = true;
+    let seed_send_calls = calls.load(Ordering::SeqCst);
+    let release_calls = harness.full_instrument_release_calls();
+    let active_mask = harness.backend_active_mask();
+    let coordinator_active_mask = harness.resources.coordinator.active_mask;
+    assert_ne!(
+        active_mask, 0,
+        "seed Down must establish physical ownership"
+    );
+    while harness.pop_observation().is_some() {}
+
+    let plan = harness.plan_current_dispatch();
+    harness.focus_active.store(false, Ordering::Release);
+
+    let step = harness.dispatch_authored_with_plan(&plan);
+
+    assert!(matches!(step, super::worker::DispatchStep::Continue));
+    assert_eq!(calls.load(Ordering::SeqCst), seed_send_calls);
+    assert_eq!(harness.full_instrument_release_calls(), release_calls);
+    assert_eq!(harness.backend_active_mask(), active_mask);
+    assert_eq!(
+        harness.resources.coordinator.active_mask,
+        coordinator_active_mask
+    );
+    assert!(
+        harness
+            .progress_clock
+            .load()
+            .expect("progress projection")
+            .paused
+    );
+    assert!(
+        !std::iter::from_fn(|| harness.pop_observation())
+            .any(|observation| { matches!(observation, DispatchObservation::Lifecycle(_)) }),
+        "cached focus loss must not publish a lifecycle reset"
     );
 }
 
@@ -3053,11 +3090,22 @@ fn authored_down_target_change_after_crossing_never_reaches_transport() {
 #[test]
 fn authored_down_focus_loss_after_crossing_never_reaches_transport() {
     use super::test_support::ProductionDispatchTestHarness;
+    use super::worker::dispatch::DispatchObservation;
 
-    let mut harness = ProductionDispatchTestHarness::new_down_only();
-    harness.config.focus.require_focus = true;
+    let mut harness = ProductionDispatchTestHarness::new_deferred_release_with_unrelated_down();
     let calls = harness.configure_send_counter();
-    harness.advance_playback_time_us(100_000);
+    harness.align_next_plan_to_future_for_test(500_000);
+    let seed_plan = harness.plan_current_dispatch();
+    assert!(matches!(
+        harness.dispatch_due_from_plan_for_test(&seed_plan),
+        super::worker::DispatchStep::Dispatched
+    ));
+    harness.config.focus.require_focus = true;
+    let seed_send_calls = calls.load(Ordering::SeqCst);
+    let release_calls = harness.full_instrument_release_calls();
+    let active_mask = harness.backend_active_mask();
+    let coordinator_active_mask = harness.resources.coordinator.active_mask;
+    while harness.pop_observation().is_some() {}
     let plan = harness.plan_current_dispatch();
     harness.set_final_gate_race_hook(|focus, _, _, _, _, _, _| {
         focus.store(false, Ordering::Release);
@@ -3065,12 +3113,27 @@ fn authored_down_focus_loss_after_crossing_never_reaches_transport() {
 
     let step = harness.dispatch_at_plan_target_for_test(&plan);
 
-    assert!(matches!(
-        step,
-        super::worker::DispatchStep::TerminateStatic("focus_lost_during_preroll")
-    ));
-    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert!(matches!(step, super::worker::DispatchStep::Continue));
+    assert_eq!(calls.load(Ordering::SeqCst), seed_send_calls);
+    assert_eq!(harness.full_instrument_release_calls(), release_calls);
+    assert_eq!(harness.backend_active_mask(), active_mask);
+    assert_eq!(
+        harness.resources.coordinator.active_mask,
+        coordinator_active_mask
+    );
+    assert!(
+        harness
+            .progress_clock
+            .load()
+            .expect("progress projection")
+            .paused
+    );
     assert_eq!(harness.local_metrics.final_gate_focus_losses, 1);
+    assert!(
+        !std::iter::from_fn(|| harness.pop_observation())
+            .any(|observation| { matches!(observation, DispatchObservation::Lifecycle(_)) }),
+        "final-gate focus loss must not publish a lifecycle reset"
+    );
 }
 
 #[test]

--- a/rust/crates/sky_player/src/engine/worker.rs
+++ b/rust/crates/sky_player/src/engine/worker.rs
@@ -26,9 +26,9 @@ pub(crate) use admission::final_control_admission_with_lease;
 pub(crate) use admission::invoke_final_gate_race_hook;
 pub(crate) use admission::{
     DownAdmission, FinalControlAdmission, FinalControlSignals, FinalGateRejection,
-    FinalTargetSignals, TargetStamp, ensure_preflight_for_target, final_control_admission_at,
-    final_control_precheck, final_down_target_admission, focus_matches, focus_matches_hwnd,
-    handle_final_focus_loss, load_target_stamp, record_final_gate_rejection,
+    FinalTargetSignals, TargetStamp, ensure_preflight_for_target, enter_focus_pause,
+    final_control_admission_at, final_control_precheck, final_down_target_admission, focus_matches,
+    focus_matches_hwnd, handle_final_focus_loss, load_target_stamp, record_final_gate_rejection,
     target_stamp_still_current, trace_kind_for_packet_kind,
 };
 use cleanup::{

--- a/rust/crates/sky_player/src/engine/worker/admission.rs
+++ b/rust/crates/sky_player/src/engine/worker/admission.rs
@@ -1,4 +1,4 @@
-use super::super::{PlaybackClockState, QpcClock, RuntimeDispatchCoordinator};
+use super::super::{PlaybackClockState, QpcClock};
 use super::dispatch::DispatchStep;
 use super::{TrackedKeyState, focus_gate_matches};
 use crate::engine::shared::SharedProgressClock;
@@ -266,34 +266,40 @@ pub(crate) fn final_down_target_admission(target: FinalTargetSignals<'_>) -> Dow
     DownAdmission::Allowed
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn handle_final_focus_loss(
-    qpc_clock: QpcClock,
-    backend: &mut TrackedKeyState,
-    coordinator: &mut RuntimeDispatchCoordinator,
+pub(crate) fn enter_focus_pause(
     clock_state: &mut PlaybackClockState,
     runtime: &mut super::WorkerRuntime,
-    target_hwnd: &AtomicIsize,
+    focus_ticks: QpcTicks,
+    progress_clock: &SharedProgressClock,
+) -> Result<bool, String> {
+    runtime.invalidate_down_authorization();
+    runtime.verified_target = None;
+    runtime.focus_restore_started_ticks = None;
+    if clock_state.has_pause_reason(PauseReason::Focus) {
+        return Ok(false);
+    }
+    clock_state
+        .enter_pause(PauseReason::Focus, focus_ticks)
+        .map_err(|error| format!("playback clock failure: {error}"))?;
+    progress_clock.publish(clock_state);
+    Ok(true)
+}
+
+pub(crate) fn handle_final_focus_loss(
+    qpc_clock: QpcClock,
+    clock_state: &mut PlaybackClockState,
+    runtime: &mut super::WorkerRuntime,
     progress_clock: &SharedProgressClock,
 ) -> Result<(), DispatchStep> {
-    runtime.verified_target = None;
     if !runtime.musical_physical_commit_started {
         return Err(DispatchStep::TerminateStatic("focus_lost_during_preroll"));
     }
     let focus_ticks = qpc_clock
         .now()
         .map_err(|error| DispatchStep::Terminate(format!("QPC failure: {error:?}")))?;
-    super::suspend_live_input(backend, coordinator, target_hwnd.load(Ordering::Acquire))
-        .map_err(|error| DispatchStep::Terminate(format!("focus suspension failed: {error}")))?;
-    clock_state
-        .enter_pause(PauseReason::Focus, focus_ticks)
-        .map_err(|error| {
-            DispatchStep::Terminate(format!(
-                "playback clock failure after final focus check: {error}"
-            ))
-        })?;
-    progress_clock.publish(clock_state);
-    runtime.focus_restore_started_ticks = None;
+    enter_focus_pause(clock_state, runtime, focus_ticks, progress_clock)
+        .map(|_| ())
+        .map_err(DispatchStep::Terminate)?;
     Ok(())
 }
 

--- a/rust/crates/sky_player/src/engine/worker/dispatch/authored.rs
+++ b/rust/crates/sky_player/src/engine/worker/dispatch/authored.rs
@@ -7,13 +7,14 @@ use super::super::invoke_final_gate_race_hook;
 use super::super::{
     DispatchPath, DownAdmission, FinalControlAdmission, FinalControlSignals, FinalGateRejection,
     FinalTargetSignals, TargetStamp, WorkerConfig, WorkerHealthState, WorkerMetricsLocal,
-    WorkerResources, WorkerRuntime, WorkerTimingState, final_control_admission_at,
-    final_control_precheck, final_down_target_admission, focus_matches, handle_final_focus_loss,
-    load_target_stamp, record_final_gate_rejection, record_sendinput_pre_call_lateness,
-    signed_ticks_to_us, suspend_live_input, target_stamp_still_current, trace_kind_for_packet_kind,
+    WorkerResources, WorkerRuntime, WorkerTimingState, enter_focus_pause,
+    final_control_admission_at, final_control_precheck, final_down_target_admission, focus_matches,
+    handle_final_focus_loss, load_target_stamp, record_final_gate_rejection,
+    record_sendinput_pre_call_lateness, signed_ticks_to_us, target_stamp_still_current,
+    trace_kind_for_packet_kind,
 };
 use super::DownBoundaryAdmission;
-use super::observation::{BlockedUnfocusedObservation, ObserverLifecycle};
+use super::observation::BlockedUnfocusedObservation;
 use super::observer::publisher_down_send_outcome;
 use super::recovery::{
     DownMissReason, record_missed_down_classification, record_rescue_admission, record_rescue_send,
@@ -22,8 +23,7 @@ use super::recovery::{
 use super::timing::interpret_down_send_timing;
 use super::{AuthoredBatchView, AuthoredPacketContext, DispatchStep, PendingObservationQueue};
 use crate::engine::shared::SharedProgressClock;
-use sky_dispatch_core::clock::PauseReason;
-use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU64};
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn dispatch_authored_packet(
     ctx: AuthoredPacketContext<'_>,
@@ -143,8 +143,6 @@ fn commit_down_send_outcome(
     let admission = match admit_authored_down(
         view,
         config,
-        backend,
-        coordinator,
         clock_state,
         runtime,
         local_metrics,
@@ -176,8 +174,6 @@ fn commit_down_send_outcome(
         view,
         config,
         qpc_clock,
-        backend,
-        coordinator,
         clock_state,
         runtime,
         local_metrics,
@@ -197,7 +193,6 @@ fn commit_down_send_outcome(
         #[cfg(any(test, feature = "test-support"))]
         test_direct_boundary,
         admission,
-        observer,
     ) {
         Ok(admission) => admission,
         Err(step) => return step,
@@ -284,8 +279,6 @@ fn resolve_target_crossing_qpc(
 fn admit_authored_down(
     view: &AuthoredBatchView,
     config: &WorkerConfig,
-    backend: &mut TrackedKeyState,
-    coordinator: &mut RuntimeDispatchCoordinator,
     clock_state: &mut PlaybackClockState,
     runtime: &mut WorkerRuntime,
     local_metrics: &mut WorkerMetricsLocal,
@@ -315,24 +308,8 @@ fn admit_authored_down(
         if !runtime.musical_physical_commit_started {
             return Err(DispatchStep::TerminateStatic("focus_lost_during_preroll"));
         }
-        if let Err(error) =
-            suspend_live_input(backend, coordinator, target_hwnd.load(Ordering::Acquire))
-        {
-            return Err(DispatchStep::Terminate(format!(
-                "focus suspension failed: {error}"
-            )));
-        }
-        runtime
-            .production_forensics
-            .observe_lifecycle(ObserverLifecycle::ResetAll);
-        super::observation::enqueue_lifecycle(observer, ObserverLifecycle::ResetAll, local_metrics);
-        if let Err(error) = clock_state.enter_pause(PauseReason::Focus, now_ticks) {
-            return Err(DispatchStep::Terminate(format!(
-                "playback clock failure: {error}"
-            )));
-        }
-        progress_clock.publish(clock_state);
-        runtime.focus_restore_started_ticks = None;
+        enter_focus_pause(clock_state, runtime, now_ticks, progress_clock)
+            .map_err(DispatchStep::Terminate)?;
         if let Some(observer) = observer {
             observer.push(
                 super::observation::DispatchObservation::BlockedUnfocused(
@@ -435,8 +412,6 @@ fn finalize_authored_down_admission(
     view: &AuthoredBatchView,
     config: &WorkerConfig,
     qpc_clock: QpcClock,
-    backend: &mut TrackedKeyState,
-    coordinator: &mut RuntimeDispatchCoordinator,
     clock_state: &mut PlaybackClockState,
     runtime: &mut WorkerRuntime,
     local_metrics: &mut WorkerMetricsLocal,
@@ -455,7 +430,6 @@ fn finalize_authored_down_admission(
     boundary_crossing_qpc: Option<QpcTicks>,
     #[cfg(any(test, feature = "test-support"))] test_direct_boundary: bool,
     admission: AdmissionOutcome,
-    observer: Option<&PendingObservationQueue>,
 ) -> Result<AdmissionOutcome, DispatchStep> {
     let AdmissionOutcome::Guarded {
         trace_kind,
@@ -521,23 +495,7 @@ fn finalize_authored_down_admission(
             DownAdmission::Allowed => {}
             DownAdmission::FocusLost => {
                 record_final_gate_rejection(local_metrics, FinalGateRejection::Focus);
-                handle_final_focus_loss(
-                    qpc_clock,
-                    backend,
-                    coordinator,
-                    clock_state,
-                    runtime,
-                    target_hwnd,
-                    progress_clock,
-                )?;
-                runtime
-                    .production_forensics
-                    .observe_lifecycle(ObserverLifecycle::ResetAll);
-                super::observation::enqueue_lifecycle(
-                    observer,
-                    ObserverLifecycle::ResetAll,
-                    local_metrics,
-                );
+                handle_final_focus_loss(qpc_clock, clock_state, runtime, progress_clock)?;
                 return Ok(AdmissionOutcome::FocusLost);
             }
             DownAdmission::TargetChanged => {

--- a/rust/crates/sky_player/src/engine/worker/dispatch/observation.rs
+++ b/rust/crates/sky_player/src/engine/worker/dispatch/observation.rs
@@ -35,20 +35,6 @@ pub enum DispatchObservation {
     Lifecycle(ObserverLifecycle),
 }
 
-pub(super) fn enqueue_lifecycle(
-    observer: Option<&super::observer::PendingObservationQueue>,
-    lifecycle: ObserverLifecycle,
-    local_metrics: &mut WorkerMetricsLocal,
-) {
-    if let Some(observer) = observer {
-        observer.push(
-            DispatchObservation::Lifecycle(lifecycle),
-            &mut local_metrics.observer_dropped_samples,
-            &mut local_metrics.observer_queue_high_watermark,
-        );
-    }
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct StaleMetadataObservation {
     pub source_action_index: u32,

--- a/rust/crates/sky_player/src/engine/worker/dispatch_loop.rs
+++ b/rust/crates/sky_player/src/engine/worker/dispatch_loop.rs
@@ -5,7 +5,7 @@ use super::{
     CommandControl, CommandControlClock, CommandControlInput, CommandControlMetrics,
     CommandControlRuntime, CommandControlSignals, PlanningInput, WaitBoundary, WaitBoundaryInput,
     WaitDeadline, WaitMutable, WaitSignals, WaitTiming, Worker, ensure_preflight_for_target,
-    focus_matches, focus_matches_hwnd, lease_bounded_ticks, load_target_stamp,
+    enter_focus_pause, focus_matches, focus_matches_hwnd, lease_bounded_ticks, load_target_stamp,
     plan_next_dispatch_projected, process_command_control, publish_backend_metrics,
     record_wait_failure, suspend_live_input, target_stamp_still_current, wait_for_next_boundary,
 };
@@ -428,24 +428,21 @@ pub(super) fn dispatch(
             }
 
             if !focus_ok {
-                core.runtime.invalidate_down_authorization();
-                core.runtime.verified_target = None;
-                core.runtime.focus_restore_started_ticks = None;
-                if !resources.playback.has_pause_reason(PauseReason::Focus) {
-                    *core.errors.abort_counts.entry("focus_lost").or_insert(0) += 1;
-                    if let Err(error) = resources
-                        .playback
-                        .enter_pause(PauseReason::Focus, now_ticks)
-                    {
+                let entered_focus_pause = match enter_focus_pause(
+                    &mut resources.playback,
+                    &mut core.runtime,
+                    now_ticks,
+                    &shared.publication.progress_clock,
+                ) {
+                    Ok(entered) => entered,
+                    Err(error) => {
                         core.runtime.force_full_cleanup = true;
-                        core.runtime.terminal_error =
-                            Some(format!("playback clock failure: {error}"));
+                        core.runtime.terminal_error = Some(error);
                         break;
                     }
-                    shared
-                        .publication
-                        .progress_clock
-                        .publish(&resources.playback);
+                };
+                if entered_focus_pause {
+                    *core.errors.abort_counts.entry("focus_lost").or_insert(0) += 1;
                     publish_backend_metrics(
                         &resources.backend,
                         &mut core.metrics,
@@ -480,6 +477,19 @@ pub(super) fn dispatch(
                         manual_pause || resources.playback.has_pause_reason(PauseReason::Manual);
                     core.runtime.verified_target = None;
                     if !manual_pause_active {
+                        if !focus_matches_hwnd(
+                            config.focus.require_focus,
+                            focus_active,
+                            preflight_target.hwnd,
+                        ) || !target_stamp_still_current(
+                            target_hwnd,
+                            target_generation,
+                            preflight_target,
+                        ) {
+                            core.runtime.verified_target = None;
+                            core.runtime.focus_restore_started_ticks = None;
+                            continue;
+                        }
                         if let Err(error) = suspend_live_input(
                             &mut resources.backend,
                             &mut resources.coordinator,
@@ -520,15 +530,17 @@ pub(super) fn dispatch(
                     if let Some(hook) = core.runtime.restore_race_hook.as_ref() {
                         hook(focus_active, target_hwnd, target_generation);
                     }
+                    let post_restore_target = load_target_stamp(target_hwnd, target_generation);
                     if !focus_matches_hwnd(
                         config.focus.require_focus,
                         focus_active,
-                        preflight_target.hwnd,
+                        post_restore_target.hwnd,
                     ) || !target_stamp_still_current(
                         target_hwnd,
                         target_generation,
                         preflight_target,
-                    ) {
+                    ) || post_restore_target != preflight_target
+                    {
                         core.runtime.verified_target = None;
                         core.runtime.focus_restore_started_ticks = None;
                         continue;


### PR DESCRIPTION
Closes #196
Parent campaign: #194

## Coordinator status

W1 implementation reviewed and approved for integration.

Commit under review:
`db2a4d90066c319a89cb352c0c90d4345f6117d4`

## Scope

- unify post-start focus-loss transition;
- preserve backend/coordinator ownership while target is unfocused;
- avoid resumable cleanup / false ResetAll evidence on the unfocused edge;
- add fresh exact focus/target proof before restore cleanup/preflight;
- revalidate again before leaving Focus pause;
- add deterministic regression coverage.

## Explicit non-goals preserved

No timing, HybridWaiter, MMCSS, Down grace, transport margin, focus grace, pre-roll, packet-capacity, key-mapping, or cleanup-retry tuning.

## Local qualification

Codex reported:
- fmt PASS;
- clippy `-D warnings` PASS;
- workspace tests PASS;
- `cargo xtask check rust` PASS;
- `cargo xtask check static` PASS;
- focused W1 regressions PASS.

No real SendInput was issued.

W2 (#197) remains blocked until this PR is merged and integration status is clean.