### PR TITLE
refactor(v4): publish only canonical release assets

### DIFF
--- a/.github/workflows/rehearse-v4.yml
+++ b/.github/workflows/rehearse-v4.yml
@@ -194,7 +194,7 @@ jobs:
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded\*.exe
-          sbom-path: ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded\SBOM.spdx.json
+          sbom-path: ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\candidate-assets\SBOM.spdx.json
 
       - name: Verify exact-source OIDC attestations
         env:

--- a/.github/workflows/rehearse-v4.yml
+++ b/.github/workflows/rehearse-v4.yml
@@ -252,7 +252,14 @@ jobs:
           if-no-files-found: error
           retention-days: 14
           path: |
-            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\**\*.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\candidate-manifest.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\candidate-assets\*.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded-manifest.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\downloaded-authenticode-verification.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\fixture-http-evidence.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\post-draft-qualification.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\defender-evidence.json
+            ${{ runner.temp }}\sky-v4-draft-rehearsal-${{ github.run_id }}\release-state.json
 
       - name: Clean runner-local draft rehearsal state
         if: always()

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -177,8 +177,14 @@ jobs:
           if-no-files-found: error
           retention-days: 14
           path: |
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\candidate-manifest.json
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\candidate-assets\*.json
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded-manifest.json
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded-authenticode-verification.json
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\fixture-http-evidence.json
             ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\post-draft-qualification.json
             ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\defender-evidence.json
+            ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\release-state.json
 
       - name: Attest exact downloaded Tauri candidate and signature
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4

--- a/.github/workflows/release-v4.yml
+++ b/.github/workflows/release-v4.yml
@@ -197,7 +197,7 @@ jobs:
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
           subject-path: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded\*.exe
-          sbom-path: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\downloaded\SBOM.spdx.json
+          sbom-path: ${{ runner.temp }}\sky-v4-release-${{ github.run_id }}\candidate-assets\SBOM.spdx.json
 
       - name: Verify exact-source OIDC attestations
         env:

--- a/docs/v4-release-authority.md
+++ b/docs/v4-release-authority.md
@@ -52,15 +52,28 @@ Sky Auto Player_<version>_x64-setup.exe
 Sky Auto Player_<version>_x64-setup.exe.sig
 ```
 
+The existing release-asset normalization maps spaces to dots for the GitHub Release names:
+
+```text
+Sky.Auto.Player_<version>_x64-setup.exe
+Sky.Auto.Player_<version>_x64-setup.exe.sig
+```
+
 The immutable asset URL is derived from the version and filename in the official repository:
 
 ```text
-https://github.com/pumni/Sky-Auto-Player/releases/download/v<version>/Sky%20Auto%20Player_<version>_x64-setup.exe
+https://github.com/pumni/Sky-Auto-Player/releases/download/v<version>/Sky.Auto.Player_<version>_x64-setup.exe
 ```
 
 Metadata contains the exact `.sig` text and the canonical `windows-x86_64` platform only. Portable
 ZIPs, custom v3 manifests, aliases, non-HTTPS URLs, other repositories, query/fragment state,
 malformed dates, extra platforms, and non-canonical artifact names are invalid v4 metadata.
+
+GitHub Release is the end-user distribution surface and must contain exactly the two canonical
+public assets: the normalized installer filename and its `.sig`. Qualification JSON, Authenticode
+evidence, artifact summaries, and `SBOM.spdx.json` are internal CI evidence. They remain bound by
+the candidate manifest and bounded GitHub Actions artifacts/attestations; they are never uploaded
+as additional GitHub Release downloads.
 
 ## Deterministic metadata commands
 
@@ -100,7 +113,8 @@ The ordering is security-critical:
 2. Build the exact source SHA once and create a draft in the official repository with
    `make_latest="false"`; the channel-specific Latest value is applied only at publication.
 3. Re-download the draft installer and signature, then qualify those exact bytes.
-4. Record SBOM and provenance/attestation evidence bound to the exact source and artifacts.
+4. Record SBOM and provenance/attestation evidence bound to the exact source and the two public
+   assets; retain internal qualification evidence through bounded CI artifacts/attestations.
 5. Snapshot the current GitHub Latest identity, then publish the already-qualified draft
    immutably with `make_latest="true"` for stable or `make_latest="false"` for beta.
 6. Verify the channel-aware Latest policy before minting the metadata App token; stable must be
@@ -126,6 +140,10 @@ The release gate preserves these properties while using one repository:
 - runner-local updater key outside the workspace, with no key-path workflow input;
 - least-privilege permissions and `persist-credentials: false` checkout;
 - fail-closed validation when metadata, release assets, signatures, or public endpoints differ.
+
+`FinalVerify` fails closed unless the published release asset set is exactly the canonical installer
+and updater signature pair. Missing, extra, aliased, or digest/size-mismatched assets are invalid.
+Evidence files and SBOMs are not part of that public release set.
 
 The current Authenticode policy is `unsigned-zero-budget`: updater cryptographic trust remains
 mandatory even while Windows publisher identity is intentionally unsigned. Any future production

--- a/docs/v4-release-execution-topology.md
+++ b/docs/v4-release-execution-topology.md
@@ -42,8 +42,9 @@ Every release candidate is subject to an immutable invariant:
 - **Zero Rebuild**: Once candidate `.exe` and `.exe.sig` are produced, they are never
   rebuilt, re-bundled, or modified.
 - **Byte-Identity**: The SHA-256 hash recorded during qualification is identical to the hash
-  in `V4_QUALIFICATION_EVIDENCE.json`, `latest.json`, `SBOM.spdx.json`, and the GitHub
-  Release download asset.
+  in `V4_QUALIFICATION_EVIDENCE.json`, `latest.json`, `SBOM.spdx.json`, and the exact GitHub
+  Release installer/signature downloads. The public release contains only that canonical pair;
+  the evidence and SBOM remain internal CI state.
 - **Fail-Closed Verification & Candidate Purge**: If any check (Authenticode state, Ed25519 Minisign,
   SBOM, bundle, smoke test) fails, the candidate binary, signature, and unpromoted evidence are
   purged from the staging directory.
@@ -87,7 +88,7 @@ GitHub Actions runner environment.
 |            |-- Runs `actions/attest` with GitHub OIDC token                     |
 |            |     \-- Generates authentic SLSA provenance & SBOM attestation     |
 |            \-- Runs `scripts/promote_v4_metadata.ps1`                           |
-|                  \-- Publishes release assets and static metadata                |
+|                  \-- Publishes installer + .sig and static metadata              |
 +---------------------------------------------------------------------------------+
 
 +---------------------------------------------------------------------------------+
@@ -338,14 +339,20 @@ acquires the updater key passphrase through the fixed Windows Credential Manager
 session broker (`scripts/v4_updater_credential_broker.ps1`, target `SkyAutoPlayer/V4UpdaterProduction`)
 into process-scoped `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`, passing no plaintext password
 CLI arguments, and automatically deletes the session credential in its `finally` block.
-The candidate manifest is the only asset upload authority. The following states download the
-draft assets again and compare names, sizes, and SHA-256 digests before running
+The candidate manifest is the only asset upload authority. It contains a complete
+`qualification_assets` set and an explicit `public_assets` projection. The latter is fail-closed
+to exactly the normalized installer and updater signature names; `CreateDraft` uploads only this
+two-record projection. The following states download the public draft assets again and compare
+names, sizes, and SHA-256 digests before running
 the Authenticode `unsigned-zero-budget`, Tauri updater signature, SPDX SBOM,
 exact-bundle, current-user install/launch/uninstall, GUI/input-safety, and
 active-playback rejection checks. The packaged official Tauri updater fixture
 runs at this post-download boundary: a throwaway previous-v4 bridge consumes
 the exact downloaded installer and `.sig`, while the production candidate is
-never rebuilt. The packaged candidate also proves that update admission is
+never rebuilt. Qualification JSON, Authenticode evidence, artifact summaries, and the SBOM are
+copied into the isolated release state root after `BuildCandidate`, checked against their frozen
+manifest hashes, and retained through bounded GitHub Actions artifacts/attestations. They are not
+uploaded to the GitHub Release. The packaged candidate also proves that update admission is
 rejected while playback is active.
 
 The controlled same-repository draft rehearsal may exercise the GitHub draft
@@ -390,6 +397,11 @@ metadata path. An unpublished draft that fails qualification may be deleted
 and recreated with the same version after the candidate is fixed. Published
 assets, release tags, and metadata remain immutable; fixes then require a new
 SemVer/RC.
+
+`FinalVerify` compares the complete published asset-name set, not just required members. It fails
+for a missing installer or signature, any third asset, an alias/non-canonical name, or a size and
+SHA-256 mismatch. Qualification evidence and SBOM retention is bounded to the workflow artifact
+and attestation surfaces; it is not a second public release download surface.
 
 The production preflight validates the canonical `pumni/Sky-Auto-Player` repository,
 the requested `main` source, immutable-release policy, and readiness of the

--- a/docs/v4-tauri-packaging.md
+++ b/docs/v4-tauri-packaging.md
@@ -171,6 +171,13 @@ the governed `unsigned-zero-budget` mode and compares installer/.sig digests to 
 published GitHub asset bytes. It rejects MSI, portable/updater ZIP, missing
 signatures, empty signatures, unexpected files, and version-naming drift.
 
+The GitHub Release is the public distribution surface and contains exactly the canonical NSIS
+installer plus its updater `.sig`. `V4_QUALIFICATION_EVIDENCE.json`, production/evidence JSON,
+Authenticode evidence, artifact summaries, and `SBOM.spdx.json` remain internal qualification
+inputs. The release pipeline freezes and hash-checks those files in the isolated runner state,
+retains bounded copies as GitHub Actions artifacts, and uses GitHub artifact attestations for
+provenance; it does not publish them as Release assets.
+
 That command is the canonical package build: it uses the normal production
 feature set and the generated test updater key/example endpoint only to
 exercise updater artifact signing. The Authenticode certificate is an

--- a/scripts/test_v4_production_topology_rehearsal.ps1
+++ b/scripts/test_v4_production_topology_rehearsal.ps1
@@ -28,8 +28,6 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $pipelinePath = Join-Path $PSScriptRoot "v4_release_pipeline.ps1"
 $candidateRoot = [IO.Path]::GetFullPath($CandidateStateRoot)
 $candidateManifestPath = Join-Path $candidateRoot "candidate-manifest.json"
-$canonicalBundleDir = Join-Path $repoRoot "rust/target/dist/bundle/nsis"
-$canonicalEvidenceDir = Join-Path $repoRoot "rust/target/dist"
 . (Join-Path $PSScriptRoot "v4_qualification_evidence.ps1")
 
 function Fail([string]$Message) {
@@ -54,17 +52,17 @@ function Write-JsonFile([string]$Path, [object]$Value) {
     [IO.File]::WriteAllText($Path, $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
 }
 
-function Get-SourceAssetPath([object]$Record) {
-    $sourceName = if ($null -ne $Record.PSObject.Properties["source_name"]) {
-        [string]$Record.source_name
-    } else {
-        [string]$Record.name
+function Get-CandidateAssetPath([object]$Record) {
+    $relative = [string]$Record.state_path
+    if ([string]::IsNullOrWhiteSpace($relative) -or [IO.Path]::IsPathRooted($relative)) {
+        Fail "candidate manifest contains an invalid frozen asset path"
     }
-    $role = [string]$Record.role
-    if ($role -in @("installer", "updater-signature")) {
-        return Join-Path $canonicalBundleDir $sourceName
+    $full = [IO.Path]::GetFullPath((Join-Path $candidateRoot $relative))
+    $prefix = $candidateRoot.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if (-not $full.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "candidate manifest asset path escapes CandidateStateRoot"
     }
-    return Join-Path $canonicalEvidenceDir $sourceName
+    return $full
 }
 
 if ($SourceSha -notmatch "^[0-9a-fA-F]{40}$") { Fail "source SHA must be an exact 40-character commit SHA" }
@@ -101,13 +99,25 @@ if ([string]$manifest.source_sha -ne $SourceSha.ToLowerInvariant() -or
     Fail "candidate manifest identity does not match the rehearsal request"
 }
 
-$records = @($manifest.assets)
-if ($records.Count -eq 0) { Fail "candidate manifest contains no assets" }
+$qualificationRecords = @($manifest.qualification_assets)
+$publicRecords = @($manifest.public_assets)
+if ($qualificationRecords.Count -lt 8) { Fail "candidate manifest omits mandatory qualification inputs" }
+if ($publicRecords.Count -ne 2) { Fail "candidate manifest public asset set must contain exactly two records" }
+$expectedPublicNames = @(
+    Get-V4SafeReleaseAssetName "Sky Auto Player_${Version}_x64-setup.exe"
+    Get-V4SafeReleaseAssetName "Sky Auto Player_${Version}_x64-setup.exe.sig"
+)
+if ((@($publicRecords | ForEach-Object { [string]$_.release_name } | Sort-Object) -join "`n") -ne
+    (@($expectedPublicNames | Sort-Object) -join "`n")) {
+    Fail "candidate manifest public asset set is not the canonical installer/signature pair"
+}
+$manifest | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $effectiveStateRoot "candidate-manifest.json") -Encoding utf8
+$records = $publicRecords
 $downloaded = Join-Path $effectiveStateRoot "downloaded"
 New-Item -ItemType Directory -Path $downloaded -Force | Out-Null
 
 try {
-    foreach ($record in $records) {
+    foreach ($record in $qualificationRecords) {
         $sourceName = if ($null -ne $record.PSObject.Properties["source_name"]) {
             [string]$record.source_name
         } else {
@@ -118,9 +128,9 @@ try {
         } else {
             Get-V4SafeReleaseAssetName $sourceName
         }
-        $sourcePath = Get-SourceAssetPath $record
+        $sourcePath = Get-CandidateAssetPath $record
         if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
-            Fail "candidate asset is missing from the BuildCandidate output: $sourcePath"
+            Fail "frozen candidate asset is missing from the BuildCandidate output: $sourcePath"
         }
         $sourceItem = Get-Item -LiteralPath $sourcePath
         $sourceHash = (Get-FileHash -LiteralPath $sourcePath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -128,13 +138,27 @@ try {
             $sourceHash -ne [string]$record.sha256) {
             Fail "candidate asset changed after BuildCandidate: $sourceName"
         }
+        $candidateDestination = Join-Path $effectiveStateRoot $record.state_path
+        New-Item -ItemType Directory -Path (Split-Path -Parent $candidateDestination) -Force | Out-Null
+        Copy-Item -LiteralPath $sourcePath -Destination $candidateDestination -Force
+        $candidateItem = Get-Item -LiteralPath $candidateDestination
+        $candidateHash = (Get-FileHash -LiteralPath $candidateDestination -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ([int64]$candidateItem.Length -ne [int64]$record.size -or
+            $candidateHash -ne [string]$record.sha256) {
+            Fail "staged rehearsal qualification asset is not byte-identical: $sourceName"
+        }
+    }
+
+    foreach ($record in $records) {
+        $releaseName = [string]$record.release_name
+        $sourcePath = Get-CandidateAssetPath $record
         $destination = Join-Path $downloaded $releaseName
         Copy-Item -LiteralPath $sourcePath -Destination $destination -Force
         $downloadedItem = Get-Item -LiteralPath $destination
         $downloadedHash = (Get-FileHash -LiteralPath $destination -Algorithm SHA256).Hash.ToLowerInvariant()
         if ([int64]$downloadedItem.Length -ne [int64]$record.size -or
             $downloadedHash -ne [string]$record.sha256) {
-            Fail "staged rehearsal asset is not byte-identical: $sourceName"
+            Fail "staged rehearsal public asset is not byte-identical: $releaseName"
         }
     }
 
@@ -150,7 +174,8 @@ try {
         immutable = $false
         attested = $false
         qualified_after_download = $false
-        assets = $records
+        qualification_assets = $qualificationRecords
+        public_assets = $records
     }
     Write-JsonFile (Join-Path $effectiveStateRoot "release-state.json") $releaseState
     Write-JsonFile (Join-Path $effectiveStateRoot "downloaded-manifest.json") ([ordered]@{
@@ -158,7 +183,7 @@ try {
         source_sha = $SourceSha.ToLowerInvariant()
         version = $Version
         channel = $Channel
-        assets = $records
+        public_assets = $records
     })
 
     $pipelineArguments = @(

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -541,9 +541,46 @@ $qualifyDownloadedBody = $pipeline.Substring(
     $pipeline.IndexOf('function Invoke-PublishDraft', [StringComparison]::Ordinal) -
         $pipeline.IndexOf('function Invoke-QualifyDownloaded', [StringComparison]::Ordinal)
 )
-if (-not $qualifyDownloadedBody.Contains('Assert-CandidateEvidence @($candidateManifest.qualification_assets)') -or
-    -not $qualifyDownloadedBody.Contains('$downloadedPublicRecords[$index].sha256')) {
+if (-not $qualifyDownloadedBody.Contains('Assert-CandidateEvidence $qualificationRecords') -or
+    -not $qualifyDownloadedBody.Contains('$downloadedPublicRecords[$index].sha256') -or
+    -not $qualifyDownloadedBody.Contains('Get-FrozenQualificationAssetPath') -or
+    -not $qualifyDownloadedBody.Contains('$frozenSbom') -or
+    -not $qualifyDownloadedBody.Contains('$frozenArtifactSummary') -or
+    -not $qualifyDownloadedBody.Contains('$frozenAuthenticodeEvidence') -or
+    -not $qualifyDownloadedBody.Contains('$frozenQualificationEvidence')) {
     Fail "QualifyDownloaded does not hash-check frozen evidence and downloaded public bytes"
+}
+$forbiddenDownloadedEvidencePaths = @(
+    '(Join-Path $downloaded $sbomName)',
+    '(Join-Path $downloaded $summaryName)',
+    '(Join-Path $downloaded $authenticodeEvidenceName)',
+    '(Join-Path $downloaded $qualificationEvidenceName)'
+)
+foreach ($forbiddenPath in $forbiddenDownloadedEvidencePaths) {
+    if ($pipeline.Contains($forbiddenPath)) {
+        Fail "internal qualification evidence must not resolve from downloaded/: $forbiddenPath"
+    }
+}
+$promoteMetadataBody = $pipeline.Substring(
+    $pipeline.IndexOf('function Invoke-PromoteMetadata', [StringComparison]::Ordinal),
+    $pipeline.IndexOf('function Invoke-FinalVerify', [StringComparison]::Ordinal) -
+        $pipeline.IndexOf('function Invoke-PromoteMetadata', [StringComparison]::Ordinal)
+)
+if (-not $promoteMetadataBody.Contains('Get-FrozenQualificationAssetPath') -or
+    -not $promoteMetadataBody.Contains('$frozenQualificationEvidence') -or
+    $promoteMetadataBody.Contains('(Join-Path $downloaded $qualificationEvidenceName)')) {
+    Fail "PromoteMetadata must use frozen qualification evidence outside downloaded/"
+}
+foreach ($workflowSource in @(
+    [pscustomobject]@{ Name = 'production release workflow'; Text = $workflow },
+    [pscustomobject]@{ Name = 'controlled rehearsal workflow'; Text = $draftWorkflow }
+)) {
+    if ($workflowSource.Text -match 'sbom-path:\s+\$\{\{ runner\.temp \}\}[^\r\n]*\\downloaded\\SBOM\.spdx\.json') {
+        Fail "$($workflowSource.Name) still attests an SBOM from downloaded/"
+    }
+    if (-not $workflowSource.Text.Contains('candidate-assets\SBOM.spdx.json')) {
+        Fail "$($workflowSource.Name) does not attest the frozen candidate SBOM"
+    }
 }
 $finalVerifyBody = $pipeline.Substring(
     $pipeline.IndexOf('function Invoke-FinalVerify', [StringComparison]::Ordinal),

--- a/scripts/test_v4_release_pipeline.ps1
+++ b/scripts/test_v4_release_pipeline.ps1
@@ -440,6 +440,7 @@ foreach ($marker in @(
     'current-user', 'active-playback-install-rejected', 'upload_url',
     'Assert-ImmutableRelease $published', 'repository release is not marked immutable',
     'V4 immutable publication guard self-test', 'immutable=false rejected',
+    'V4 exact public asset-set self-test', 'missing and extra assets rejected',
     'Get-V4ReleaseMakeLatestValue',
     'Get-V4ReleaseDraftMakeLatestValue',
     'make_latest = Get-V4ReleaseDraftMakeLatestValue',
@@ -495,6 +496,67 @@ if (-not $publishDraftBody.Contains('make_latest = Get-V4ReleaseMakeLatestValue 
     $publishDraftBody.Contains('Get-V4ReleaseDraftMakeLatestValue')) {
     Fail "PublishDraft must use the channel-aware publication make_latest helper"
 }
+
+# Public release asset regression contract: the previous v4.0.1 failure uploaded
+# the complete eight-file qualification candidate set. Keep the two sets explicit
+# and make every public boundary consume only the canonical two-record projection.
+foreach ($marker in @(
+    'function Get-QualificationCandidateRecords',
+    'function Get-PublicReleaseRecords',
+    'function Get-CanonicalPublicReleaseNames',
+    'qualification_assets = $candidateAssets',
+    'public_assets = $publicRecords',
+    'Assert-ManifestAssetFiles',
+    'Freeze-CandidateAssets',
+    'Get-StateAssetPath',
+    'Assert-ExactPublicReleaseAssetSet',
+    'candidate manifest must declare qualification_assets and public_assets separately',
+    'downloaded manifest must contain only the public release asset set'
+)) {
+    if (-not $pipeline.Contains($marker)) {
+        Fail "public release asset separation marker is missing: $marker"
+    }
+}
+$createDraftUploadBody = $createDraftBody.Substring(
+    $createDraftBody.IndexOf('foreach ($record in $publicRecords)', [StringComparison]::Ordinal)
+)
+if (-not $createDraftUploadBody.Contains('Invoke-V4ReleaseAssetUpload') -or
+    $createDraftUploadBody.Contains('Get-QualificationCandidateRecords') -or
+    $createDraftUploadBody.Contains('manifest.assets')) {
+    Fail "CreateDraft upload loop is not restricted to public_assets"
+}
+$downloadDraftBody = $pipeline.Substring(
+    $pipeline.IndexOf('function Invoke-DownloadDraft', [StringComparison]::Ordinal),
+    $pipeline.IndexOf('function Invoke-Checked', [StringComparison]::Ordinal) -
+        $pipeline.IndexOf('function Invoke-DownloadDraft', [StringComparison]::Ordinal)
+)
+if (-not $downloadDraftBody.Contains('$publicRecords = @(Get-PublicReleaseRecordsFromManifest $candidateManifest)') -or
+    -not $downloadDraftBody.Contains('foreach ($expected in $publicRecords)') -or
+    -not $downloadDraftBody.Contains('Get-FileHash') -or
+    -not $downloadDraftBody.Contains('$expected.sha256')) {
+    Fail "DownloadDraft does not digest-check the exact public candidate records"
+}
+$qualifyDownloadedBody = $pipeline.Substring(
+    $pipeline.IndexOf('function Invoke-QualifyDownloaded', [StringComparison]::Ordinal),
+    $pipeline.IndexOf('function Invoke-PublishDraft', [StringComparison]::Ordinal) -
+        $pipeline.IndexOf('function Invoke-QualifyDownloaded', [StringComparison]::Ordinal)
+)
+if (-not $qualifyDownloadedBody.Contains('Assert-CandidateEvidence @($candidateManifest.qualification_assets)') -or
+    -not $qualifyDownloadedBody.Contains('$downloadedPublicRecords[$index].sha256')) {
+    Fail "QualifyDownloaded does not hash-check frozen evidence and downloaded public bytes"
+}
+$finalVerifyBody = $pipeline.Substring(
+    $pipeline.IndexOf('function Invoke-FinalVerify', [StringComparison]::Ordinal),
+    $pipeline.IndexOf('function Invoke-SelfTest', [StringComparison]::Ordinal) -
+        $pipeline.IndexOf('function Invoke-FinalVerify', [StringComparison]::Ordinal)
+)
+if (-not $finalVerifyBody.Contains('Assert-ExactPublicReleaseAssetSet $release') -or
+    -not $finalVerifyBody.Contains('Assert-ExactAssetSet $release $publicRecords') -or
+    -not $finalVerifyBody.Contains('Get-PublicReleaseRecordsFromManifest $candidateManifest') -or
+    -not $finalVerifyBody.Contains('Get-FileHash')) {
+    Fail "FinalVerify does not enforce exact public asset-set and byte equality"
+}
+Write-Host "V4 public release asset regression contract: PASS (8-file qualification set isolated; exact 2-file public set enforced)"
 foreach ($marker in @(
     'function Get-SanitizedReleaseProbeOutput',
     'version-check.log',
@@ -646,6 +708,19 @@ foreach ($marker in @(
     'RecordAttestations', 'PublishDraft', 'PromoteMetadata', 'FinalVerify'
 )) {
     if (-not $workflow.Contains($marker)) { Fail "workflow marker is missing: $marker" }
+}
+foreach ($marker in @(
+    'candidate-manifest.json',
+    'candidate-assets\*.json',
+    'downloaded-manifest.json',
+    'downloaded-authenticode-verification.json',
+    'fixture-http-evidence.json',
+    'post-draft-qualification.json',
+    'defender-evidence.json',
+    'release-state.json'
+)) {
+    if (-not $workflow.Contains($marker)) { Fail "production bounded evidence retention marker is missing: $marker" }
+    if (-not $draftWorkflow.Contains($marker)) { Fail "rehearsal bounded evidence retention marker is missing: $marker" }
 }
 if ($workflow.Contains('inputs:') -or $workflow.Contains('inputs.')) {
     Fail "production release workflow must not expose semantic workflow_dispatch inputs"

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -482,6 +482,21 @@ function Get-StateAssetPath([object]$Record) {
     return $full
 }
 
+function Get-FrozenQualificationAssetPath([object[]]$Records, [string]$SourceName) {
+    $matches = @($Records | Where-Object {
+        [string]$_.source_name -eq $SourceName -or
+        ([string]$_.name -eq $SourceName -and $null -eq $_.PSObject.Properties['source_name'])
+    })
+    if ($matches.Count -ne 1) {
+        Fail "candidate manifest must contain exactly one frozen qualification asset: $SourceName"
+    }
+    $path = Get-StateAssetPath $matches[0]
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        Fail "frozen qualification asset is missing: $SourceName"
+    }
+    return $path
+}
+
 function Assert-ManifestAssetFiles([object[]]$Records) {
     foreach ($record in @($Records)) {
         $path = Get-StateAssetPath $record
@@ -883,6 +898,7 @@ function Invoke-QualifyDownloaded {
     }
     $candidateManifest = Read-JsonFile (Join-Path $root "candidate-manifest.json")
     $publicRecords = @(Get-PublicReleaseRecordsFromManifest $candidateManifest)
+    $qualificationRecords = @($candidateManifest.qualification_assets)
     $downloadedPublicRecords = @($downloadedManifest.public_assets)
     if ($downloadedPublicRecords.Count -ne $publicRecords.Count) {
         Fail "downloaded public manifest does not match the canonical public asset count"
@@ -894,7 +910,11 @@ function Invoke-QualifyDownloaded {
             Fail "downloaded public manifest does not bind the candidate installer/signature bytes"
         }
     }
-    Assert-CandidateEvidence @($candidateManifest.qualification_assets)
+    Assert-CandidateEvidence $qualificationRecords
+    $frozenQualificationEvidence = Get-FrozenQualificationAssetPath $qualificationRecords $qualificationEvidenceName
+    $frozenAuthenticodeEvidence = Get-FrozenQualificationAssetPath $qualificationRecords $authenticodeEvidenceName
+    $frozenArtifactSummary = Get-FrozenQualificationAssetPath $qualificationRecords $summaryName
+    $frozenSbom = Get-FrozenQualificationAssetPath $qualificationRecords $sbomName
     $bundle = Join-Path $root "downloaded-bundle"
     if (Test-Path -LiteralPath $bundle) { Remove-Item -LiteralPath $bundle -Recurse -Force }
     New-Item -ItemType Directory -Path $bundle -Force | Out-Null
@@ -916,18 +936,18 @@ function Invoke-QualifyDownloaded {
         "--signature", (Join-Path $bundle $sourceSignature)
     ) "downloaded candidate Tauri updater signature verification failed"
     Invoke-Checked "cargo" @(
-        "xtask", "sbom", "verify", "--artifact-dir", $bundle, "--sbom", (Join-Path $downloaded $sbomName)
+        "xtask", "sbom", "verify", "--artifact-dir", $bundle, "--sbom", $frozenSbom
     ) "downloaded candidate SPDX SBOM verification failed"
     Invoke-Checked "cargo" @(
         "xtask", "verify-tauri-bundle", "--bundle-dir", $bundle,
-        "--summary", (Join-Path $downloaded $summaryName),
-        "--authenticode-evidence", (Join-Path $downloaded $authenticodeEvidenceName),
-        "--sbom", (Join-Path $downloaded $sbomName)
+        "--summary", $frozenArtifactSummary,
+        "--authenticode-evidence", $frozenAuthenticodeEvidence,
+        "--sbom", $frozenSbom
     ) "downloaded candidate exact Tauri bundle verification failed"
     Invoke-Checked "pwsh" @(
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", (Join-Path $PSScriptRoot "promote_v4_metadata.ps1"),
-        "-ValidateEvidence", (Join-Path $downloaded $qualificationEvidenceName)
+        "-ValidateEvidence", $frozenQualificationEvidence
     ) "downloaded candidate qualification evidence schema validation failed"
 
     # Export the canonical public root through the existing updater-trust
@@ -1172,6 +1192,9 @@ function Invoke-PromoteMetadata {
     }
     Assert-ImmutableRelease $publishedRelease
     $publicationDateUtc = Convert-PublishedAtToMetadataTimestamp $publishedRelease
+    $candidateManifest = Read-JsonFile (Join-Path $root "candidate-manifest.json")
+    $qualificationRecords = @($candidateManifest.qualification_assets)
+    $frozenQualificationEvidence = Get-FrozenQualificationAssetPath $qualificationRecords $qualificationEvidenceName
     $metadataCheckout = Join-Path $root "release-metadata"
     if (Test-Path -LiteralPath $metadataCheckout) { Remove-Item -LiteralPath $metadataCheckout -Recurse -Force }
     Invoke-GitHubApi -Arguments @("repo", "clone", $repository, $metadataCheckout, "--", "--branch", "release-metadata", "--depth", "1") -Raw | Out-Null
@@ -1192,7 +1215,7 @@ function Invoke-PromoteMetadata {
         "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
         "-File", (Join-Path $PSScriptRoot "promote_v4_metadata.ps1"),
         "-Channel", $Channel, "-Metadata", $metadata,
-        "-QualificationEvidence", (Join-Path $downloaded $qualificationEvidenceName),
+        "-QualificationEvidence", $frozenQualificationEvidence,
         "-MetadataCheckout", $metadataCheckout, "-SourceCheckout", $repoRoot
     ) "post-publication metadata promotion validation failed"
     $destination = Join-Path $metadataCheckout "channels/$Channel/latest.json"

--- a/scripts/v4_release_pipeline.ps1
+++ b/scripts/v4_release_pipeline.ps1
@@ -397,7 +397,7 @@ function Get-ExpectedInstallerName {
     return "Sky Auto Player_${Version}$installerSuffix"
 }
 
-function Get-CandidateRecords {
+function Get-QualificationCandidateRecords {
     $installer = Get-ExpectedInstallerName
     $bundle = Join-Path $repoRoot "rust/target/dist/bundle/nsis"
     $evidence = Join-Path $repoRoot "rust/target/dist"
@@ -413,6 +413,43 @@ function Get-CandidateRecords {
     )
 }
 
+function Get-CanonicalPublicReleaseNames {
+    $installer = Get-V4SafeReleaseAssetName (Get-ExpectedInstallerName)
+    return @(
+        $installer
+        (Get-V4SafeReleaseAssetName "$((Get-ExpectedInstallerName)).sig")
+    )
+}
+
+function Get-PublicReleaseRecords([object[]]$QualificationRecords) {
+    if ($null -eq $QualificationRecords -or @($QualificationRecords).Count -eq 0) {
+        Fail "qualification candidate set is empty"
+    }
+
+    $expectedNames = @(Get-CanonicalPublicReleaseNames)
+    $records = @(
+        foreach ($expectedName in $expectedNames) {
+            $matches = @($QualificationRecords | Where-Object {
+                [string]$_.release_name -eq $expectedName
+            })
+            if ($matches.Count -ne 1) {
+                Fail "qualification candidate set does not contain exactly one canonical public record: $expectedName"
+            }
+            $matches[0]
+        }
+    )
+
+    $expectedRoles = @("installer", "updater-signature")
+    for ($index = 0; $index -lt $records.Count; $index++) {
+        $record = $records[$index]
+        if ([string]$record.role -ne $expectedRoles[$index] -or
+            [string]$record.release_name -ne $expectedNames[$index]) {
+            Fail "canonical public record has an unexpected role or release name: $($record.release_name)"
+        }
+    }
+    return $records
+}
+
 function Get-FileRecord([object]$Candidate) {
     if (-not (Test-Path -LiteralPath $Candidate.path -PathType Leaf)) { Fail "qualified candidate file is missing: $($Candidate.name)" }
     $item = Get-Item -LiteralPath $Candidate.path
@@ -426,7 +463,71 @@ function Get-FileRecord([object]$Candidate) {
         role = [string]$Candidate.role
         size = [int64]$item.Length
         sha256 = (Get-FileHash -LiteralPath $Candidate.path -Algorithm SHA256).Hash.ToLowerInvariant()
+        source_path = [string]$Candidate.path
+        state_path = (Join-Path "candidate-assets" $releaseName).Replace("\", "/")
     }
+}
+
+function Get-StateAssetPath([object]$Record) {
+    $relative = [string]$Record.state_path
+    if ([string]::IsNullOrWhiteSpace($relative) -or [IO.Path]::IsPathRooted($relative)) {
+        Fail "candidate manifest contains an invalid state asset path"
+    }
+    $root = Get-EffectiveStateRoot
+    $full = [IO.Path]::GetFullPath((Join-Path $root $relative))
+    $prefix = $root.TrimEnd("\", "/") + [IO.Path]::DirectorySeparatorChar
+    if (-not $full.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+        Fail "candidate manifest state asset path escapes the release state root"
+    }
+    return $full
+}
+
+function Assert-ManifestAssetFiles([object[]]$Records) {
+    foreach ($record in @($Records)) {
+        $path = Get-StateAssetPath $record
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            Fail "frozen qualification asset is missing: $($record.release_name)"
+        }
+        $item = Get-Item -LiteralPath $path
+        $hash = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ([int64]$item.Length -ne [int64]$record.size -or $hash -ne [string]$record.sha256) {
+            Fail "frozen qualification asset differs from the candidate manifest: $($record.release_name)"
+        }
+    }
+}
+
+function Freeze-CandidateAssets([object[]]$Records) {
+    foreach ($record in @($Records)) {
+        $destination = Get-StateAssetPath $record
+        New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force | Out-Null
+        Copy-Item -LiteralPath ([string]$record.source_path) -Destination $destination -Force
+    }
+    Assert-ManifestAssetFiles $Records
+}
+
+function Get-PublicReleaseRecordsFromManifest([object]$Manifest) {
+    if ($null -eq $Manifest.PSObject.Properties['qualification_assets'] -or
+        $null -eq $Manifest.PSObject.Properties['public_assets']) {
+        Fail "candidate manifest must declare qualification_assets and public_assets separately"
+    }
+    $qualificationRecords = @($Manifest.qualification_assets)
+    $derived = @(Get-PublicReleaseRecords $qualificationRecords)
+    $declared = @($Manifest.public_assets)
+    if ($declared.Count -ne $derived.Count) {
+        Fail "candidate manifest public_assets must contain exactly the canonical installer and signature"
+    }
+    for ($index = 0; $index -lt $derived.Count; $index++) {
+        if ([string]$declared[$index].name -ne [string]$derived[$index].name -or
+            [string]$declared[$index].release_name -ne [string]$derived[$index].release_name -or
+            [string]$declared[$index].source_name -ne [string]$derived[$index].source_name -or
+            [string]$declared[$index].role -ne [string]$derived[$index].role -or
+            [string]$declared[$index].state_path -ne [string]$derived[$index].state_path -or
+            [string]$declared[$index].sha256 -ne [string]$derived[$index].sha256 -or
+            [int64]$declared[$index].size -ne [int64]$derived[$index].size) {
+            Fail "candidate manifest public_assets are not an exact projection of qualification_assets"
+        }
+    }
+    return $derived
 }
 
 function Assert-EvidenceIdentity([string]$ProductionPath, [string]$QualificationPath, [object[]]$Records) {
@@ -459,6 +560,9 @@ function Assert-EvidenceIdentity([string]$ProductionPath, [string]$Qualification
     }
     $instRec = $recordsByName[(Get-ExpectedInstallerName)]
     $sigRec = $recordsByName["$((Get-ExpectedInstallerName)).sig"]
+    if ($null -eq $instRec -or $null -eq $sigRec) {
+        Fail "candidate manifest is missing the canonical installer or updater signature record"
+    }
     $instSourceName = if ($null -ne $instRec.PSObject.Properties['source_name']) { [string]$instRec.source_name } else { [string]$instRec.name }
     $sigSourceName = if ($null -ne $sigRec.PSObject.Properties['source_name']) { [string]$sigRec.source_name } else { [string]$sigRec.name }
 
@@ -467,6 +571,7 @@ function Assert-EvidenceIdentity([string]$ProductionPath, [string]$Qualification
         [string]$evidence.authenticode_evidence -ne $authenticodeEvidenceName -or
         [string]$evidence.sbom -ne $sbomName -or
         [string]$evidence.installer -ne $instSourceName -or
+        [string]$evidence.updater_signature -ne $sigSourceName -or
         [int64]$evidence.installer_size -ne [int64]$instRec.size -or
         [string]$evidence.installer_sha256 -ne [string]$instRec.sha256 -or
         [int64]$evidence.signature_size -ne [int64]$sigRec.size -or
@@ -486,9 +591,15 @@ function Assert-EvidenceIdentity([string]$ProductionPath, [string]$Qualification
 }
 
 function Assert-CandidateEvidence([object[]]$Records) {
+    Assert-ManifestAssetFiles $Records
+    $productionRecord = @($Records | Where-Object { [string]$_.source_name -eq $productionEvidenceName })
+    $qualificationRecord = @($Records | Where-Object { [string]$_.source_name -eq $qualificationEvidenceName })
+    if ($productionRecord.Count -ne 1 -or $qualificationRecord.Count -ne 1) {
+        Fail "candidate manifest is missing frozen production or qualification evidence"
+    }
     Assert-EvidenceIdentity `
-        (Join-Path $repoRoot "rust/target/dist/$productionEvidenceName") `
-        (Join-Path $repoRoot "rust/target/dist/$qualificationEvidenceName") `
+        (Get-StateAssetPath $productionRecord[0]) `
+        (Get-StateAssetPath $qualificationRecord[0]) `
         $Records
 }
 
@@ -520,7 +631,7 @@ function Invoke-BuildCandidate {
         if ($LASTEXITCODE -ne 0) { Fail "production orchestrator failed" }
     }
 
-    $records = @(Get-CandidateRecords | ForEach-Object { Get-FileRecord $_ })
+    $records = @(Get-QualificationCandidateRecords | ForEach-Object { Get-FileRecord $_ })
     $releaseNames = @{}
     foreach ($record in $records) {
         $releaseName = [string]$record.release_name
@@ -529,14 +640,28 @@ function Invoke-BuildCandidate {
         }
         $releaseNames[$releaseName] = [string]$record.source_name
     }
-    Assert-CandidateEvidence $records
+    Freeze-CandidateAssets $records
+    $candidateAssets = @($records | ForEach-Object {
+        [pscustomobject]@{
+            name = $_.name
+            source_name = $_.source_name
+            release_name = $_.release_name
+            role = $_.role
+            size = $_.size
+            sha256 = $_.sha256
+            state_path = $_.state_path
+        }
+    })
+    $publicRecords = @(Get-PublicReleaseRecords $candidateAssets)
+    Assert-CandidateEvidence $candidateAssets
     $manifest = [ordered]@{
         schema_version = 1
         source_sha = $SourceSha.ToLowerInvariant()
         version = $Version
         channel = $Channel
         authenticode_mode = "unsigned-zero-budget"
-        assets = $records
+        qualification_assets = $candidateAssets
+        public_assets = $publicRecords
     }
     Write-JsonFile (Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json") $manifest
     Write-Host "V4 candidate build: PASS (one orchestrator invocation; exact candidate manifest recorded)"
@@ -623,6 +748,8 @@ function Invoke-CreateDraft {
     $repository = Get-CanonicalRepository
     $manifestPath = Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json"
     $manifest = Read-JsonFile $manifestPath
+    $publicRecords = @(Get-PublicReleaseRecordsFromManifest $manifest)
+    Assert-CandidateEvidence @($manifest.qualification_assets)
     Assert-NoExistingReleaseTag
     $notesPath = Assert-ReleaseNotes
     $body = "V4 qualified release candidate`n`nsource_sha: $($SourceSha.ToLowerInvariant())`nchannel: $Channel`nqualification: exact candidate manifest attached`n"
@@ -645,18 +772,18 @@ function Invoke-CreateDraft {
         Fail "repository draft returned an unexpected release asset upload_url"
     }
 
-    foreach ($record in $manifest.assets) {
+    foreach ($record in $publicRecords) {
         $sourceName = if ($null -ne $record.PSObject.Properties['source_name']) { [string]$record.source_name } else { [string]$record.name }
         $releaseName = if ($null -ne $record.PSObject.Properties['release_name']) { [string]$record.release_name } else { Get-V4SafeReleaseAssetName $sourceName }
-        $candidate = (Get-CandidateRecords | Where-Object { $_.name -eq $sourceName })
-        if ($null -eq $candidate) { Fail "candidate manifest contains an unknown asset: $sourceName" }
+        $candidatePath = Get-StateAssetPath $record
+        if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) { Fail "frozen public candidate is missing: $sourceName" }
         # GitHub's release-specific upload_url is deliberately used here. The
         # endpoint rejects duplicate names; this path never deletes or
         # replaces an asset after a failed upload.
         $uploaded = Invoke-V4ReleaseAssetUpload `
             -UploadUrl $uploadUrl `
             -AssetName $releaseName `
-            -FilePath ([string]$candidate.path)
+            -FilePath $candidatePath
         if ([string]$uploaded.name -ne $releaseName -or
             [int64]$uploaded.size -ne [int64]$record.size -or
             [string]$uploaded.state -ne "uploaded") {
@@ -675,7 +802,8 @@ function Invoke-CreateDraft {
         immutable = $false
         attested = $false
         qualified_after_download = $false
-        assets = $manifest.assets
+        qualification_assets = @($manifest.qualification_assets)
+        public_assets = $publicRecords
     }
     Write-JsonFile (Get-StatePath) $state
     Write-Host "V4 repository draft: PASS (tag=$Tag; exact qualified asset set uploaded)"
@@ -687,6 +815,14 @@ function Assert-ExactAssetSet([object]$Release, [object[]]$Expected) {
         if ($null -ne $_.PSObject.Properties['release_name']) { [string]$_.release_name } else { [string]$_.name }
     } | Sort-Object)
     if (($actual -join "`n") -ne ($expectedNames -join "`n")) { Fail "repository release asset set differs from the qualified candidate set" }
+}
+
+function Assert-ExactPublicReleaseAssetSet([object]$Release) {
+    $actual = @($Release.assets | ForEach-Object { [string]$_.name } | Sort-Object)
+    $expected = @(Get-CanonicalPublicReleaseNames | Sort-Object)
+    if (($actual -join "`n") -ne ($expected -join "`n")) {
+        Fail "repository release must contain exactly the canonical installer and updater signature"
+    }
 }
 
 function Assert-ImmutableRelease([object]$Release) {
@@ -701,11 +837,14 @@ function Invoke-DownloadDraft {
     $repository = Get-CanonicalRepository
     $release = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/$($state.release_id)")
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "repository release is not the expected draft" }
-    Assert-ExactAssetSet $release $state.assets
+    $candidateManifest = Read-JsonFile (Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json")
+    $publicRecords = @(Get-PublicReleaseRecordsFromManifest $candidateManifest)
+    Assert-ExactPublicReleaseAssetSet $release
+    Assert-ExactAssetSet $release $publicRecords
     $downloaded = Join-Path (Get-EffectiveStateRoot) "downloaded"
     if (Test-Path -LiteralPath $downloaded) { Remove-Item -LiteralPath $downloaded -Recurse -Force }
     New-Item -ItemType Directory -Path $downloaded -Force | Out-Null
-    foreach ($expected in $state.assets) {
+    foreach ($expected in $publicRecords) {
         $expectedReleaseName = if ($null -ne $expected.PSObject.Properties['release_name']) { [string]$expected.release_name } else { [string]$expected.name }
         $asset = @($release.assets | Where-Object { [string]$_.name -eq $expectedReleaseName })
         if ($asset.Count -ne 1) { Fail "expected repository asset is missing: $expectedReleaseName" }
@@ -722,9 +861,9 @@ function Invoke-DownloadDraft {
         source_sha = [string]$state.source_sha
         version = [string]$state.version
         channel = [string]$state.channel
-        assets = $state.assets
+        public_assets = $publicRecords
     })
-    Write-Host "V4 draft download: PASS (all qualification inputs re-downloaded and byte-checked)"
+    Write-Host "V4 draft download: PASS (exact public installer and signature re-downloaded and byte-checked)"
 }
 
 function Invoke-Checked([string]$File, [string[]]$Arguments, [string]$Failure) {
@@ -737,12 +876,25 @@ function Invoke-QualifyDownloaded {
     if (-not $state.draft -or $state.published) { Fail "post-draft qualification requires an unpublished draft" }
     $root = Get-EffectiveStateRoot
     $downloaded = Join-Path $root "downloaded"
-    $manifest = Read-JsonFile (Join-Path $root "downloaded-manifest.json")
-    if ([string]$manifest.source_sha -ne $SourceSha.ToLowerInvariant()) { Fail "downloaded source binding mismatch" }
-    Assert-EvidenceIdentity `
-        (Join-Path $downloaded $productionEvidenceName) `
-        (Join-Path $downloaded $qualificationEvidenceName) `
-        @($manifest.assets)
+    $downloadedManifest = Read-JsonFile (Join-Path $root "downloaded-manifest.json")
+    if ([string]$downloadedManifest.source_sha -ne $SourceSha.ToLowerInvariant()) { Fail "downloaded source binding mismatch" }
+    if ($null -eq $downloadedManifest.PSObject.Properties['public_assets']) {
+        Fail "downloaded manifest must contain only the public release asset set"
+    }
+    $candidateManifest = Read-JsonFile (Join-Path $root "candidate-manifest.json")
+    $publicRecords = @(Get-PublicReleaseRecordsFromManifest $candidateManifest)
+    $downloadedPublicRecords = @($downloadedManifest.public_assets)
+    if ($downloadedPublicRecords.Count -ne $publicRecords.Count) {
+        Fail "downloaded public manifest does not match the canonical public asset count"
+    }
+    for ($index = 0; $index -lt $publicRecords.Count; $index++) {
+        if ([string]$downloadedPublicRecords[$index].release_name -ne [string]$publicRecords[$index].release_name -or
+            [string]$downloadedPublicRecords[$index].sha256 -ne [string]$publicRecords[$index].sha256 -or
+            [int64]$downloadedPublicRecords[$index].size -ne [int64]$publicRecords[$index].size) {
+            Fail "downloaded public manifest does not bind the candidate installer/signature bytes"
+        }
+    }
+    Assert-CandidateEvidence @($candidateManifest.qualification_assets)
     $bundle = Join-Path $root "downloaded-bundle"
     if (Test-Path -LiteralPath $bundle) { Remove-Item -LiteralPath $bundle -Recurse -Force }
     New-Item -ItemType Directory -Path $bundle -Force | Out-Null
@@ -810,7 +962,7 @@ function Invoke-QualifyDownloaded {
         "-Evidence", $defenderEvidencePath
     ) "exact downloaded installer Defender scan failed"
     $defenderEvidence = Read-JsonFile $defenderEvidencePath
-    $installerRecord = @($state.assets | Where-Object {
+    $installerRecord = @($publicRecords | Where-Object {
         [string]$_.name -eq $releaseInstaller -or
         ($null -ne $_.PSObject.Properties['source_name'] -and [string]$_.source_name -eq $sourceInstaller)
     })
@@ -963,8 +1115,11 @@ function Invoke-PublishDraft {
     $repository = Get-CanonicalRepository
     $release = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/$($state.release_id)")
     if (-not $release.draft -or [string]$release.tag_name -ne $Tag) { Fail "draft is missing or has changed before publication" }
-    Assert-ExactAssetSet $release $state.assets
-    foreach ($expected in $state.assets) {
+    $candidateManifest = Read-JsonFile (Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json")
+    $publicRecords = @(Get-PublicReleaseRecordsFromManifest $candidateManifest)
+    Assert-ExactPublicReleaseAssetSet $release
+    Assert-ExactAssetSet $release $publicRecords
+    foreach ($expected in $publicRecords) {
         $expectedReleaseName = if ($null -ne $expected.PSObject.Properties['release_name']) { [string]$expected.release_name } else { [string]$expected.name }
         $asset = @($release.assets | Where-Object { [string]$_.name -eq $expectedReleaseName })
         if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "draft asset changed before publication: $expectedReleaseName" }
@@ -1074,8 +1229,11 @@ function Invoke-FinalVerify {
     $release = Invoke-GitHubApi -Arguments @("api", "repos/$repository/releases/tags/$Tag")
     if ($release.draft -or [string]::IsNullOrWhiteSpace([string]$release.published_at)) { Fail "final release is still draft or unpublished" }
     Assert-ImmutableRelease $release
-    Assert-ExactAssetSet $release $state.assets
-    foreach ($expected in $state.assets) {
+    $candidateManifest = Read-JsonFile (Join-Path (Get-EffectiveStateRoot) "candidate-manifest.json")
+    $publicRecords = @(Get-PublicReleaseRecordsFromManifest $candidateManifest)
+    Assert-ExactPublicReleaseAssetSet $release
+    Assert-ExactAssetSet $release $publicRecords
+    foreach ($expected in $publicRecords) {
         $expectedReleaseName = if ($null -ne $expected.PSObject.Properties['release_name']) { [string]$expected.release_name } else { [string]$expected.name }
         $asset = @($release.assets | Where-Object { [string]$_.name -eq $expectedReleaseName })
         if ($asset.Count -ne 1 -or [int64]$asset[0].size -ne [int64]$expected.size) { Fail "final public asset identity changed: $expectedReleaseName" }
@@ -1156,6 +1314,37 @@ function Invoke-SelfTest {
     }
     Assert-ImmutableRelease ([pscustomobject]@{ immutable = $true })
     Write-Host "V4 immutable publication guard self-test: PASS (immutable=false rejected; immutable=true accepted)"
+
+    $selfTestVersion = $Version
+    try {
+        $Version = "4.0.0-rc.1"
+        $publicNames = @(Get-CanonicalPublicReleaseNames)
+        $exactPublicRelease = [pscustomobject]@{
+            assets = @(
+                [pscustomobject]@{ name = $publicNames[0] }
+                [pscustomobject]@{ name = $publicNames[1] }
+            )
+        }
+        Assert-ExactPublicReleaseAssetSet $exactPublicRelease
+        foreach ($invalidAssets in @(
+            @([pscustomobject]@{ name = $publicNames[0] }),
+            @(
+                [pscustomobject]@{ name = $publicNames[0] }
+                [pscustomobject]@{ name = $publicNames[1] }
+                [pscustomobject]@{ name = "SBOM.spdx.json" }
+            )
+        )) {
+            try {
+                Assert-ExactPublicReleaseAssetSet ([pscustomobject]@{ assets = $invalidAssets })
+                Fail "FinalVerify public asset-set self-test accepted missing or extra assets"
+            } catch {
+                if ($_.Exception.Message -notmatch "exactly the canonical installer") { throw }
+            }
+        }
+        Write-Host "V4 exact public asset-set self-test: PASS (missing and extra assets rejected)"
+    } finally {
+        $Version = $selfTestVersion
+    }
 
     foreach ($channelCase in @(
         [pscustomobject]@{ Channel = "stable"; PublishExpected = "true" },


### PR DESCRIPTION
Fixes #204

## Public asset contract

Before: candidate-manifest.json had one 8-file asset set and CreateDraft uploaded installer, signature, qualification JSON, Authenticode evidence, artifact summary, and SBOM.

After: qualification_assets retains all mandatory qualification inputs; public_assets is an explicit fail-closed projection containing exactly the normalized installer and updater signature. CreateDraft, draft download, publication, and FinalVerify consume only that public pair.

## Release-state invariants

- Frozen qualification assets are copied into the isolated state root and re-validated by size/SHA-256 before trusted use.
- DownloadDraft, PublishDraft, and FinalVerify bind public bytes to candidate-manifest.json.
- FinalVerify rejects missing, extra, aliased, or size/digest-mismatched public assets.
- OIDC and SPDX attestations remain on exact downloaded installer/signature bytes.
- Evidence/SBOM retention is bounded to GitHub Actions artifacts and attestations; v4.0.1 is untouched.
- Updater metadata, immutable publication, and monotonic promotion guards are preserved.

## Verification

- `pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/v4_release_pipeline.ps1 -State SelfTest`: PASS
- `pwsh -NoProfile -NonInteractive -ExecutionPolicy Bypass -File scripts/test_v4_release_pipeline.ps1`: PASS
- `cargo xtask check static`: PASS
- PowerShell parser checks for changed scripts: PASS
- `git diff --check`: PASS

No production release was dispatched or published. v4.0.1 was not modified.