### PR TITLE
feat(rt): add frozen instrument key profiles

### DIFF
--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -3487,6 +3487,7 @@ impl NativePlaybackService {
             priority: PriorityOptions {
                 mode: PriorityMode::Auto,
             },
+            instrument_key_profile: None,
             #[cfg(feature = "tauri-test")]
             startup_ordering_hook: None,
             #[cfg(feature = "tauri-test")]

--- a/rust/crates/sky_dispatch_win32/src/input.rs
+++ b/rust/crates/sky_dispatch_win32/src/input.rs
@@ -4,6 +4,7 @@ mod down_transaction;
 mod outcome;
 mod packet;
 mod physical;
+pub mod profile;
 mod raw;
 mod scan_code;
 mod tracked;
@@ -32,6 +33,10 @@ pub use packet::{
     send_prepared_physical_packet_view_once_with_start_and_cutoff,
 };
 pub use physical::is_scan_code_physically_down;
+pub use profile::{
+    InstrumentKeyProfile, InstrumentKeyProfileError, InstrumentKeyProfileSpec,
+    MaterializedInstrumentKeyProfile, PhysicalKey, SUPPORTED_NON_EXTENDED_SCAN_CODES,
+};
 pub use raw::{send_input_raw, send_input_raw_with_clock};
 pub use scan_code::{
     FULL_INSTRUMENT_MASK, PHYSICAL_INSTRUMENT_SCAN_CODES, SKY_PLAYER_SIGNATURE,

--- a/rust/crates/sky_dispatch_win32/src/input/outcome.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/outcome.rs
@@ -1,3 +1,4 @@
+use super::profile::MaterializedInstrumentKeyProfile;
 use super::scan_code::scan_codes_from_mask;
 use crate::clock::QpcTicks;
 use smallvec::SmallVec;
@@ -168,6 +169,14 @@ impl ReleaseAllOutcome {
 
     pub fn stuck_keys(&self) -> Vec<u16> {
         scan_codes_from_mask(self.stuck_mask).into_iter().collect()
+    }
+
+    pub fn attempted_with_profile(&self, profile: &MaterializedInstrumentKeyProfile) -> Vec<u16> {
+        profile.scan_codes_from_mask(self.attempted_mask).into_vec()
+    }
+
+    pub fn stuck_keys_with_profile(&self, profile: &MaterializedInstrumentKeyProfile) -> Vec<u16> {
+        profile.scan_codes_from_mask(self.stuck_mask).into_vec()
     }
 }
 

--- a/rust/crates/sky_dispatch_win32/src/input/packet.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/packet.rs
@@ -2,6 +2,7 @@ use super::outcome::{
     PacketPreparationError, PacketRetryReason, PhysicalPacket, PlatformSendResult, SendEvidence,
     SendTransactionOutcome, SendTransactionStatus, classify_send_status,
 };
+use super::profile::MaterializedInstrumentKeyProfile;
 use super::scan_code::{
     FULL_INSTRUMENT_MASK, PHYSICAL_INSTRUMENT_SCAN_CODES, SKY_PLAYER_SIGNATURE,
 };
@@ -60,6 +61,20 @@ impl std::fmt::Debug for PreparedPhysicalPacket {
 
 impl PreparedPhysicalPacket {
     pub fn try_new(packet: PhysicalPacket) -> Result<Self, PacketPreparationError> {
+        Self::try_new_internal(packet, None)
+    }
+
+    pub fn try_new_with_profile(
+        packet: PhysicalPacket,
+        profile: &MaterializedInstrumentKeyProfile,
+    ) -> Result<Self, PacketPreparationError> {
+        Self::try_new_internal(packet, Some(profile))
+    }
+
+    fn try_new_internal(
+        packet: PhysicalPacket,
+        profile: Option<&MaterializedInstrumentKeyProfile>,
+    ) -> Result<Self, PacketPreparationError> {
         let overlap_mask = packet.up_mask & packet.down_mask;
         if overlap_mask != 0 {
             return Err(PacketPreparationError::OverlappingDirections { overlap_mask });
@@ -71,7 +86,7 @@ impl PreparedPhysicalPacket {
             return Err(PacketPreparationError::Empty);
         }
         #[cfg(windows)]
-        let (inputs, length) = build_inputs(packet);
+        let (inputs, length) = build_inputs(packet, profile);
         #[cfg(not(windows))]
         let length = packet.event_count() as usize;
         Ok(Self {
@@ -262,7 +277,7 @@ impl PreparedTaggedCalibrationPacket {
 const MAX_SCAN_CODE: usize = 0x36;
 
 #[cfg(windows)]
-const fn create_keyboard_input(
+pub(crate) const fn create_keyboard_input(
     scan_code: u16,
     key_up: bool,
 ) -> windows_sys::Win32::UI::Input::KeyboardAndMouse::INPUT {
@@ -318,6 +333,7 @@ fn valid_packet(packet: PhysicalPacket) -> bool {
 #[cfg(windows)]
 fn build_inputs(
     packet: PhysicalPacket,
+    profile: Option<&MaterializedInstrumentKeyProfile>,
 ) -> (
     [MaybeUninit<windows_sys::Win32::UI::Input::KeyboardAndMouse::INPUT>; MAX_PACKET_EVENTS],
     usize,
@@ -327,16 +343,26 @@ fn build_inputs(
     let mut inputs: [MaybeUninit<INPUT>; MAX_PACKET_EVENTS] =
         [const { MaybeUninit::uninit() }; MAX_PACKET_EVENTS];
     let mut length = 0usize;
-    let mut append_mask = |mut mask: u16, templates: &[INPUT; MAX_SCAN_CODE]| {
+    let mut append_mask = |mut mask: u16, templates: &[INPUT; MAX_SCAN_CODE], down: bool| {
         while mask != 0 {
             let slot = mask.trailing_zeros() as usize;
             mask &= mask - 1;
-            inputs[length].write(templates[PHYSICAL_INSTRUMENT_SCAN_CODES[slot] as usize]);
+            let input = match profile {
+                Some(profile) => {
+                    if down {
+                        profile.down_template(slot)
+                    } else {
+                        profile.up_template(slot)
+                    }
+                }
+                None => templates[PHYSICAL_INSTRUMENT_SCAN_CODES[slot] as usize],
+            };
+            inputs[length].write(input);
             length += 1;
         }
     };
-    append_mask(packet.up_mask, &UP_TEMPLATES);
-    append_mask(packet.down_mask, &DOWN_TEMPLATES);
+    append_mask(packet.up_mask, &UP_TEMPLATES, false);
+    append_mask(packet.down_mask, &DOWN_TEMPLATES, true);
     (inputs, length)
 }
 
@@ -1027,21 +1053,6 @@ pub fn send_physical_packet_once_with_clock(
     send_physical_packet_once_impl(packet, |packet| run_send_attempt(packet, clock, None))
 }
 
-/// One packet transaction using a start boundary sampled by the caller after
-/// all control, focus, target, and lease gates have passed.
-pub fn send_physical_packet_once_with_start(
-    packet: PhysicalPacket,
-    clock: QpcClock,
-    started_ticks: QpcTicks,
-) -> SendTransactionOutcome {
-    if packet.event_count() == 0 || !valid_packet(packet) {
-        return invalid_packet_outcome(packet);
-    }
-    send_physical_packet_once_impl(packet, |packet| {
-        run_send_attempt(packet, clock, Some(started_ticks))
-    })
-}
-
 /// One packet transaction using a payload built before the final admission
 /// boundary and a caller-owned authoritative start timestamp.
 pub fn send_prepared_physical_packet_once_with_start(
@@ -1635,7 +1646,7 @@ mod tests {
     fn input_builder_places_all_up_events_before_down_events() {
         use windows_sys::Win32::UI::Input::KeyboardAndMouse::KEYEVENTF_KEYUP;
 
-        let (inputs, len) = build_inputs(PhysicalPacket::new(0b1, 0b10));
+        let (inputs, len) = build_inputs(PhysicalPacket::new(0b1, 0b10), None);
         assert_eq!(len, 2);
         unsafe {
             let first = inputs[0].assume_init_ref();
@@ -1644,6 +1655,69 @@ mod tests {
             assert_ne!(first.Anonymous.ki.dwFlags & KEYEVENTF_KEYUP, 0);
             assert_eq!(second.Anonymous.ki.wScan, 0x16);
             assert_eq!(second.Anonymous.ki.dwFlags & KEYEVENTF_KEYUP, 0);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn profile_templates_preserve_default_and_allow_non_canonical_remap() {
+        use super::super::profile::{InstrumentKeyProfile, InstrumentKeyProfileSpec, PhysicalKey};
+
+        let canonical = MaterializedInstrumentKeyProfile::canonical();
+        for slot in 0..MAX_KEYS {
+            let expected_down = DOWN_TEMPLATES[PHYSICAL_INSTRUMENT_SCAN_CODES[slot] as usize];
+            let expected_up = UP_TEMPLATES[PHYSICAL_INSTRUMENT_SCAN_CODES[slot] as usize];
+            let actual_down = canonical.down_template(slot);
+            let actual_up = canonical.up_template(slot);
+            assert_eq!(actual_down.r#type, expected_down.r#type);
+            assert_eq!(actual_up.r#type, expected_up.r#type);
+            unsafe {
+                assert_eq!(actual_down.Anonymous.ki.wVk, expected_down.Anonymous.ki.wVk);
+                assert_eq!(
+                    actual_down.Anonymous.ki.wScan,
+                    expected_down.Anonymous.ki.wScan
+                );
+                assert_eq!(
+                    actual_down.Anonymous.ki.dwFlags,
+                    expected_down.Anonymous.ki.dwFlags
+                );
+                assert_eq!(
+                    actual_down.Anonymous.ki.time,
+                    expected_down.Anonymous.ki.time
+                );
+                assert_eq!(
+                    actual_down.Anonymous.ki.dwExtraInfo,
+                    expected_down.Anonymous.ki.dwExtraInfo
+                );
+                assert_eq!(actual_up.Anonymous.ki.wVk, expected_up.Anonymous.ki.wVk);
+                assert_eq!(actual_up.Anonymous.ki.wScan, expected_up.Anonymous.ki.wScan);
+                assert_eq!(
+                    actual_up.Anonymous.ki.dwFlags,
+                    expected_up.Anonymous.ki.dwFlags
+                );
+                assert_eq!(actual_up.Anonymous.ki.time, expected_up.Anonymous.ki.time);
+                assert_eq!(
+                    actual_up.Anonymous.ki.dwExtraInfo,
+                    expected_up.Anonymous.ki.dwExtraInfo
+                );
+            }
+        }
+
+        let mut spec = InstrumentKeyProfileSpec::canonical();
+        spec.keys[0] = PhysicalKey {
+            scan_code: 0x02,
+            extended: false,
+        };
+        let remapped = MaterializedInstrumentKeyProfile::from_validated(
+            InstrumentKeyProfile::try_from_spec(spec).expect("remapped profile"),
+        );
+        let (inputs, length) = build_inputs(PhysicalPacket::new(0b001, 0b010), Some(&remapped));
+        assert_eq!(length, 2);
+        unsafe {
+            let up = inputs[0].assume_init_ref();
+            let down = inputs[1].assume_init_ref();
+            assert_eq!(up.Anonymous.ki.wScan, 0x02);
+            assert_eq!(down.Anonymous.ki.wScan, 0x16);
         }
     }
 

--- a/rust/crates/sky_dispatch_win32/src/input/physical.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/physical.rs
@@ -448,8 +448,12 @@ pub fn is_scan_code_physically_down(scan_code: u16, target_hwnd: isize) -> Optio
 #[cfg(test)]
 mod tests {
     use super::{
-        InstrumentPhysicalState, classify_logical_async_key_states,
-        instrument_physical_state_for_mask_with,
+        InstrumentPhysicalState, LogicalInstrumentPhysicalState, classify_logical_async_key_states,
+        instrument_logical_physical_state_for_mask_with, instrument_physical_state_for_mask_with,
+    };
+    use crate::input::{
+        InstrumentKeyProfile, InstrumentKeyProfileSpec, MaterializedInstrumentKeyProfile,
+        PhysicalKey,
     };
 
     #[test]
@@ -487,5 +491,75 @@ mod tests {
             classify_logical_async_key_states(0x7fff, &key_states),
             super::LogicalInstrumentPhysicalState::Held((1 << 0) | (1 << 14))
         );
+    }
+
+    #[test]
+    fn profile_aware_snapshot_maps_non_canonical_key_to_logical_slot() {
+        let mut spec = InstrumentKeyProfileSpec::canonical();
+        spec.keys[0] = PhysicalKey {
+            scan_code: 0x02,
+            extended: false,
+        };
+        let profile = MaterializedInstrumentKeyProfile::from_validated(
+            InstrumentKeyProfile::try_from_spec(spec).expect("profile"),
+        );
+        let mut mapped_scan_code = None;
+        let mut queried_virtual_key = None;
+        let state = instrument_logical_physical_state_for_mask_with(
+            &profile,
+            42,
+            1,
+            |_| true,
+            |_| Some(()),
+            |_, profile, requested_mask| {
+                assert_eq!(requested_mask, 1);
+                mapped_scan_code = Some(profile.physical_key(0).scan_code);
+                let mut virtual_keys = [0; super::MAX_KEYS];
+                virtual_keys[0] = 123;
+                Some(virtual_keys)
+            },
+            |index, virtual_key| {
+                assert_eq!(index, 0);
+                queried_virtual_key = Some(virtual_key);
+                i16::MIN
+            },
+        );
+
+        assert_eq!(mapped_scan_code, Some(0x02));
+        assert_eq!(queried_virtual_key, Some(123));
+        assert_eq!(state, LogicalInstrumentPhysicalState::Held(1));
+    }
+
+    #[test]
+    fn profile_aware_snapshot_focus_race_is_inconclusive() {
+        let profile = MaterializedInstrumentKeyProfile::canonical();
+        let mut foreground_checks = 0;
+        let mut key_reads = 0;
+        let state = instrument_logical_physical_state_for_mask_with(
+            &profile,
+            42,
+            1,
+            |target| {
+                assert_eq!(target, 42);
+                foreground_checks += 1;
+                foreground_checks == 1
+            },
+            |_| Some(()),
+            |_, _, _| {
+                let mut virtual_keys = [0; super::MAX_KEYS];
+                virtual_keys[0] = 123;
+                Some(virtual_keys)
+            },
+            |index, virtual_key| {
+                assert_eq!(index, 0);
+                assert_eq!(virtual_key, 123);
+                key_reads += 1;
+                i16::MIN
+            },
+        );
+
+        assert_eq!(state, LogicalInstrumentPhysicalState::Inconclusive);
+        assert_eq!(foreground_checks, 2);
+        assert_eq!(key_reads, 1);
     }
 }

--- a/rust/crates/sky_dispatch_win32/src/input/physical.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/physical.rs
@@ -1,5 +1,9 @@
-use super::scan_code::{FULL_INSTRUMENT_MASK, PHYSICAL_INSTRUMENT_SCAN_CODES, key_mask};
+use super::profile::MaterializedInstrumentKeyProfile;
+#[cfg(test)]
+use super::scan_code::PHYSICAL_INSTRUMENT_SCAN_CODES;
+use super::scan_code::{FULL_INSTRUMENT_MASK, key_mask};
 use crate::focus::foreground_window_matches;
+use sky_dispatch_core::model::MAX_KEYS;
 use smallvec::SmallVec;
 
 #[cfg(windows)]
@@ -36,6 +40,7 @@ pub(crate) fn keyboard_context_for_target(target_hwnd: isize) -> Option<TargetKe
 }
 
 #[cfg(windows)]
+#[cfg(test)]
 pub(crate) fn map_instrument_virtual_keys(
     context: &TargetKeyboardContext,
     requested_mask: u16,
@@ -66,6 +71,17 @@ pub(crate) fn map_instrument_virtual_keys(
 pub enum InstrumentPhysicalState {
     AllUp,
     Held(SmallVec<[u16; 15]>),
+    Inconclusive,
+}
+
+/// Logical-mask physical evidence used by an armed session. The legacy
+/// `InstrumentPhysicalState` remains available for canonical-only callers and
+/// for the public preflight error shape; session reconciliation never maps
+/// custom keys through the canonical scan-code registry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LogicalInstrumentPhysicalState {
+    AllUp,
+    Held(u16),
     Inconclusive,
 }
 
@@ -102,6 +118,7 @@ impl CleanupVerification {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn reconcile_release_observation(
     requested_mask: u16,
     transport_confirmed_mask: u16,
@@ -127,6 +144,31 @@ pub(crate) fn reconcile_release_observation(
     }
 }
 
+pub(crate) fn reconcile_logical_release_observation(
+    requested_mask: u16,
+    transport_confirmed_mask: u16,
+    physical_state: LogicalInstrumentPhysicalState,
+) -> ReconciledRelease {
+    match physical_state {
+        LogicalInstrumentPhysicalState::AllUp
+            if transport_confirmed_mask & requested_mask == requested_mask =>
+        {
+            ReconciledRelease::VerifiedAllUp
+        }
+        LogicalInstrumentPhysicalState::AllUp => {
+            ReconciledRelease::Inconclusive(requested_mask & !transport_confirmed_mask)
+        }
+        LogicalInstrumentPhysicalState::Held(held_mask) => {
+            ReconciledRelease::Held(held_mask & requested_mask)
+        }
+        LogicalInstrumentPhysicalState::Inconclusive => {
+            let unresolved = requested_mask & !transport_confirmed_mask;
+            ReconciledRelease::Inconclusive(unresolved)
+        }
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn classify_async_key_states(
     requested_mask: u16,
     key_states: &[i16; 15],
@@ -150,6 +192,26 @@ pub(crate) fn classify_async_key_states(
     }
 }
 
+pub(crate) fn classify_logical_async_key_states(
+    requested_mask: u16,
+    key_states: &[i16; MAX_KEYS],
+) -> LogicalInstrumentPhysicalState {
+    if requested_mask & !FULL_INSTRUMENT_MASK != 0 {
+        return LogicalInstrumentPhysicalState::Inconclusive;
+    }
+    let mut held_mask = 0u16;
+    for (index, &state) in key_states.iter().enumerate() {
+        if requested_mask & (1u16 << index) != 0 && (state as u16 & 0x8000) != 0 {
+            held_mask |= 1u16 << index;
+        }
+    }
+    if held_mask == 0 {
+        LogicalInstrumentPhysicalState::AllUp
+    } else {
+        LogicalInstrumentPhysicalState::Held(held_mask)
+    }
+}
+
 fn query_async_key_state(_index: usize, virtual_key: i32) -> i16 {
     #[cfg(windows)]
     {
@@ -164,6 +226,7 @@ fn query_async_key_state(_index: usize, virtual_key: i32) -> i16 {
     }
 }
 
+#[cfg(test)]
 fn instrument_physical_state_for_mask_with<
     Context,
     Foreground,
@@ -213,6 +276,114 @@ where
     classify_async_key_states(requested_mask, &key_states)
 }
 
+#[cfg(windows)]
+pub(crate) fn map_profile_virtual_keys(
+    context: &TargetKeyboardContext,
+    profile: &MaterializedInstrumentKeyProfile,
+    requested_mask: u16,
+) -> Option<[i32; MAX_KEYS]> {
+    let mut virtual_keys = [0i32; MAX_KEYS];
+    for (slot, virtual_key_slot) in virtual_keys.iter_mut().enumerate() {
+        if requested_mask & (1u16 << slot) == 0 {
+            continue;
+        }
+        let key = profile.physical_key(slot);
+        if key.extended {
+            return None;
+        }
+        // SAFETY: MapVirtualKeyExW reads only the validated scan-code scalar
+        // and borrowed HKL handle; it does not retain either value.
+        let virtual_key = unsafe {
+            windows_sys::Win32::UI::Input::KeyboardAndMouse::MapVirtualKeyExW(
+                u32::from(key.scan_code),
+                windows_sys::Win32::UI::Input::KeyboardAndMouse::MAPVK_VSC_TO_VK_EX,
+                context.layout,
+            )
+        };
+        if virtual_key == 0 {
+            return None;
+        }
+        *virtual_key_slot = virtual_key as i32;
+    }
+    Some(virtual_keys)
+}
+
+fn instrument_logical_physical_state_for_mask_with<
+    Context,
+    Foreground,
+    ContextResolver,
+    VirtualKeyMapper,
+    KeyStateQuery,
+>(
+    profile: &MaterializedInstrumentKeyProfile,
+    target_hwnd: isize,
+    requested_mask: u16,
+    mut foreground_matches: Foreground,
+    mut context_for_target: ContextResolver,
+    mut map_virtual_keys: VirtualKeyMapper,
+    mut query_key_state: KeyStateQuery,
+) -> LogicalInstrumentPhysicalState
+where
+    Foreground: FnMut(isize) -> bool,
+    ContextResolver: FnMut(isize) -> Option<Context>,
+    VirtualKeyMapper:
+        FnMut(&Context, &MaterializedInstrumentKeyProfile, u16) -> Option<[i32; MAX_KEYS]>,
+    KeyStateQuery: FnMut(usize, i32) -> i16,
+{
+    if target_hwnd == 0 || !foreground_matches(target_hwnd) {
+        return LogicalInstrumentPhysicalState::Inconclusive;
+    }
+    if requested_mask == 0 {
+        return LogicalInstrumentPhysicalState::AllUp;
+    }
+    if requested_mask & !FULL_INSTRUMENT_MASK != 0 {
+        return LogicalInstrumentPhysicalState::Inconclusive;
+    }
+
+    let Some(context) = context_for_target(target_hwnd) else {
+        return LogicalInstrumentPhysicalState::Inconclusive;
+    };
+    let Some(virtual_keys) = map_virtual_keys(&context, profile, requested_mask) else {
+        return LogicalInstrumentPhysicalState::Inconclusive;
+    };
+    let mut key_states = [0i16; MAX_KEYS];
+    for (index, &virtual_key) in virtual_keys.iter().enumerate() {
+        if requested_mask & (1u16 << index) == 0 {
+            continue;
+        }
+        key_states[index] = query_key_state(index, virtual_key);
+    }
+    if !foreground_matches(target_hwnd) {
+        return LogicalInstrumentPhysicalState::Inconclusive;
+    }
+    classify_logical_async_key_states(requested_mask, &key_states)
+}
+
+pub(crate) fn instrument_logical_physical_state_for_mask(
+    profile: &MaterializedInstrumentKeyProfile,
+    target_hwnd: isize,
+    requested_mask: u16,
+) -> LogicalInstrumentPhysicalState {
+    #[cfg(windows)]
+    {
+        instrument_logical_physical_state_for_mask_with(
+            profile,
+            target_hwnd,
+            requested_mask,
+            foreground_window_matches,
+            keyboard_context_for_target,
+            map_profile_virtual_keys,
+            query_async_key_state,
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = (profile, target_hwnd, requested_mask);
+        LogicalInstrumentPhysicalState::Inconclusive
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn instrument_physical_state_for_mask(
     target_hwnd: isize,
     requested_mask: u16,
@@ -276,7 +447,10 @@ pub fn is_scan_code_physically_down(scan_code: u16, target_hwnd: isize) -> Optio
 
 #[cfg(test)]
 mod tests {
-    use super::{InstrumentPhysicalState, instrument_physical_state_for_mask_with};
+    use super::{
+        InstrumentPhysicalState, classify_logical_async_key_states,
+        instrument_physical_state_for_mask_with,
+    };
 
     #[test]
     fn focus_transition_after_key_reads_is_inconclusive() {
@@ -302,5 +476,16 @@ mod tests {
         assert_eq!(state, InstrumentPhysicalState::Inconclusive);
         assert_eq!(foreground_checks, 2);
         assert_eq!(key_reads, 1);
+    }
+
+    #[test]
+    fn logical_classification_preserves_profile_slot_identity() {
+        let mut key_states = [0i16; super::MAX_KEYS];
+        key_states[0] = i16::MIN;
+        key_states[14] = i16::MIN;
+        assert_eq!(
+            classify_logical_async_key_states(0x7fff, &key_states),
+            super::LogicalInstrumentPhysicalState::Held((1 << 0) | (1 << 14))
+        );
     }
 }

--- a/rust/crates/sky_dispatch_win32/src/input/profile.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/profile.rs
@@ -1,0 +1,251 @@
+use sky_dispatch_core::model::MAX_KEYS;
+use smallvec::SmallVec;
+
+/// A physical keyboard identity at the Win32 input boundary.
+///
+/// W4 accepts only non-extended Set-1 make codes, but the flag is retained in
+/// the value so a future extended-key work order cannot infer semantics from a
+/// scan-code number or keyboard layout.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PhysicalKey {
+    pub scan_code: u16,
+    pub extended: bool,
+}
+
+/// The finite W4 domain: ordinary non-extended main-key Set-1 make codes.
+/// Control, modifier, lock, function, keypad, navigation, and E0/E1 keys are
+/// intentionally outside this first profile contract.
+pub const SUPPORTED_NON_EXTENDED_SCAN_CODES: &[u16] = &[
+    0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x10, 0x11, 0x12, 0x13,
+    0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25,
+    0x26, 0x27, 0x28, 0x29, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x39,
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InstrumentKeyProfileSpec {
+    pub keys: [PhysicalKey; MAX_KEYS],
+}
+
+impl InstrumentKeyProfileSpec {
+    pub fn canonical() -> Self {
+        Self {
+            keys: std::array::from_fn(|slot| PhysicalKey {
+                scan_code: super::scan_code::PHYSICAL_INSTRUMENT_SCAN_CODES[slot],
+                extended: false,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum InstrumentKeyProfileError {
+    #[error("instrument profile scan code is zero at logical slot {slot}")]
+    ZeroScanCode { slot: usize },
+    #[error("instrument profile uses an extended key at logical slot {slot}")]
+    ExtendedKey { slot: usize, scan_code: u16 },
+    #[error("instrument profile uses an E0/E1 prefix at logical slot {slot}: {scan_code:#x}")]
+    ExtendedPrefix { slot: usize, scan_code: u16 },
+    #[error(
+        "instrument profile scan code is outside the W4 supported domain at logical slot {slot}: {scan_code:#x}"
+    )]
+    UnsupportedScanCode { slot: usize, scan_code: u16 },
+    #[error(
+        "instrument profile duplicates scan code {scan_code:#x} at logical slot {slot} (already used at slot {first_slot})"
+    )]
+    DuplicateScanCode {
+        slot: usize,
+        first_slot: usize,
+        scan_code: u16,
+    },
+}
+
+/// A validated, fixed-capacity profile. Its fields are private so callers
+/// cannot construct a value that bypasses admission validation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InstrumentKeyProfile {
+    keys: [PhysicalKey; MAX_KEYS],
+}
+
+impl InstrumentKeyProfile {
+    pub fn try_from_spec(
+        spec: InstrumentKeyProfileSpec,
+    ) -> Result<Self, InstrumentKeyProfileError> {
+        for (slot, key) in spec.keys.iter().copied().enumerate() {
+            if key.scan_code == 0 {
+                return Err(InstrumentKeyProfileError::ZeroScanCode { slot });
+            }
+            if key.scan_code == 0xe0 || key.scan_code == 0xe1 {
+                return Err(InstrumentKeyProfileError::ExtendedPrefix {
+                    slot,
+                    scan_code: key.scan_code,
+                });
+            }
+            if key.extended {
+                return Err(InstrumentKeyProfileError::ExtendedKey {
+                    slot,
+                    scan_code: key.scan_code,
+                });
+            }
+            if !SUPPORTED_NON_EXTENDED_SCAN_CODES.contains(&key.scan_code) {
+                return Err(InstrumentKeyProfileError::UnsupportedScanCode {
+                    slot,
+                    scan_code: key.scan_code,
+                });
+            }
+            if let Some(first_slot) = spec.keys[..slot]
+                .iter()
+                .position(|prior| prior.scan_code == key.scan_code)
+            {
+                return Err(InstrumentKeyProfileError::DuplicateScanCode {
+                    slot,
+                    first_slot,
+                    scan_code: key.scan_code,
+                });
+            }
+        }
+        Ok(Self { keys: spec.keys })
+    }
+
+    pub fn canonical() -> Self {
+        Self::try_from_spec(InstrumentKeyProfileSpec::canonical())
+            .expect("the canonical instrument profile must be valid")
+    }
+
+    pub(crate) fn keys(&self) -> &[PhysicalKey; MAX_KEYS] {
+        &self.keys
+    }
+}
+
+/// The one session-owned Win32 profile. Template arrays are built once during
+/// session admission and are never rebuilt on the precision path.
+pub struct MaterializedInstrumentKeyProfile {
+    keys: [PhysicalKey; MAX_KEYS],
+    #[cfg(windows)]
+    down_templates: [windows_sys::Win32::UI::Input::KeyboardAndMouse::INPUT; MAX_KEYS],
+    #[cfg(windows)]
+    up_templates: [windows_sys::Win32::UI::Input::KeyboardAndMouse::INPUT; MAX_KEYS],
+}
+
+impl std::fmt::Debug for MaterializedInstrumentKeyProfile {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MaterializedInstrumentKeyProfile")
+            .field("keys", &self.keys)
+            .finish()
+    }
+}
+
+impl MaterializedInstrumentKeyProfile {
+    pub fn from_validated(profile: InstrumentKeyProfile) -> Self {
+        let keys = *profile.keys();
+        #[cfg(windows)]
+        {
+            let mut down_templates = [super::packet::create_keyboard_input(0, false); MAX_KEYS];
+            let mut up_templates = [super::packet::create_keyboard_input(0, true); MAX_KEYS];
+            for slot in 0..MAX_KEYS {
+                down_templates[slot] =
+                    super::packet::create_keyboard_input(keys[slot].scan_code, false);
+                up_templates[slot] =
+                    super::packet::create_keyboard_input(keys[slot].scan_code, true);
+            }
+            Self {
+                keys,
+                down_templates,
+                up_templates,
+            }
+        }
+        #[cfg(not(windows))]
+        Self { keys }
+    }
+
+    pub fn canonical() -> Self {
+        Self::from_validated(InstrumentKeyProfile::canonical())
+    }
+
+    pub fn physical_key(&self, slot: usize) -> PhysicalKey {
+        self.keys[slot]
+    }
+
+    pub(crate) fn logical_mask_for_scan_codes(&self, scan_codes: &[u16]) -> Option<u16> {
+        scan_codes.iter().try_fold(0u16, |mask, scan_code| {
+            self.keys
+                .iter()
+                .position(|key| key.scan_code == *scan_code && !key.extended)
+                .map(|slot| mask | (1u16 << slot))
+        })
+    }
+
+    pub(crate) fn scan_codes_from_mask(&self, mask: u16) -> SmallVec<[u16; MAX_KEYS]> {
+        let mut scan_codes = SmallVec::new();
+        for slot in 0..MAX_KEYS {
+            if mask & (1u16 << slot) != 0 {
+                scan_codes.push(self.keys[slot].scan_code);
+            }
+        }
+        scan_codes
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn down_template(
+        &self,
+        slot: usize,
+    ) -> windows_sys::Win32::UI::Input::KeyboardAndMouse::INPUT {
+        self.down_templates[slot]
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn up_template(
+        &self,
+        slot: usize,
+    ) -> windows_sys::Win32::UI::Input::KeyboardAndMouse::INPUT {
+        self.up_templates[slot]
+    }
+}
+
+impl Default for MaterializedInstrumentKeyProfile {
+    fn default() -> Self {
+        Self::canonical()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        InstrumentKeyProfile, InstrumentKeyProfileError, InstrumentKeyProfileSpec, PhysicalKey,
+    };
+
+    #[test]
+    fn accepts_non_canonical_main_key() {
+        let mut spec = InstrumentKeyProfileSpec::canonical();
+        spec.keys[0] = PhysicalKey {
+            scan_code: 0x02,
+            extended: false,
+        };
+        let profile = InstrumentKeyProfile::try_from_spec(spec).expect("profile");
+        assert_eq!(profile.keys()[0].scan_code, 0x02);
+    }
+
+    #[test]
+    fn rejects_duplicate_extended_and_out_of_domain_keys() {
+        let mut duplicate = InstrumentKeyProfileSpec::canonical();
+        duplicate.keys[1] = duplicate.keys[0];
+        assert!(matches!(
+            InstrumentKeyProfile::try_from_spec(duplicate),
+            Err(InstrumentKeyProfileError::DuplicateScanCode { .. })
+        ));
+
+        let mut extended = InstrumentKeyProfileSpec::canonical();
+        extended.keys[0].extended = true;
+        assert!(matches!(
+            InstrumentKeyProfile::try_from_spec(extended),
+            Err(InstrumentKeyProfileError::ExtendedKey { .. })
+        ));
+
+        let mut unsupported = InstrumentKeyProfileSpec::canonical();
+        unsupported.keys[0].scan_code = 0x3a;
+        assert!(matches!(
+            InstrumentKeyProfile::try_from_spec(unsupported),
+            Err(InstrumentKeyProfileError::UnsupportedScanCode { .. })
+        ));
+    }
+}

--- a/rust/crates/sky_dispatch_win32/src/input/profile.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/profile.rs
@@ -212,7 +212,9 @@ impl Default for MaterializedInstrumentKeyProfile {
 mod tests {
     use super::{
         InstrumentKeyProfile, InstrumentKeyProfileError, InstrumentKeyProfileSpec, PhysicalKey,
+        SUPPORTED_NON_EXTENDED_SCAN_CODES,
     };
+    use sky_dispatch_core::model::MAX_KEYS;
 
     #[test]
     fn accepts_non_canonical_main_key() {
@@ -247,5 +249,43 @@ mod tests {
             InstrumentKeyProfile::try_from_spec(unsupported),
             Err(InstrumentKeyProfileError::UnsupportedScanCode { .. })
         ));
+    }
+
+    #[test]
+    fn supported_domain_is_exact_unique_and_exhaustively_validated() {
+        const EXPECTED: [u16; 48] = [
+            0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x10, 0x11,
+            0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1e, 0x1f, 0x20, 0x21,
+            0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+            0x31, 0x32, 0x33, 0x34, 0x35, 0x39,
+        ];
+        assert_eq!(SUPPORTED_NON_EXTENDED_SCAN_CODES, EXPECTED);
+        let mut sorted = EXPECTED;
+        sorted.sort_unstable();
+        assert!(sorted.windows(2).all(|pair| pair[0] != pair[1]));
+        assert!(EXPECTED.iter().all(|scan_code| *scan_code != 0));
+
+        for &scan_code in &EXPECTED {
+            let mut keys = [PhysicalKey {
+                scan_code: EXPECTED[0],
+                extended: false,
+            }; MAX_KEYS];
+            keys[0] = PhysicalKey {
+                scan_code,
+                extended: false,
+            };
+            let mut slot = 1;
+            for &other in &EXPECTED {
+                if other != scan_code && slot < MAX_KEYS {
+                    keys[slot] = PhysicalKey {
+                        scan_code: other,
+                        extended: false,
+                    };
+                    slot += 1;
+                }
+            }
+            assert_eq!(slot, MAX_KEYS);
+            assert!(InstrumentKeyProfile::try_from_spec(InstrumentKeyProfileSpec { keys }).is_ok());
+        }
     }
 }

--- a/rust/crates/sky_dispatch_win32/src/input/tests/cleanup.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tests/cleanup.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::input::{
+    InstrumentKeyProfile, InstrumentKeyProfileSpec, MaterializedInstrumentKeyProfile, PhysicalKey,
+};
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn partial_transport_plus_physical_all_up_is_inconclusive() {
@@ -138,6 +142,49 @@ fn cleanup_fsm_executes_tracked_then_verifies_physical_all_up() {
     assert!(outcome.released_successfully);
     assert_eq!(state.active_mask, 0);
     assert_eq!(state.failed_release_mask, 0);
+}
+
+#[test]
+fn full_cleanup_emits_custom_profile_keys_from_logical_mask() {
+    let mut spec = InstrumentKeyProfileSpec::canonical();
+    for (slot, scan_code) in super::super::profile::SUPPORTED_NON_EXTENDED_SCAN_CODES
+        .iter()
+        .copied()
+        .take(15)
+        .enumerate()
+    {
+        spec.keys[slot] = PhysicalKey {
+            scan_code,
+            extended: false,
+        };
+    }
+    let profile = MaterializedInstrumentKeyProfile::from_validated(
+        InstrumentKeyProfile::try_from_spec(spec).expect("custom profile"),
+    );
+    let emitted = Arc::new(Mutex::new(Vec::<(Vec<u16>, bool)>::new()));
+    let emitted_copy = Arc::clone(&emitted);
+    let mut state = TrackedKeyState::with_profile(profile);
+    state.set_emitter(move |codes, key_up| {
+        emitted_copy
+            .lock()
+            .expect("emitted lock")
+            .push((codes.to_vec(), key_up));
+        test_send_result(codes.len() as u8, codes.len() as u8, 0)
+    });
+    state.set_probe(|_, _| InstrumentPhysicalState::AllUp);
+
+    let outcome = state.release_all_full_instrument(0);
+    assert!(outcome.released_successfully);
+    let calls = emitted.lock().expect("emitted lock");
+    assert_eq!(calls.len(), 1);
+    assert!(calls[0].1);
+    assert_eq!(
+        calls[0].0,
+        vec![
+            0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x10, 0x11,
+            0x12
+        ]
+    );
 }
 
 #[test]

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/cleanup.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/cleanup.rs
@@ -1,8 +1,8 @@
 use super::super::outcome::{PacketRetryReason, ReleaseAllOutcome, SendTransactionStatus};
 use super::super::physical::{
-    CleanupVerification, ReconciledRelease, reconcile_release_observation,
+    CleanupVerification, ReconciledRelease, reconcile_logical_release_observation,
 };
-use super::super::scan_code::{FULL_INSTRUMENT_MASK, scan_codes_from_mask};
+use super::super::scan_code::FULL_INSTRUMENT_MASK;
 use super::{ReleaseScope, TrackedKeyState, release_retry_sleep};
 
 impl TrackedKeyState {
@@ -43,8 +43,7 @@ impl TrackedKeyState {
             }
 
             let previous_unresolved = unresolved_mask;
-            let send_codes = scan_codes_from_mask(unresolved_mask);
-            let emitted = self.do_emit_up_once(&send_codes);
+            let emitted = self.do_emit_up_once(unresolved_mask);
             let transport_confirmed_mask = emitted.evidence.confirmed_mask;
 
             transport_anomaly |= !matches!(emitted.status, SendTransactionStatus::Complete)
@@ -55,7 +54,7 @@ impl TrackedKeyState {
 
             let physical_state =
                 self.resolve_release_probe(target_hwnd, unresolved_mask, transport_confirmed_mask);
-            let reconciled = reconcile_release_observation(
+            let reconciled = reconcile_logical_release_observation(
                 unresolved_mask,
                 transport_confirmed_mask,
                 physical_state,
@@ -132,8 +131,12 @@ impl TrackedKeyState {
             ReleaseScope::Tracked => "tracked release incomplete".to_string(),
             ReleaseScope::FullInstrument => format!(
                 "full-instrument release incomplete: {}/{} keys unresolved",
-                scan_codes_from_mask(unresolved_mask).len(),
-                scan_codes_from_mask(requested_mask).len()
+                self.instrument_key_profile
+                    .scan_codes_from_mask(unresolved_mask)
+                    .len(),
+                self.instrument_key_profile
+                    .scan_codes_from_mask(requested_mask)
+                    .len()
             ),
         };
         if !released_successfully {

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/mod.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/mod.rs
@@ -5,6 +5,8 @@ mod packet_send_test_support;
 mod preflight;
 mod state;
 
+use super::profile::MaterializedInstrumentKeyProfile;
+
 #[cfg(any(test, feature = "test-support"))]
 pub type CustomEmitterFn =
     Box<dyn Fn(&[u16], bool) -> super::outcome::PlatformSendResult + Send + Sync>;
@@ -75,6 +77,7 @@ fn release_retry_sleep(_ms: u64) {
 
 #[derive(Default)]
 pub struct TrackedKeyState {
+    pub(crate) instrument_key_profile: MaterializedInstrumentKeyProfile,
     pub active_mask: u16,
     pub possibly_active_mask: u16,
     pub failed_release_mask: u16,

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/packet_send.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/packet_send.rs
@@ -4,7 +4,7 @@ use super::super::outcome::{
 };
 use super::super::packet::{
     PreparedPacketView, PreparedPhysicalPacket, invalid_packet_outcome,
-    send_physical_packet_once_with_start,
+    send_prepared_physical_packet_once, send_prepared_physical_packet_once_with_start,
 };
 use super::super::physical::mask_for_scan_codes;
 use super::super::raw::{
@@ -95,18 +95,41 @@ impl TrackedKeyState {
     /// Single-send note-off for operator-owned cleanup retries. The cleanup FSM
     /// bounds the raw `SendInput` count itself; this must never perform an
     /// internal retry.
-    pub(super) fn do_emit_up_once(&mut self, scan_codes: &[u16]) -> SendTransactionOutcome {
+    pub(super) fn do_emit_up_once(&mut self, logical_mask: u16) -> SendTransactionOutcome {
+        let packet = PhysicalPacket::new(logical_mask, 0);
+        let prepared = match PreparedPhysicalPacket::try_new_with_profile(
+            packet,
+            &self.instrument_key_profile,
+        ) {
+            Ok(prepared) => prepared,
+            Err(_) => return invalid_packet_outcome(packet),
+        };
+
         #[cfg(any(test, feature = "test-support"))]
         if let Some(ref emitter) = self.custom_emitter {
-            return emit_up_once_with(scan_codes, |sc, key_up| emitter(sc, key_up));
+            let scan_codes = self
+                .instrument_key_profile
+                .scan_codes_from_mask(logical_mask);
+            let mut outcome = emit_up_once_with(&scan_codes, |sc, key_up| emitter(sc, key_up));
+            outcome.evidence.requested_mask = logical_mask;
+            outcome.evidence.skipped_mask = 0;
+            outcome.evidence.confirmed_mask = if outcome.is_success() {
+                logical_mask
+            } else {
+                logical_prefix_mask(logical_mask, outcome.evidence.first_inserted)
+            };
+            return outcome;
         }
-        if let Some(clock) = self.qpc_clock {
-            emit_up_once_with(scan_codes, |sc, key_up| {
-                send_input_raw_with_clock(sc, key_up, clock)
-            })
-        } else {
-            emit_up_once_with(scan_codes, send_input_raw)
+
+        #[cfg(any(test, feature = "test-support"))]
+        if let Some(emitter) = self.custom_packet_emitter.as_ref() {
+            return emitter(packet);
         }
+
+        let Some(clock) = self.qpc_clock else {
+            return invalid_packet_outcome(packet);
+        };
+        send_prepared_physical_packet_once(&prepared, clock)
     }
 
     pub fn key_down(&mut self, scan_codes: &[u16]) -> SendTransactionOutcome {
@@ -286,10 +309,16 @@ impl TrackedKeyState {
         packet: PhysicalPacket,
         started_ticks: QpcTicks,
     ) -> SendTransactionOutcome {
-        if let Err(error) = PreparedPhysicalPacket::try_new(packet) {
-            self.last_error = Some(format!("physical packet preparation failed: {error}"));
-            return self.apply_packet_outcome(packet, invalid_packet_outcome(packet));
-        }
+        let prepared = match PreparedPhysicalPacket::try_new_with_profile(
+            packet,
+            &self.instrument_key_profile,
+        ) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                self.last_error = Some(format!("physical packet preparation failed: {error}"));
+                return self.apply_packet_outcome(packet, invalid_packet_outcome(packet));
+            }
+        };
         let outcome = {
             #[cfg(any(test, feature = "test-support"))]
             if let Some(emitter) = self.custom_packet_emitter.as_ref() {
@@ -317,7 +346,7 @@ impl TrackedKeyState {
                         },
                     };
                 };
-                send_physical_packet_once_with_start(packet, clock, started_ticks)
+                send_prepared_physical_packet_once_with_start(&prepared, clock, started_ticks)
             }
             #[cfg(not(any(test, feature = "test-support")))]
             {
@@ -341,7 +370,7 @@ impl TrackedKeyState {
                         },
                     };
                 };
-                send_physical_packet_once_with_start(packet, clock, started_ticks)
+                send_prepared_physical_packet_once_with_start(&prepared, clock, started_ticks)
             }
         };
 
@@ -845,4 +874,18 @@ impl TrackedKeyState {
             },
         }
     }
+}
+
+fn logical_prefix_mask(mask: u16, count: u8) -> u16 {
+    let mut remaining = mask;
+    let mut prefix = 0u16;
+    for _ in 0..count {
+        if remaining == 0 {
+            break;
+        }
+        let bit = 1u16 << remaining.trailing_zeros();
+        prefix |= bit;
+        remaining &= !bit;
+    }
+    prefix
 }

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/preflight.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/preflight.rs
@@ -1,5 +1,8 @@
 use super::super::outcome::PhysicalKeyPreflightError;
-use super::super::physical::{InstrumentPhysicalState, instrument_physical_state_for_mask};
+use super::super::physical::{
+    InstrumentPhysicalState, LogicalInstrumentPhysicalState,
+    instrument_logical_physical_state_for_mask,
+};
 use super::super::scan_code::FULL_INSTRUMENT_MASK;
 use super::TrackedKeyState;
 
@@ -22,12 +25,20 @@ impl TrackedKeyState {
         if target_hwnd == 0 {
             return Err(PhysicalKeyPreflightError::VerificationInconclusive);
         }
-        match instrument_physical_state_for_mask(target_hwnd, FULL_INSTRUMENT_MASK) {
-            InstrumentPhysicalState::AllUp => Ok(()),
-            InstrumentPhysicalState::Held(held) => {
-                Err(PhysicalKeyPreflightError::UserHeld(held.into_vec()))
+        match instrument_logical_physical_state_for_mask(
+            &self.instrument_key_profile,
+            target_hwnd,
+            FULL_INSTRUMENT_MASK,
+        ) {
+            LogicalInstrumentPhysicalState::AllUp => Ok(()),
+            LogicalInstrumentPhysicalState::Held(held_mask) => {
+                Err(PhysicalKeyPreflightError::UserHeld(
+                    self.instrument_key_profile
+                        .scan_codes_from_mask(held_mask)
+                        .into_vec(),
+                ))
             }
-            InstrumentPhysicalState::Inconclusive => {
+            LogicalInstrumentPhysicalState::Inconclusive => {
                 Err(PhysicalKeyPreflightError::VerificationInconclusive)
             }
         }
@@ -46,21 +57,37 @@ impl TrackedKeyState {
         target_hwnd: isize,
         unresolved_mask: u16,
         transport_confirmed_mask: u16,
-    ) -> InstrumentPhysicalState {
+    ) -> LogicalInstrumentPhysicalState {
         if let Some(probe) = &self.custom_probe {
-            probe(unresolved_mask, transport_confirmed_mask)
+            match probe(unresolved_mask, transport_confirmed_mask) {
+                InstrumentPhysicalState::AllUp => LogicalInstrumentPhysicalState::AllUp,
+                InstrumentPhysicalState::Held(held) => self
+                    .instrument_key_profile
+                    .logical_mask_for_scan_codes(&held)
+                    .map_or(
+                        LogicalInstrumentPhysicalState::Inconclusive,
+                        LogicalInstrumentPhysicalState::Held,
+                    ),
+                InstrumentPhysicalState::Inconclusive => {
+                    LogicalInstrumentPhysicalState::Inconclusive
+                }
+            }
         } else if self.uses_custom_emitter() {
-            InstrumentPhysicalState::Inconclusive
+            LogicalInstrumentPhysicalState::Inconclusive
         } else {
             #[cfg(windows)]
             {
                 let _ = target_hwnd;
-                instrument_physical_state_for_mask(target_hwnd, unresolved_mask)
+                instrument_logical_physical_state_for_mask(
+                    &self.instrument_key_profile,
+                    target_hwnd,
+                    unresolved_mask,
+                )
             }
             #[cfg(not(windows))]
             {
                 let _ = (target_hwnd, unresolved_mask);
-                InstrumentPhysicalState::Inconclusive
+                LogicalInstrumentPhysicalState::Inconclusive
             }
         }
     }
@@ -72,7 +99,11 @@ impl TrackedKeyState {
         target_hwnd: isize,
         unresolved_mask: u16,
         _transport_confirmed_mask: u16,
-    ) -> InstrumentPhysicalState {
-        instrument_physical_state_for_mask(target_hwnd, unresolved_mask)
+    ) -> LogicalInstrumentPhysicalState {
+        instrument_logical_physical_state_for_mask(
+            &self.instrument_key_profile,
+            target_hwnd,
+            unresolved_mask,
+        )
     }
 }

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/state.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/state.rs
@@ -169,13 +169,6 @@ impl TrackedKeyState {
         &self.instrument_key_profile
     }
 
-    pub fn set_instrument_key_profile(
-        &mut self,
-        instrument_key_profile: MaterializedInstrumentKeyProfile,
-    ) {
-        self.instrument_key_profile = instrument_key_profile;
-    }
-
     #[cfg(any(test, feature = "test-support"))]
     pub(super) fn uses_custom_emitter(&self) -> bool {
         self.custom_emitter.is_some() || self.custom_packet_emitter.is_some()

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/state.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/state.rs
@@ -4,6 +4,7 @@ use super::super::outcome::{
 };
 #[cfg(any(test, feature = "test-support"))]
 use super::super::physical::InstrumentPhysicalState;
+use super::super::profile::MaterializedInstrumentKeyProfile;
 use super::TrackedKeyState;
 use crate::clock::QpcClock;
 use std::fmt;
@@ -144,6 +145,35 @@ impl TrackedKeyState {
             qpc_clock: Some(clock),
             ..Default::default()
         }
+    }
+
+    pub fn with_qpc_clock_and_profile(
+        clock: QpcClock,
+        instrument_key_profile: MaterializedInstrumentKeyProfile,
+    ) -> Self {
+        Self {
+            instrument_key_profile,
+            qpc_clock: Some(clock),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_profile(instrument_key_profile: MaterializedInstrumentKeyProfile) -> Self {
+        Self {
+            instrument_key_profile,
+            ..Default::default()
+        }
+    }
+
+    pub fn instrument_key_profile(&self) -> &MaterializedInstrumentKeyProfile {
+        &self.instrument_key_profile
+    }
+
+    pub fn set_instrument_key_profile(
+        &mut self,
+        instrument_key_profile: MaterializedInstrumentKeyProfile,
+    ) {
+        self.instrument_key_profile = instrument_key_profile;
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/rust/crates/sky_player/src/engine/config.rs
+++ b/rust/crates/sky_player/src/engine/config.rs
@@ -1,5 +1,6 @@
 use super::telemetry::TelemetryMode;
 use sky_dispatch_core::model::RuntimeSchedule;
+use sky_dispatch_win32::input::{InstrumentKeyProfileSpec, MaterializedInstrumentKeyProfile};
 use sky_dispatch_win32::mmcss::PriorityMode;
 
 pub(crate) const STARTUP_READINESS_RESERVE_US: u64 = 2_000;
@@ -161,6 +162,9 @@ pub struct NativeSessionOptions {
     pub wait: WaitOptions,
     pub telemetry: TelemetryOptions,
     pub priority: PriorityOptions,
+    /// Optional unvalidated Win32-boundary profile input. `None` selects the
+    /// canonical 15-key profile during native session admission.
+    pub instrument_key_profile: Option<InstrumentKeyProfileSpec>,
     #[cfg(any(test, feature = "test-support"))]
     pub startup_ordering_hook: Option<Arc<StartupOrderingHook>>,
     #[cfg(any(test, feature = "test-support"))]
@@ -168,6 +172,11 @@ pub struct NativeSessionOptions {
     #[cfg(any(test, feature = "test-support"))]
     pub timer_lifecycle_context:
         Option<sky_dispatch_win32::timer::test_support::TimerLifecycleContext>,
+}
+
+pub(crate) struct AdmittedNativeSessionOptions {
+    pub(crate) options: NativeSessionOptions,
+    pub(crate) instrument_key_profile: MaterializedInstrumentKeyProfile,
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/rust/crates/sky_player/src/engine/session.rs
+++ b/rust/crates/sky_player/src/engine/session.rs
@@ -1,4 +1,4 @@
-use super::config::{DispatchProfile, NativeSessionOptions};
+use super::config::{AdmittedNativeSessionOptions, DispatchProfile, NativeSessionOptions};
 use super::shared::{
     SessionCommands, SessionLifecycle, SessionPublication, SessionShared, SessionTarget,
 };
@@ -72,7 +72,7 @@ pub(crate) fn validate_native_schedule_timing_with_release_gap(
 }
 
 pub struct NativeDispatchSession {
-    config: Mutex<Option<NativeSessionOptions>>,
+    config: Mutex<Option<AdmittedNativeSessionOptions>>,
     profile: DispatchProfile,
     generation_count: u64,
     shared: Arc<SessionShared>,
@@ -80,7 +80,7 @@ pub struct NativeDispatchSession {
 }
 
 impl NativeDispatchSession {
-    pub fn new(options: NativeSessionOptions) -> Result<Self, String> {
+    pub fn new(mut options: NativeSessionOptions) -> Result<Self, String> {
         validate_timing_constants()?;
         // This is the authoritative native admission boundary.  Python calls
         // the same core validator before crossing into Rust, but direct native
@@ -98,6 +98,14 @@ impl NativeDispatchSession {
         if !cfg!(windows) && matches!(&options.backend, BackendConfig::Production) {
             return Err("production native dispatch is supported only on Windows".to_string());
         }
+        let profile_spec = options
+            .instrument_key_profile
+            .take()
+            .unwrap_or_else(sky_dispatch_win32::input::InstrumentKeyProfileSpec::canonical);
+        let instrument_key_profile =
+            sky_dispatch_win32::input::InstrumentKeyProfile::try_from_spec(profile_spec)
+                .map(sky_dispatch_win32::input::MaterializedInstrumentKeyProfile::from_validated)
+                .map_err(|error| format!("native instrument profile admission failed: {error}"))?;
         let initial_heartbeat_ticks = qpc_clock
             .now()
             .map_err(|error| format!("QPC admission failed before session creation: {error:?}"))?;
@@ -153,9 +161,13 @@ impl NativeDispatchSession {
                 startup_ready: AtomicBool::new(false),
             },
         });
+        let admitted_options = AdmittedNativeSessionOptions {
+            options,
+            instrument_key_profile,
+        };
         Ok(Self {
-            profile: options.profile,
-            config: Mutex::new(Some(options)),
+            profile: admitted_options.options.profile,
+            config: Mutex::new(Some(admitted_options)),
             generation_count,
             shared,
             thread_handle: Mutex::new(None),
@@ -220,7 +232,7 @@ impl NativeDispatchSession {
         };
 
         #[cfg(any(test, feature = "test-support"))]
-        let timer_lifecycle_context = config.timer_lifecycle_context.clone();
+        let timer_lifecycle_context = config.options.timer_lifecycle_context.clone();
 
         let shared = Arc::clone(&self.shared);
         self.shared

--- a/rust/crates/sky_player/src/engine/test_support/dispatch_harness.rs
+++ b/rust/crates/sky_player/src/engine/test_support/dispatch_harness.rs
@@ -989,6 +989,7 @@ impl ProductionDispatchTestHarness {
             self.resources.clock,
             &self.config.timing,
             &self.runtime.preparation_probe,
+            self.resources.backend.instrument_key_profile(),
         )
         .expect("plan_next_dispatch");
         preflight_prepared_plan(
@@ -1018,6 +1019,7 @@ impl ProductionDispatchTestHarness {
                 coordinator: &self.resources.coordinator,
                 epoch_qpc: self.resources.playback.epoch,
                 preparation_probe: &self.runtime.preparation_probe,
+                instrument_key_profile: self.resources.backend.instrument_key_profile(),
             },
             plan,
         )
@@ -1333,7 +1335,11 @@ impl ProductionDispatchTestHarness {
         &mut self,
         packet: PhysicalPacket,
     ) -> (QpcTicks, SendTransactionOutcome) {
-        let prepared = PreparedPhysicalPacket::try_new(packet).expect("prepared benchmark packet");
+        let prepared = PreparedPhysicalPacket::try_new_with_profile(
+            packet,
+            self.resources.backend.instrument_key_profile(),
+        )
+        .expect("prepared benchmark packet");
         self.send_prepared_phase_a_packet_for_test(&prepared)
     }
 

--- a/rust/crates/sky_player/src/engine/test_support/mock_sender.rs
+++ b/rust/crates/sky_player/src/engine/test_support/mock_sender.rs
@@ -4,8 +4,9 @@ use super::fault_injection::{FaultInjectionScript, InjectedSendOutcome};
 use sky_dispatch_core::time::DurationTicks;
 use sky_dispatch_win32::clock::{QpcClock, QpcError, QpcTicks};
 use sky_dispatch_win32::input::{
-    InstrumentPhysicalState, PacketRetryReason, PhysicalPacket, PlatformSendResult, SendEvidence,
-    SendTransactionOutcome, SendTransactionStatus, TrackedKeyState, scan_codes_from_mask,
+    InstrumentPhysicalState, MaterializedInstrumentKeyProfile, PacketRetryReason, PhysicalPacket,
+    PlatformSendResult, SendEvidence, SendTransactionOutcome, SendTransactionStatus,
+    TrackedKeyState, scan_codes_from_mask,
 };
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -13,6 +14,7 @@ use std::time::Duration;
 
 pub(crate) fn create_mock_backend(
     qpc_clock: QpcClock,
+    instrument_key_profile: MaterializedInstrumentKeyProfile,
     latency_base_us: u64,
     latency_per_key_us: u64,
     fault_script: FaultInjectionScript,
@@ -22,7 +24,8 @@ pub(crate) fn create_mock_backend(
     let send_call_count = script.send_call_count.clone();
     let script_emitter = Arc::clone(&script);
     let call_index_emitter = Arc::clone(&call_index);
-    let mut backend = TrackedKeyState::with_qpc_clock(qpc_clock);
+    let mut backend =
+        TrackedKeyState::with_qpc_clock_and_profile(qpc_clock, instrument_key_profile);
     backend.set_emitter(move |codes, _key_up| {
         if let Some(counter) = &send_call_count {
             counter.fetch_add(1, Ordering::SeqCst);

--- a/rust/crates/sky_player/src/engine/tests.rs
+++ b/rust/crates/sky_player/src/engine/tests.rs
@@ -23,6 +23,7 @@ use sky_dispatch_core::time::TimelineTicks;
 use sky_dispatch_win32::clock::{
     DurationTicks, QpcClock, QpcTicks, qpc_frequency, qpc_ticks_to_us, qpc_us_to_ticks,
 };
+use sky_dispatch_win32::input::{InstrumentKeyProfileSpec, PhysicalKey};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -67,6 +68,7 @@ fn test_session_options(
         priority: PriorityOptions {
             mode: sky_dispatch_win32::mmcss::PriorityMode::Off,
         },
+        instrument_key_profile: None,
         startup_ordering_hook: None,
         restore_race_hook: None,
         timer_lifecycle_context: None,
@@ -1602,25 +1604,50 @@ fn worker_takes_runtime_schedule_only_once() {
         },
     ))
     .expect("test session admission");
-    let mut worker = Worker::new(
-        test_session_options(
-            startup_boundary_schedule(),
-            1,
-            BackendConfig::Mock {
-                latency_base_us: 0,
-                latency_per_key_us: 0,
-                fault_script: FaultInjectionScript::none(),
-            },
-        ),
-        session.shared_for_test(),
-        QpcTicks::ZERO,
+    let worker_options = test_session_options(
+        startup_boundary_schedule(),
+        1,
+        BackendConfig::Mock {
+            latency_base_us: 0,
+            latency_per_key_us: 0,
+            fault_script: FaultInjectionScript::none(),
+        },
     );
+    let admitted_options = super::config::AdmittedNativeSessionOptions {
+        options: worker_options,
+        instrument_key_profile:
+            sky_dispatch_win32::input::MaterializedInstrumentKeyProfile::canonical(),
+    };
+    let mut worker = Worker::new(admitted_options, session.shared_for_test(), QpcTicks::ZERO);
 
     assert!(worker.take_schedule_for_test().is_ok());
     assert!(matches!(
         worker.take_schedule_for_test(),
         Err("worker runtime schedule was already consumed")
     ));
+}
+
+#[test]
+fn invalid_instrument_profile_is_rejected_before_worker_start() {
+    let mut options = test_session_options(
+        startup_boundary_schedule(),
+        1,
+        BackendConfig::Mock {
+            latency_base_us: 0,
+            latency_per_key_us: 0,
+            fault_script: FaultInjectionScript::none(),
+        },
+    );
+    let mut spec = InstrumentKeyProfileSpec::canonical();
+    spec.keys[0] = PhysicalKey {
+        scan_code: 0x3a,
+        extended: false,
+    };
+    options.instrument_key_profile = Some(spec);
+    let error = NativeDispatchSession::new(options)
+        .err()
+        .expect("invalid profile must fail at admission");
+    assert!(error.contains("native instrument profile admission failed"));
 }
 
 #[test]

--- a/rust/crates/sky_player/src/engine/worker.rs
+++ b/rust/crates/sky_player/src/engine/worker.rs
@@ -525,31 +525,37 @@ pub(super) struct Worker<'a> {
     config: WorkerConfig,
     shared: &'a SessionShared,
     epoch_qpc: QpcTicks,
+    instrument_key_profile: Option<sky_dispatch_win32::input::MaterializedInstrumentKeyProfile>,
     core: WorkerCore,
 }
 
 impl<'a> Worker<'a> {
     pub(super) fn new(
-        options: NativeSessionOptions,
+        admitted: super::config::AdmittedNativeSessionOptions,
         shared: &'a SessionShared,
         epoch_qpc: QpcTicks,
     ) -> Self {
-        let NativeSessionOptions {
-            schedule,
-            backend,
-            profile,
-            timing,
-            focus,
-            wait,
-            telemetry,
-            priority,
-            #[cfg(any(test, feature = "test-support"))]
-            startup_ordering_hook,
-            #[cfg(any(test, feature = "test-support"))]
-            restore_race_hook,
-            #[cfg(any(test, feature = "test-support"))]
-                timer_lifecycle_context: _,
-        } = options;
+        let super::config::AdmittedNativeSessionOptions {
+            options:
+                NativeSessionOptions {
+                    schedule,
+                    backend,
+                    profile,
+                    timing,
+                    focus,
+                    wait,
+                    telemetry,
+                    priority,
+                    #[cfg(any(test, feature = "test-support"))]
+                    startup_ordering_hook,
+                    #[cfg(any(test, feature = "test-support"))]
+                    restore_race_hook,
+                    #[cfg(any(test, feature = "test-support"))]
+                        timer_lifecycle_context: _,
+                    instrument_key_profile: _,
+                },
+            instrument_key_profile,
+        } = admitted;
         #[cfg(any(test, feature = "test-support"))]
         let runtime = WorkerRuntime {
             startup_ordering_hook,
@@ -571,6 +577,7 @@ impl<'a> Worker<'a> {
             },
             shared,
             epoch_qpc,
+            instrument_key_profile: Some(instrument_key_profile),
             core: WorkerCore {
                 runtime,
                 ..WorkerCore::default()

--- a/rust/crates/sky_player/src/engine/worker/boot.rs
+++ b/rust/crates/sky_player/src/engine/worker/boot.rs
@@ -126,19 +126,29 @@ pub(super) fn initialize(worker: &mut Worker<'_>, wait_fault: bool) -> u8 {
             return 1;
         }
     };
+    let instrument_key_profile = worker
+        .instrument_key_profile
+        .take()
+        .expect("worker instrument profile is admitted before boot");
     let mut backend = match &worker.config.backend {
         #[cfg(any(test, feature = "test-support"))]
         BackendConfig::Mock {
             latency_base_us,
             latency_per_key_us,
             fault_script,
-        } => create_mock_backend(
-            qpc_clock,
-            *latency_base_us,
-            *latency_per_key_us,
-            fault_script.clone(),
-        ),
-        BackendConfig::Production => TrackedKeyState::with_qpc_clock(qpc_clock),
+        } => {
+            let mut backend = create_mock_backend(
+                qpc_clock,
+                *latency_base_us,
+                *latency_per_key_us,
+                fault_script.clone(),
+            );
+            backend.set_instrument_key_profile(instrument_key_profile);
+            backend
+        }
+        BackendConfig::Production => {
+            TrackedKeyState::with_qpc_clock_and_profile(qpc_clock, instrument_key_profile)
+        }
     };
     let target_hwnd = &shared.target.target_hwnd;
     let priority_acquired = &shared.publication.priority_acquired;
@@ -151,7 +161,7 @@ pub(super) fn initialize(worker: &mut Worker<'_>, wait_fault: bool) -> u8 {
             } else {
                 format!(
                     "{primary_error}; admission cleanup failed: {}",
-                    describe_release_outcome(&cleanup)
+                    describe_release_outcome(backend, &cleanup)
                 )
             };
             *metrics.last_error.lock() = Some(message);

--- a/rust/crates/sky_player/src/engine/worker/boot.rs
+++ b/rust/crates/sky_player/src/engine/worker/boot.rs
@@ -136,16 +136,13 @@ pub(super) fn initialize(worker: &mut Worker<'_>, wait_fault: bool) -> u8 {
             latency_base_us,
             latency_per_key_us,
             fault_script,
-        } => {
-            let mut backend = create_mock_backend(
-                qpc_clock,
-                *latency_base_us,
-                *latency_per_key_us,
-                fault_script.clone(),
-            );
-            backend.set_instrument_key_profile(instrument_key_profile);
-            backend
-        }
+        } => create_mock_backend(
+            qpc_clock,
+            instrument_key_profile,
+            *latency_base_us,
+            *latency_per_key_us,
+            fault_script.clone(),
+        ),
         BackendConfig::Production => {
             TrackedKeyState::with_qpc_clock_and_profile(qpc_clock, instrument_key_profile)
         }

--- a/rust/crates/sky_player/src/engine/worker/cleanup.rs
+++ b/rust/crates/sky_player/src/engine/worker/cleanup.rs
@@ -155,7 +155,7 @@ pub(super) fn finalize_worker(context: FinalizeInput<'_>) -> u8 {
                 &mut secondary_errors,
                 format!(
                     "terminal release verification failed: {}",
-                    describe_release_outcome(outcome)
+                    describe_release_outcome(&backend, outcome)
                 ),
             );
         }
@@ -340,11 +340,14 @@ pub(crate) fn clean_completion_proven(
         && backend.authored_keys_rejected == 0
 }
 
-pub(crate) fn describe_release_outcome(outcome: &ReleaseAllOutcome) -> String {
+pub(crate) fn describe_release_outcome(
+    backend: &TrackedKeyState,
+    outcome: &ReleaseAllOutcome,
+) -> String {
     format!(
         "released_successfully={}, stuck_keys={:?}, verification_inconclusive={}",
         outcome.released_successfully,
-        outcome.stuck_keys(),
+        outcome.stuck_keys_with_profile(backend.instrument_key_profile()),
         outcome.verification_inconclusive
     )
 }
@@ -380,7 +383,7 @@ pub(crate) fn suspend_live_input(
     if !release_state_verified(backend, &release) {
         return Err(format!(
             "release verification failed: {}",
-            describe_release_outcome(&release)
+            describe_release_outcome(backend, &release)
         ));
     }
 

--- a/rust/crates/sky_player/src/engine/worker/control.rs
+++ b/rust/crates/sky_player/src/engine/worker/control.rs
@@ -115,7 +115,7 @@ pub(super) fn process_command_control(context: CommandControlInput<'_>) -> Comma
                 secondary_errors,
                 format!(
                     "panic cleanup release verification failed: {}",
-                    describe_release_outcome(&panic_release)
+                    describe_release_outcome(backend, &panic_release)
                 ),
             );
         }

--- a/rust/crates/sky_player/src/engine/worker/dispatch/timing.rs
+++ b/rust/crates/sky_player/src/engine/worker/dispatch/timing.rs
@@ -19,7 +19,9 @@ use super::{AuthoredBatchView, BatchViewResult, DispatchStep, PhysicalCommit, Re
 #[cfg(any(test, feature = "test-support"))]
 use sky_dispatch_core::coordinator::PreparedAuthoredFrame;
 use sky_dispatch_core::coordinator::{PreparedAuthoredPacket, PreparedBatch};
-use sky_dispatch_win32::input::{PacketRetryReason, PhysicalPacket, SendTransactionStatus};
+use sky_dispatch_win32::input::{
+    MaterializedInstrumentKeyProfile, PacketRetryReason, PhysicalPacket, SendTransactionStatus,
+};
 
 /// Typed transport/timing evidence shared by DownOnly, Mixed, and UpOnly
 /// dispatch observations.  The observer applies the one canonical predicate
@@ -78,6 +80,7 @@ pub(crate) fn prepare_authored_batch_view(
     coordinator: &RuntimeDispatchCoordinator,
     prepared_batch: PreparedBatch,
     preparation_probe: &DispatchPreparationProbe,
+    instrument_key_profile: &MaterializedInstrumentKeyProfile,
 ) -> BatchViewResult {
     let batch_index = prepared_batch.index;
     let batch_scheduled_ticks = prepared_batch.effective_scheduled_ticks;
@@ -158,7 +161,10 @@ pub(crate) fn prepare_authored_batch_view(
         }
     };
     let prepared_packet =
-        match sky_dispatch_win32::input::PreparedPhysicalPacket::try_new(packet_masks) {
+        match sky_dispatch_win32::input::PreparedPhysicalPacket::try_new_with_profile(
+            packet_masks,
+            instrument_key_profile,
+        ) {
             Ok(value) => value,
             Err(error) => {
                 return Err(DispatchStep::Terminate(format!(
@@ -213,6 +219,7 @@ pub(crate) fn prepare_authored_frame_view_from_prepared(
     pending_release_mask: u16,
     pending_due_ticks: TimelineTicks,
     preparation_probe: &DispatchPreparationProbe,
+    instrument_key_profile: &MaterializedInstrumentKeyProfile,
 ) -> BatchViewResult {
     let PreparedAuthoredPacket {
         frame,
@@ -232,8 +239,9 @@ pub(crate) fn prepare_authored_frame_view_from_prepared(
     let conflict_mask =
         coordinator.check_packet_down_conflicts(selected_up_mask, selected_down_mask);
     preparation_probe.record_input_build();
-    let prepared_packet = sky_dispatch_win32::input::PreparedPhysicalPacket::try_new(
+    let prepared_packet = sky_dispatch_win32::input::PreparedPhysicalPacket::try_new_with_profile(
         selected_packet,
+        instrument_key_profile,
     )
     .map_err(|error| {
         DispatchStep::Terminate(format!("physical packet preparation failure: {error}"))
@@ -291,6 +299,7 @@ pub(crate) fn prepare_pending_release_view(
     release_mask: u16,
     due_ticks: TimelineTicks,
     preparation_probe: &DispatchPreparationProbe,
+    instrument_key_profile: &MaterializedInstrumentKeyProfile,
 ) -> BatchViewResult {
     if release_mask == 0 {
         return Err(DispatchStep::Terminate(
@@ -298,12 +307,15 @@ pub(crate) fn prepare_pending_release_view(
         ));
     }
     let packet = PhysicalPacket::new(release_mask, 0);
-    let prepared_packet = sky_dispatch_win32::input::PreparedPhysicalPacket::try_new(packet)
-        .map_err(|error| {
-            DispatchStep::Terminate(format!(
-                "pending release packet preparation failure: {error}"
-            ))
-        })?;
+    let prepared_packet = sky_dispatch_win32::input::PreparedPhysicalPacket::try_new_with_profile(
+        packet,
+        instrument_key_profile,
+    )
+    .map_err(|error| {
+        DispatchStep::Terminate(format!(
+            "pending release packet preparation failure: {error}"
+        ))
+    })?;
     preparation_probe.record_input_build();
     let count = release_mask.count_ones() as usize;
     let source_action_index = coordinator

--- a/rust/crates/sky_player/src/engine/worker/dispatch_loop.rs
+++ b/rust/crates/sky_player/src/engine/worker/dispatch_loop.rs
@@ -836,6 +836,7 @@ pub(super) fn dispatch(
                     coordinator: &resources.coordinator,
                     epoch_qpc: resources.playback.epoch,
                     preparation_probe: &core.runtime.preparation_probe,
+                    instrument_key_profile: resources.backend.instrument_key_profile(),
                 },
                 &mut dispatch_plan,
             ) {

--- a/rust/crates/sky_player/src/engine/worker/planning.rs
+++ b/rust/crates/sky_player/src/engine/worker/planning.rs
@@ -16,6 +16,7 @@ use crate::engine::config::TimingOptions;
 use sky_dispatch_core::coordinator::{CoordinatorError, RuntimeDispatchCoordinator};
 use sky_dispatch_core::time::{DurationTicks, TimelineTicks};
 use sky_dispatch_win32::clock::QpcTicks;
+use sky_dispatch_win32::input::MaterializedInstrumentKeyProfile;
 use std::fmt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -180,6 +181,7 @@ pub(crate) fn plan_next_dispatch(
     _qpc_clock: sky_dispatch_win32::clock::QpcClock,
     _timing: &TimingOptions,
     preparation_probe: &DispatchPreparationProbe,
+    instrument_key_profile: &MaterializedInstrumentKeyProfile,
 ) -> Result<NextDispatchPlan, PlanningError> {
     let mut plan = NextDispatchPlan::default();
     plan_next_dispatch_projected(
@@ -187,6 +189,7 @@ pub(crate) fn plan_next_dispatch(
             coordinator,
             epoch_qpc,
             preparation_probe,
+            instrument_key_profile,
         },
         &mut plan,
     )?;
@@ -197,6 +200,7 @@ pub(crate) struct PlanningInput<'a> {
     pub(crate) coordinator: &'a RuntimeDispatchCoordinator,
     pub(crate) epoch_qpc: QpcTicks,
     pub(crate) preparation_probe: &'a DispatchPreparationProbe,
+    pub(crate) instrument_key_profile: &'a MaterializedInstrumentKeyProfile,
 }
 
 /// Write the epoch product into the caller-owned slot so the approximately
@@ -212,6 +216,7 @@ pub(crate) fn plan_next_dispatch_projected(
         coordinator,
         epoch_qpc,
         preparation_probe,
+        instrument_key_profile,
     } = input;
     let authored_packet = coordinator.prepare_current_authored_packet()?;
     #[cfg(any(test, feature = "test-support"))]
@@ -236,6 +241,7 @@ pub(crate) fn plan_next_dispatch_projected(
             release_mask,
             target,
             preparation_probe,
+            instrument_key_profile,
         ))?;
         return physical_plan_from_view(view, epoch_qpc, plan);
     }
@@ -248,6 +254,7 @@ pub(crate) fn plan_next_dispatch_projected(
                 release_mask,
                 target,
                 preparation_probe,
+                instrument_key_profile,
             ))?;
             return physical_plan_from_view(view, epoch_qpc, plan);
         }
@@ -283,6 +290,7 @@ pub(crate) fn plan_next_dispatch_projected(
         coalesced_pending_mask,
         frame.authored_ticks,
         preparation_probe,
+        instrument_key_profile,
     ))?;
     physical_plan_from_view(authored_view, epoch_qpc, plan)
 }

--- a/rust/crates/sky_player/src/engine/worker/planning.rs
+++ b/rust/crates/sky_player/src/engine/worker/planning.rs
@@ -342,9 +342,13 @@ fn physical_plan_from_view(
 #[cfg(test)]
 mod layout_tests {
     use super::{AuthoredBatchView, NextDispatchPlan, PhysicalDispatchPlan};
+    use crate::engine::worker::{Worker, WorkerResources};
     use sky_dispatch_core::clock::PlaybackClockState;
     use sky_dispatch_core::coordinator::{ActiveGeneration, PreparedAuthoredCommit};
-    use sky_dispatch_win32::input::PreparedPhysicalPacket;
+    use sky_dispatch_win32::input::{
+        InstrumentKeyProfile, InstrumentKeyProfileSpec, MaterializedInstrumentKeyProfile,
+        PhysicalKey, PreparedPhysicalPacket, TrackedKeyState,
+    };
     use std::collections::HashSet;
     use std::mem::size_of;
 
@@ -397,6 +401,28 @@ mod layout_tests {
         println!(
             "size_of::<LegacyPlaybackClockLayout>()={}",
             size_of::<LegacyPlaybackClockLayout>()
+        );
+        println!(
+            "size_of::<TrackedKeyState>()={}",
+            size_of::<TrackedKeyState>()
+        );
+        println!(
+            "size_of::<WorkerResources>()={}",
+            size_of::<WorkerResources>()
+        );
+        println!("size_of::<Worker>()={}", size_of::<Worker<'static>>());
+        println!("size_of::<PhysicalKey>()={}", size_of::<PhysicalKey>());
+        println!(
+            "size_of::<InstrumentKeyProfileSpec>()={}",
+            size_of::<InstrumentKeyProfileSpec>()
+        );
+        println!(
+            "size_of::<InstrumentKeyProfile>()={}",
+            size_of::<InstrumentKeyProfile>()
+        );
+        println!(
+            "size_of::<MaterializedInstrumentKeyProfile>()={}",
+            size_of::<MaterializedInstrumentKeyProfile>()
         );
     }
 }


### PR DESCRIPTION
Closes #199
Parent campaign: #194

## Coordinator status

W4 design, implementation, and narrow rework reviewed and approved for integration.

Base:
`c920bee66026733f9fa5fe84cb4c688cc660f87e`

Head:
`72c0592cd1d049129c4b5b638a40a4cd88a79551`

## Scope

- add Win32-owned fixed 15-slot physical key profile types;
- validate and materialize an immutable profile before worker start;
- preserve canonical default behavior;
- support approved non-extended non-canonical remaps;
- use one frozen profile for authored dispatch, pending release, cleanup, full-instrument release, and preflight;
- keep internal reconciliation in logical-mask space;
- preserve canonical raw/calibration/emergency safety paths.

## Preserved invariants

No scheduler/timestamp changes, no mask-width migration, no timing/wait/spin/MMCSS changes, no focus-policy changes, no cleanup retry-delay changes, no alternate input API, and no runtime hot-remap mutation.

## Qualification

- cargo xtask check all: PASS
- sky_dispatch_win32: 232/232 PASS
- sky_player: 238/238 PASS
- RT no-allocation: 20/20 PASS
- git diff --check: PASS
- paired release-profile synthetic sender benchmark acceptance-clean/statistics-eligible
- no real SendInput/game claim

W5/#200 remains blocked until this PR is merged.