### PR TITLE
perf(rt): shrink prepared packet capacity

### DIFF
--- a/rust/crates/sky_dispatch_win32/src/input/packet.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/packet.rs
@@ -6,10 +6,11 @@ use super::scan_code::{
     FULL_INSTRUMENT_MASK, PHYSICAL_INSTRUMENT_SCAN_CODES, SKY_PLAYER_SIGNATURE,
 };
 use crate::clock::{QpcClock, QpcTicks};
+use sky_dispatch_core::model::MAX_KEYS;
 #[cfg(windows)]
 use std::mem::MaybeUninit;
 
-pub const MAX_PACKET_EVENTS: usize = 30;
+pub const MAX_PACKET_EVENTS: usize = MAX_KEYS;
 
 /// Return whether a packet containing a Down crossed its authoritative
 /// sender cutoff. The predicate is shared by the real SendInput envelope,
@@ -1567,9 +1568,12 @@ mod tests {
     }
 
     #[test]
-    fn physical_packet_accepts_at_most_thirty_events() {
-        let packet = PhysicalPacket::new(FULL_INSTRUMENT_MASK, FULL_INSTRUMENT_MASK);
-        assert_eq!(packet.event_count(), MAX_PACKET_EVENTS as u8);
+    fn physical_packet_accepts_fifteen_events_per_direction() {
+        for (up_mask, down_mask) in [(FULL_INSTRUMENT_MASK, 0), (0, FULL_INSTRUMENT_MASK)] {
+            let prepared = PreparedPhysicalPacket::try_new(PhysicalPacket::new(up_mask, down_mask))
+                .expect("fifteen-key packet prepares");
+            assert_eq!(prepared.event_count(), MAX_PACKET_EVENTS as u8);
+        }
     }
 
     #[test]
@@ -1593,6 +1597,7 @@ mod tests {
             .expect("full mixed packet prepares");
         let recovery = prepared.up_recovery_view().expect("full mixed Up prefix");
 
+        assert_eq!(prepared.event_count(), MAX_PACKET_EVENTS as u8);
         assert_eq!(recovery.packet(), PhysicalPacket::new(0x01ff, 0));
         assert_eq!(recovery.packet().event_count(), 9);
         #[cfg(windows)]


### PR DESCRIPTION
Closes #197
Parent campaign: #194

## Coordinator status

W2 reviewed and approved for integration.

Commit:
`f4c73b2cf88c6a9703740f270f501e2d11de4556`

Base:
`2f565ba65603617d097020aeb18547e2efc1bcb7`

## Scope

- derive `MAX_PACKET_EVENTS` from the 15-slot domain maximum;
- reduce `PreparedPhysicalPacket` fixed capacity from unreachable 30 to exact maximum 15;
- preserve Up-before-Down ordering and Mixed borrowed Up-prefix recovery;
- add/adjust exact-capacity boundary coverage.

## Structural evidence

Windows x64:
- PreparedPhysicalPacket 1208 → 608
- AuthoredBatchView 1872 → 1272
- PhysicalDispatchPlan / NextDispatchPlan 1936 → 1336
- PreparedAuthoredCommit unchanged 544

No claim is made that the removed 600-byte capacity was previously initialized.

## Local qualification

fmt / Win32 tests / core tests / player tests / no-allocation tests / static gate / canonical Rust gate: final PASS.

One timing-sensitive focus-restore test failed on the first full Rust run, then passed isolated and in the complete rerun. It is recorded as host/flakiness evidence.

## Performance qualification

No runtime improvement is claimed. The W2 deterministic benchmark was not profile-matched to the W0 release baseline and candidate production-boundary runs were not acceptance-clean. W5 will rerun paired qualification correctly.

W3 (#198) remains blocked until this PR is merged.