### PR TITLE
[Desktop] Add production-bundle E2E for React Compiler output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,6 +654,11 @@ jobs:
         working-directory: desktop
         run: bun run test:e2e
 
+      - name: Run production-bundle browser smoke
+        if: needs.changes.outputs.desktop_e2e_required == 'true'
+        working-directory: desktop
+        run: bun run test:e2e:bundle
+
       - name: Report CI timing
         if: always()
         run: |

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "node scripts/run-e2e.mjs",
+    "test:e2e:bundle": "node scripts/run-bundle-e2e.mjs",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build --ci -- --profile dist",

--- a/desktop/playwright.config.ts
+++ b/desktop/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './tests/e2e',
-  use: { baseURL: 'http://127.0.0.1:4173', ...devices['Desktop Chrome'] },
+  testDir: process.env.PLAYWRIGHT_TEST_DIR ?? './tests/e2e',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173',
+    ...devices['Desktop Chrome'],
+  },
 });

--- a/desktop/scripts/run-bundle-e2e.mjs
+++ b/desktop/scripts/run-bundle-e2e.mjs
@@ -1,0 +1,94 @@
+import { spawn, spawnSync } from 'node:child_process';
+import process from 'node:process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const desktopRoot = fileURLToPath(new URL('..', import.meta.url));
+const viteCli = fileURLToPath(new URL('../node_modules/vite/bin/vite.js', import.meta.url));
+const playwrightCli = fileURLToPath(
+  new URL('../node_modules/@playwright/test/cli.js', import.meta.url),
+);
+const bundleUrl = 'http://127.0.0.1:4174';
+let previewServer;
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function assertSuccess(label, result) {
+  if (result.signal || result.code !== 0) {
+    throw new Error(`${label} failed with ${result.signal ?? `exit code ${result.code}`}`);
+  }
+}
+
+async function waitForServer(server) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    if (server.exitCode !== null) {
+      throw new Error(`Vite preview exited before becoming ready with code ${server.exitCode}`);
+    }
+    try {
+      const response = await fetch(`${bundleUrl}/`);
+      if (response.ok) return;
+    } catch {
+      // Vite preview is still starting.
+    }
+    await delay(250);
+  }
+  throw new Error('Vite preview did not become ready within 15 seconds');
+}
+
+function stopServer(server) {
+  if (!server?.pid) return;
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/pid', String(server.pid), '/t', '/f'], { stdio: 'ignore' });
+  } else {
+    server.kill('SIGTERM');
+  }
+}
+
+try {
+  const build = spawn(process.execPath, [viteCli, 'build', '--config', 'vite.config.ts'], {
+    cwd: desktopRoot,
+    stdio: 'inherit',
+    windowsHide: true,
+  });
+  assertSuccess('Production Vite build', await waitForExit(build));
+
+  previewServer = spawn(
+    process.execPath,
+    [
+      viteCli,
+      'preview',
+      '--config',
+      'vite.config.ts',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '4174',
+      '--strictPort',
+    ],
+    {
+      cwd: desktopRoot,
+      stdio: 'inherit',
+      windowsHide: true,
+    },
+  );
+  await waitForServer(previewServer);
+
+  const runner = spawn(process.execPath, [playwrightCli, 'test'], {
+    cwd: desktopRoot,
+    env: {
+      ...process.env,
+      PLAYWRIGHT_BASE_URL: bundleUrl,
+      PLAYWRIGHT_TEST_DIR: './tests/e2e-bundle',
+    },
+    stdio: 'inherit',
+    windowsHide: true,
+  });
+  assertSuccess('Production-bundle Playwright smoke', await waitForExit(runner));
+} finally {
+  stopServer(previewServer);
+}

--- a/desktop/tests/e2e-bundle/bundle.spec.ts
+++ b/desktop/tests/e2e-bundle/bundle.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('production bundle boots the mock shell and supports a representative flow', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'All Songs' })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Aurora Landing/ })).toBeVisible();
+
+  await page.getByLabel('Search library').fill('Moonlit');
+  await expect(page.getByRole('row', { name: /Moonlit Village/ })).toBeVisible();
+  await page.getByRole('row', { name: /Moonlit Village/ }).click();
+  await page.getByRole('button', { name: 'Open utility panel' }).click();
+  await expect(page.getByText('Low timing risk')).toBeVisible();
+});


### PR DESCRIPTION
Implements #215; coordinated under #213.

## Summary
- Added a separate test:e2e:bundle path: real vite build using vite.config.ts, deterministic vite preview on 127.0.0.1:4174, then a focused Playwright smoke.
- Added a production-bundle bootstrap/search/select/utility flow using the intentional mock bridge outside Tauri.
- Kept existing bun run test:e2e isolated to tests/e2e and unchanged in behavior.
- Added the smoke to the existing desktop_web CI lane after pinned Chromium installation; packaged/native/release jobs are unchanged.

## Verification
- bun run test:e2e:bundle: PASS (production build + Playwright smoke 1/1).
- bun run test:e2e: PASS (27/27 existing tests).
- bun run check: PASS (60 unit tests, build, lint, typecheck, format).
- cargo xtask check desktop: PASS.
- cargo xtask check static: PASS.
- scripts/test_ci_classify.ps1: PASS.

## Boundary
No production React/Tauri code, React Compiler configuration, packaged release job, or #116 CI trust-domain behavior was changed.