### PR TITLE
Polish desktop update titlebar indicator

### DIFF
--- a/desktop/src/components/chrome/AppTitleBar.test.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.test.tsx
@@ -49,6 +49,53 @@ describe('AppTitleBar', () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
+  it('shows a subtle update indicator only when an update is available', async () => {
+    const { bootstrap, useStore } = await testBootstrap();
+    const controls: WindowControls = {
+      minimize: async () => undefined,
+      toggleMaximize: async () => undefined,
+      close: async () => undefined,
+      isMaximized: async () => false,
+      onResize: async () => () => undefined,
+    };
+
+    render(<AppTitleBar bootstrap={bootstrap} useStore={useStore} windowControls={controls} />);
+    expect(screen.queryByRole('button', { name: /Update available:/ })).toBeNull();
+
+    act(() => {
+      useStore.setState({
+        update: {
+          ...useStore.getState().update,
+          state: 'available',
+          currentVersion: bootstrap.app_version,
+          availableVersion: '4.0.2',
+        },
+      });
+    });
+
+    const indicator = await screen.findByRole('button', { name: 'Update available: 4.0.2' });
+    expect(indicator).toHaveAttribute(
+      'title',
+      'Update available: 4.0.2. Open update details.',
+    );
+    expect(indicator.querySelector('.update-indicator-dot')).toHaveAttribute('aria-hidden', 'true');
+
+    fireEvent.click(indicator);
+    expect(useStore.getState().update.dialogOpen).toBe(true);
+
+    act(() => {
+      useStore.setState({
+        update: {
+          ...useStore.getState().update,
+          state: 'current',
+          availableVersion: null,
+          dialogOpen: false,
+        },
+      });
+    });
+    expect(screen.queryByRole('button', { name: /Update available:/ })).toBeNull();
+  });
+
   it('refreshes the maximize state after resize', async () => {
     const { bootstrap, useStore } = await testBootstrap();
     let maximized = false;

--- a/desktop/src/components/chrome/AppTitleBar.test.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.test.tsx
@@ -74,10 +74,7 @@ describe('AppTitleBar', () => {
     });
 
     const indicator = await screen.findByRole('button', { name: 'Update available: 4.0.2' });
-    expect(indicator).toHaveAttribute(
-      'title',
-      'Update available: 4.0.2. Open update details.',
-    );
+    expect(indicator).toHaveAttribute('title', 'Update available: 4.0.2. Open update details.');
     expect(indicator.querySelector('.update-indicator-dot')).toHaveAttribute('aria-hidden', 'true');
 
     fireEvent.click(indicator);

--- a/desktop/src/components/chrome/AppTitleBar.test.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.test.tsx
@@ -85,7 +85,10 @@ describe('AppTitleBar', () => {
     });
 
     const indicator = await screen.findByRole('button', { name: 'Update available: 4.0.2' });
-    expect(indicator).toHaveAttribute('title', 'Update available: 4.0.2. Open update details.');
+    expect(indicator.closest('.update-indicator-shell')).toHaveAttribute(
+      'title',
+      'Update available: 4.0.2. Open update details.',
+    );
     expect(indicator.querySelector('.update-indicator-dot')).toHaveAttribute('aria-hidden', 'true');
 
     fireEvent.click(indicator);

--- a/desktop/src/components/chrome/AppTitleBar.test.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.test.tsx
@@ -59,6 +59,18 @@ describe('AppTitleBar', () => {
       onResize: async () => () => undefined,
     };
 
+    act(() => {
+      useStore.setState({
+        update: {
+          ...useStore.getState().update,
+          state: 'current',
+          currentVersion: bootstrap.app_version,
+          availableVersion: null,
+          dialogOpen: false,
+        },
+      });
+    });
+
     render(<AppTitleBar bootstrap={bootstrap} useStore={useStore} windowControls={controls} />);
     expect(screen.queryByRole('button', { name: /Update available:/ })).toBeNull();
 
@@ -67,7 +79,6 @@ describe('AppTitleBar', () => {
         update: {
           ...useStore.getState().update,
           state: 'available',
-          currentVersion: bootstrap.app_version,
           availableVersion: '4.0.2',
         },
       });

--- a/desktop/src/components/chrome/AppTitleBar.test.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.test.tsx
@@ -72,7 +72,7 @@ describe('AppTitleBar', () => {
     });
 
     render(<AppTitleBar bootstrap={bootstrap} useStore={useStore} windowControls={controls} />);
-    expect(screen.queryByRole('button', { name: /Update available:/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Open update/ })).toBeNull();
 
     act(() => {
       useStore.setState({
@@ -84,7 +84,7 @@ describe('AppTitleBar', () => {
       });
     });
 
-    const indicator = await screen.findByRole('button', { name: 'Update available: 4.0.2' });
+    const indicator = await screen.findByRole('button', { name: 'Open update 4.0.2' });
     expect(indicator.closest('.update-indicator-shell')).toHaveAttribute(
       'title',
       'Update available: 4.0.2. Open update details.',
@@ -104,7 +104,7 @@ describe('AppTitleBar', () => {
         },
       });
     });
-    expect(screen.queryByRole('button', { name: /Update available:/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Open update/ })).toBeNull();
   });
 
   it('refreshes the maximize state after resize', async () => {

--- a/desktop/src/components/chrome/AppTitleBar.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.tsx
@@ -45,16 +45,20 @@ export function AppTitleBar({ useStore, settingsTriggerRef, windowControls }: Ap
       <GlobalSearch useStore={useStore} />
       <div className="app-titlebar-actions" data-tauri-drag-region="false">
         {update.state === 'available' && (
-          <Button
-            className="update-indicator"
-            aria-label={`Update available: ${updateVersion}`}
+          <span
+            className="update-indicator-shell"
             title={`Update available: ${updateVersion}. Open update details.`}
-            onPress={() => setUpdateDialogOpen(true)}
           >
-            <Download size={15} aria-hidden="true" />
-            <span className="update-indicator-dot" aria-hidden="true" />
-            <span className="visually-hidden">Update available</span>
-          </Button>
+            <Button
+              className="update-indicator"
+              aria-label={`Update available: ${updateVersion}`}
+              onPress={() => setUpdateDialogOpen(true)}
+            >
+              <Download size={15} aria-hidden="true" />
+              <span className="update-indicator-dot" aria-hidden="true" />
+              <span className="visually-hidden">Update available</span>
+            </Button>
+          </span>
         )}
         <Button
           className="icon-button"

--- a/desktop/src/components/chrome/AppTitleBar.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.tsx
@@ -24,6 +24,7 @@ export function AppTitleBar({ useStore, settingsTriggerRef, windowControls }: Ap
   const setSettingsOpen = useStore((store: DesktopStore) => store.setSettingsOpen);
   const update = useStore((store: DesktopStore) => store.update);
   const setUpdateDialogOpen = useStore((store: DesktopStore) => store.setUpdateDialogOpen);
+  const updateVersion = update.availableVersion ?? 'new version';
 
   return (
     <header className="app-titlebar" aria-label="Sky Auto Player" data-tauri-drag-region="deep">
@@ -46,12 +47,13 @@ export function AppTitleBar({ useStore, settingsTriggerRef, windowControls }: Ap
         {update.state === 'available' && (
           <Button
             className="update-indicator"
-            aria-label={`Open update ${update.availableVersion}`}
-            title={`Update available: ${update.availableVersion}`}
+            aria-label={`Update available: ${updateVersion}`}
+            title={`Update available: ${updateVersion}. Open update details.`}
             onPress={() => setUpdateDialogOpen(true)}
           >
             <Download size={15} aria-hidden="true" />
-            <span className="visually-hidden">Update</span>
+            <span className="update-indicator-dot" aria-hidden="true" />
+            <span className="visually-hidden">Update available</span>
           </Button>
         )}
         <Button

--- a/desktop/src/components/chrome/AppTitleBar.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.tsx
@@ -51,7 +51,7 @@ export function AppTitleBar({ useStore, settingsTriggerRef, windowControls }: Ap
           >
             <Button
               className="update-indicator"
-              aria-label={`Update available: ${updateVersion}`}
+              aria-label={`Open update ${updateVersion}`}
               onPress={() => setUpdateDialogOpen(true)}
             >
               <Download size={15} aria-hidden="true" />

--- a/desktop/src/styles/chrome.css
+++ b/desktop/src/styles/chrome.css
@@ -86,10 +86,15 @@
 }
 
 .app-titlebar-actions .icon-button,
+.app-titlebar-actions .update-indicator-shell,
 .app-titlebar-actions .update-indicator {
   flex: 0 0 34px;
   width: 34px;
   min-height: 34px;
+}
+
+.app-titlebar-actions .update-indicator-shell {
+  display: inline-flex;
 }
 
 .app-titlebar-actions .icon-button {

--- a/desktop/src/styles/chrome.css
+++ b/desktop/src/styles/chrome.css
@@ -97,6 +97,22 @@
   background: transparent;
 }
 
+.app-titlebar-actions .update-indicator {
+  position: relative;
+}
+
+.update-indicator-dot {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 2px var(--canvas);
+  pointer-events: none;
+}
+
 .window-caption-controls {
   display: flex;
   grid-column: 6;
@@ -190,6 +206,11 @@
 }
 
 @media (forced-colors: active) {
+  .update-indicator-dot {
+    background: Highlight;
+    box-shadow: 0 0 0 2px Canvas;
+  }
+
   .caption-button:focus-visible,
   .global-search:focus-within {
     outline: 2px solid Highlight;


### PR DESCRIPTION
## Summary

- keep the existing non-interruptive update flow: no automatic modal or toast
- make the titlebar update affordance easier to notice with a small static accent dot
- improve the version-aware accessible label and native tooltip
- preserve forced-colors visibility
- add coverage that the indicator only appears for `available` updates and opens update details when clicked

## Scope

This is UI-only. Update checking, channel selection, download/install behavior, and dialog auto-open behavior are unchanged.

## Testing

- Added a focused `AppTitleBar` test for update availability and click behavior.
- Local `bun` checks could not be executed in the tool environment because outbound Git access is unavailable; repository CI should validate typecheck/lint/format/test.