### PR TITLE
fix(rt): harden cleanup evidence boundaries

### DIFF
--- a/rust/crates/sky_dispatch_win32/src/input/physical.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/physical.rs
@@ -164,11 +164,27 @@ fn query_async_key_state(_index: usize, virtual_key: i32) -> i16 {
     }
 }
 
-pub(crate) fn instrument_physical_state_for_mask(
+fn instrument_physical_state_for_mask_with<
+    Context,
+    Foreground,
+    ContextResolver,
+    VirtualKeyMapper,
+    KeyStateQuery,
+>(
     target_hwnd: isize,
     requested_mask: u16,
-) -> InstrumentPhysicalState {
-    if target_hwnd == 0 || !foreground_window_matches(target_hwnd) {
+    mut foreground_matches: Foreground,
+    mut context_for_target: ContextResolver,
+    mut map_virtual_keys: VirtualKeyMapper,
+    mut query_key_state: KeyStateQuery,
+) -> InstrumentPhysicalState
+where
+    Foreground: FnMut(isize) -> bool,
+    ContextResolver: FnMut(isize) -> Option<Context>,
+    VirtualKeyMapper: FnMut(&Context, u16) -> Option<[i32; PHYSICAL_INSTRUMENT_SCAN_CODES.len()]>,
+    KeyStateQuery: FnMut(usize, i32) -> i16,
+{
+    if target_hwnd == 0 || !foreground_matches(target_hwnd) {
         return InstrumentPhysicalState::Inconclusive;
     }
     if requested_mask == 0 {
@@ -177,26 +193,44 @@ pub(crate) fn instrument_physical_state_for_mask(
     if requested_mask & !FULL_INSTRUMENT_MASK != 0 {
         return InstrumentPhysicalState::Inconclusive;
     }
+
+    let Some(context) = context_for_target(target_hwnd) else {
+        return InstrumentPhysicalState::Inconclusive;
+    };
+    let Some(virtual_keys) = map_virtual_keys(&context, requested_mask) else {
+        return InstrumentPhysicalState::Inconclusive;
+    };
+    let mut key_states = [0i16; PHYSICAL_INSTRUMENT_SCAN_CODES.len()];
+    for (index, &virtual_key) in virtual_keys.iter().enumerate() {
+        if requested_mask & (1u16 << index) == 0 {
+            continue;
+        }
+        key_states[index] = query_key_state(index, virtual_key);
+    }
+    if !foreground_matches(target_hwnd) {
+        return InstrumentPhysicalState::Inconclusive;
+    }
+    classify_async_key_states(requested_mask, &key_states)
+}
+
+pub(crate) fn instrument_physical_state_for_mask(
+    target_hwnd: isize,
+    requested_mask: u16,
+) -> InstrumentPhysicalState {
     #[cfg(windows)]
     {
-        let Some(context) = keyboard_context_for_target(target_hwnd) else {
-            return InstrumentPhysicalState::Inconclusive;
-        };
-        let Some(virtual_keys) = map_instrument_virtual_keys(&context, requested_mask) else {
-            return InstrumentPhysicalState::Inconclusive;
-        };
-        let mut key_states = [0i16; 15];
-        for (index, &virtual_key) in virtual_keys.iter().enumerate() {
-            if requested_mask & (1u16 << index) == 0 {
-                continue;
-            }
-            key_states[index] = query_async_key_state(index, virtual_key);
-        }
-        classify_async_key_states(requested_mask, &key_states)
+        instrument_physical_state_for_mask_with(
+            target_hwnd,
+            requested_mask,
+            foreground_window_matches,
+            keyboard_context_for_target,
+            map_instrument_virtual_keys,
+            query_async_key_state,
+        )
     }
     #[cfg(not(windows))]
     {
-        let _ = (target_hwnd, requested_mask);
+        let _ = (target_hwnd, requested_mask, foreground_window_matches);
         InstrumentPhysicalState::Inconclusive
     }
 }
@@ -237,5 +271,36 @@ pub fn is_scan_code_physically_down(scan_code: u16, target_hwnd: isize) -> Optio
     {
         let _ = (scan_code, target_hwnd);
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InstrumentPhysicalState, instrument_physical_state_for_mask_with};
+
+    #[test]
+    fn focus_transition_after_key_reads_is_inconclusive() {
+        let mut foreground_checks = 0;
+        let mut key_reads = 0;
+        let state = instrument_physical_state_for_mask_with(
+            42,
+            1,
+            |target| {
+                assert_eq!(target, 42);
+                foreground_checks += 1;
+                foreground_checks == 1
+            },
+            |_| Some(()),
+            |_, _| Some([0; super::PHYSICAL_INSTRUMENT_SCAN_CODES.len()]),
+            |index, _| {
+                assert_eq!(index, 0);
+                key_reads += 1;
+                i16::MIN
+            },
+        );
+
+        assert_eq!(state, InstrumentPhysicalState::Inconclusive);
+        assert_eq!(foreground_checks, 2);
+        assert_eq!(key_reads, 1);
     }
 }

--- a/rust/crates/sky_dispatch_win32/src/input/raw.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/raw.rs
@@ -116,6 +116,7 @@ pub fn send_input_raw_with_clock(
     }
     #[cfg(windows)]
     {
+        use windows_sys::Win32::Foundation::SetLastError;
         use windows_sys::Win32::UI::Input::KeyboardAndMouse::{INPUT, SendInput};
 
         if scan_codes.is_empty() {
@@ -144,6 +145,9 @@ pub fn send_input_raw_with_clock(
         let requested = len as u32;
         let cb_size = std::mem::size_of::<INPUT>() as i32;
 
+        // Clear stale thread-local state before the authoritative start sample;
+        // the reset must not sit inside the measured SendInput envelope.
+        unsafe { SetLastError(0) };
         let started_ticks = match clock.now() {
             Ok(ticks) => ticks,
             Err(timing_error) => {
@@ -191,5 +195,27 @@ pub fn send_input_raw_with_clock(
             win32_error: 0,
             timing_error,
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    #[test]
+    fn clears_last_error_before_authoritative_start_sample() {
+        let source = include_str!("raw.rs").replace("\r\n", "\n");
+        let sender = source
+            .split("pub fn send_input_raw_with_clock")
+            .nth(1)
+            .expect("raw sender implementation");
+        let reset = sender
+            .find("SetLastError(0)")
+            .expect("raw sender last-error reset");
+        let start = sender
+            .find("let started_ticks = match clock.now()")
+            .expect("raw sender authoritative start sample");
+        let syscall = sender.find("SendInput(").expect("raw SendInput call");
+
+        assert!(reset < start);
+        assert!(start < syscall);
     }
 }


### PR DESCRIPTION
Closes #198
Parent campaign: #194

## Coordinator status

W3 reviewed and approved for integration.

Commit:
`25548caf5a79eb011b9379f1b1b2c3bfc9eb3629`

Base:
`a20589256ad7b834502398695cf5bb35dc6d46e9`

## Scope

- clear raw SendInput last-error state before the authoritative start sample;
- post-validate exact foreground identity after physical key-state snapshot;
- return Inconclusive if target focus changes across the snapshot;
- add deterministic/source-order regression coverage.

## Explicit non-goals preserved

No cleanup-delay changes, no musical SendInput retry, no 2 ms drain, no focus policy change, no PID/GA_ROOT fallback, no timing/MMCSS/wait tuning, and no key-profile work.

## Local qualification

- sky_dispatch_win32: 224/224 PASS
- RT no-allocation: 20/20 PASS
- cargo xtask check static: PASS
- cargo xtask check rust: PASS

No real SendInput was issued.

W4 (#199) remains blocked until this PR is merged.