### PR TITLE
refactor: clean up React effect ownership

### DIFF
--- a/desktop/src/app/App.test.tsx
+++ b/desktop/src/app/App.test.tsx
@@ -1,10 +1,13 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockBridge } from '../bridge/mockBridge';
 import { App } from './App';
 
 describe('desktop application shell', () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    delete (window as Window & { __SKY_DESKTOP_GUI_SMOKE__?: boolean }).__SKY_DESKTOP_GUI_SMOKE__;
+    cleanup();
+  });
 
   it('renders the navigator, track browser, utility details, and settings', async () => {
     render(<App bridge={createMockBridge()} />);
@@ -63,6 +66,15 @@ describe('desktop application shell', () => {
     );
   });
 
+  it('focuses the global search input from the keyboard shortcut', async () => {
+    render(<App bridge={createMockBridge()} />);
+    const search = await screen.findByRole('searchbox');
+
+    fireEvent.keyDown(window, { key: '/' });
+
+    expect(document.activeElement).toBe(search);
+  });
+
   it('loads and selects a keyboard destination on an unloaded virtualized page', async () => {
     render(<App bridge={createMockBridge()} />);
     const grid = await screen.findByRole('grid', { name: 'Songs' });
@@ -85,6 +97,17 @@ describe('desktop application shell', () => {
     render(<App bridge={bridge} />);
     expect(await screen.findByRole('alert')).toHaveTextContent('Native application is unavailable');
     expect(screen.queryByRole('button', { name: /Try again/i })).toBeNull();
+  });
+
+  it('runs the packaged GUI smoke orchestration when requested', async () => {
+    const bridge = createMockBridge();
+    const shutdown = vi.spyOn(bridge, 'shutdown');
+    (window as Window & { __SKY_DESKTOP_GUI_SMOKE__?: boolean }).__SKY_DESKTOP_GUI_SMOKE__ = true;
+
+    render(<App bridge={bridge} />);
+
+    await waitFor(() => expect(shutdown).toHaveBeenCalledTimes(1), { timeout: 2_000 });
+    expect(shutdown).toHaveBeenCalledWith();
   });
 
   it('opens the docked utility diagnostics and closes with Escape', async () => {
@@ -114,5 +137,6 @@ describe('desktop application shell', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog', { name: 'Timing calibration' })).toBeNull(),
     );
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Open settings' }));
   });
 });

--- a/desktop/src/app/App.tsx
+++ b/desktop/src/app/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import type { DesktopBridge, UiEvent } from '../bridge/DesktopBridge';
+import type { DesktopBridge } from '../bridge/DesktopBridge';
 import { BootstrapGate } from './BootstrapGate';
 import { SettingsPanel } from '../components/settings/SettingsPanel';
 import { AppTitleBar } from '../components/chrome/AppTitleBar';
@@ -9,6 +9,7 @@ import { CalibrationDialog } from '../components/calibration/CalibrationDialog';
 import { UpdateDialog } from '../components/updates/UpdateDialog';
 import { createDesktopStore } from '../state/store';
 import { createWindowControls } from '../platform/windowControls';
+import { usePackagedSmokeTest } from './usePackagedSmokeTest';
 
 interface AppProps {
   bridge: DesktopBridge;
@@ -17,6 +18,7 @@ interface AppProps {
 export function App({ bridge }: AppProps) {
   const utilityTriggerRef = useRef<HTMLButtonElement>(null);
   const settingsTriggerRef = useRef<HTMLButtonElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const useStore = useMemo(() => createDesktopStore(bridge), [bridge]);
   const bootstrap = useStore((store) => store.bootstrap);
   const settingsOpen = useStore((store) => store.settingsOpen);
@@ -37,183 +39,14 @@ export function App({ bridge }: AppProps) {
         !settingsOpen
       ) {
         event.preventDefault();
-        document.querySelector<HTMLInputElement>('input[type="search"]')?.focus();
+        searchInputRef.current?.focus();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [settingsOpen, useStore]);
 
-  useEffect(() => {
-    let completed = false;
-    const runPackagedSmoke = async () => {
-      if (completed) return;
-      completed = true;
-      const waitForReady = async () => {
-        for (let attempt = 0; attempt < 300; attempt += 1) {
-          const state = useStore.getState();
-          if (state.bootstrapState === 'ready' && state.settings) return;
-          if (state.bootstrapState === 'fatal') {
-            throw new Error(state.fatal ?? 'packaged GUI bootstrap failed');
-          }
-          await new Promise((resolve) => window.setTimeout(resolve, 100));
-        }
-        throw new Error('packaged GUI bootstrap timed out');
-      };
-      const waitForStore = async (predicate: () => boolean, description: string): Promise<void> => {
-        for (let attempt = 0; attempt < 100; attempt += 1) {
-          if (predicate()) return;
-          await new Promise((resolve) => window.setTimeout(resolve, 50));
-        }
-        throw new Error(`packaged GUI ${description} state timed out`);
-      };
-
-      await waitForReady();
-      const state = useStore.getState();
-      if (!document.querySelector('.app-shell')) {
-        throw new Error('packaged GUI shell did not render');
-      }
-      const generation = state.library.generation;
-      const search = await bridge.searchSongs({
-        query: '',
-        offset: 0,
-        limit: 200,
-        source: { kind: 'smart', id: 'all' },
-        ...(generation > 0 ? { generation } : {}),
-      });
-      if (
-        !Number.isInteger(search.generation) ||
-        search.generation < 0 ||
-        !Number.isInteger(search.total) ||
-        search.total < 0 ||
-        !Array.isArray(search.items) ||
-        search.items.length > search.limit
-      ) {
-        throw new Error('packaged GUI search postcondition failed');
-      }
-      await waitForStore(() => {
-        const current = useStore.getState();
-        return !current.library.loading && current.library.error === null;
-      }, 'library');
-      const afterSearch = useStore.getState();
-      if (
-        afterSearch.bootstrapState !== 'ready' ||
-        afterSearch.library.loading ||
-        afterSearch.library.error !== null ||
-        afterSearch.fatal !== null
-      ) {
-        throw new Error('packaged GUI library store postcondition failed');
-      }
-      const expectedTheme = state.bootstrap?.theme ?? 'aurora';
-      const smokeTheme = expectedTheme === 'aurora' ? 'slate' : 'aurora';
-      const patched = await bridge.patchSettings({ theme: smokeTheme });
-      if (patched.theme !== smokeTheme) {
-        throw new Error('packaged GUI settings mutation postcondition failed');
-      }
-      const reread = await bridge.getSettings();
-      if (reread.theme !== smokeTheme) {
-        throw new Error('packaged GUI settings round-trip postcondition failed');
-      }
-      const restored = await bridge.patchSettings({ theme: expectedTheme });
-      if (restored.theme !== expectedTheme) {
-        throw new Error('packaged GUI settings restore postcondition failed');
-      }
-      const restoredRead = await bridge.getSettings();
-      if (restoredRead.theme !== expectedTheme) {
-        throw new Error('packaged GUI settings restore round-trip failed');
-      }
-      const afterSettings = useStore.getState();
-      if (afterSettings.settingsState !== 'ready' || afterSettings.fatal !== null) {
-        throw new Error('packaged GUI settings store postcondition failed');
-      }
-      const enabled = await bridge.setDiagnosticsEnabled({ enabled: true });
-      if (enabled.enabled !== true) {
-        throw new Error('packaged GUI diagnostics enable postcondition failed');
-      }
-      const disabled = await bridge.setDiagnosticsEnabled({ enabled: false });
-      if (disabled.enabled !== false) {
-        throw new Error('packaged GUI diagnostics disable postcondition failed');
-      }
-
-      let calibrationOperationId: string | null = null;
-      let calibrationFinished: Extract<UiEvent, { name: 'calibration.finished' }>;
-      const earlyCalibrationFinished: Extract<UiEvent, { name: 'calibration.finished' }>[] = [];
-      let resolveCalibration!: (event: Extract<UiEvent, { name: 'calibration.finished' }>) => void;
-      const calibrationDone = new Promise<Extract<UiEvent, { name: 'calibration.finished' }>>(
-        (resolve) => {
-          resolveCalibration = resolve;
-        },
-      );
-      const unsubscribe = await bridge.subscribeUiEvents((event) => {
-        if (
-          event.name === 'calibration.finished' &&
-          calibrationOperationId !== null &&
-          event.payload.operation_id === calibrationOperationId
-        ) {
-          resolveCalibration(event);
-        } else if (event.name === 'calibration.finished') {
-          earlyCalibrationFinished.push(event);
-        }
-      });
-      try {
-        const calibration = await bridge.startCalibration({
-          mode: 'quick',
-          className: null,
-          polyphony: null,
-          samples: null,
-          timeoutSeconds: null,
-        });
-        if (calibration.state !== 'running') {
-          throw new Error('packaged GUI calibration did not start');
-        }
-        calibrationOperationId = calibration.operation_id;
-        const early = earlyCalibrationFinished.find(
-          (event) => event.payload.operation_id === calibrationOperationId,
-        );
-        if (early) resolveCalibration(early);
-        calibrationFinished = await Promise.race([
-          calibrationDone,
-          new Promise<never>((_, reject) =>
-            window.setTimeout(
-              () => reject(new Error('packaged GUI calibration timed out')),
-              10_000,
-            ),
-          ),
-        ]);
-      } finally {
-        unsubscribe();
-      }
-      if (
-        !calibrationFinished ||
-        !['succeeded', 'cancelled'].includes(calibrationFinished.payload.outcome)
-      ) {
-        throw new Error('packaged GUI calibration terminal postcondition failed');
-      }
-      // The controlled-close command destroys this WebView after starting
-      // bounded native cleanup. Do not wait for an invoke response from a
-      // window that is intentionally being destroyed.
-      void bridge.shutdown();
-    };
-
-    const onSmokeEvent = () => {
-      void runPackagedSmoke().catch((error: unknown) => {
-        console.error('packaged GUI smoke failed', error);
-        void bridge.shutdown(true).catch((shutdownError: unknown) => {
-          console.error('packaged GUI failure shutdown failed', shutdownError);
-        });
-      });
-    };
-    window.addEventListener('sky-desktop-gui-smoke', onSmokeEvent);
-    if ((window as Window & { __SKY_DESKTOP_GUI_SMOKE__?: boolean }).__SKY_DESKTOP_GUI_SMOKE__) {
-      void runPackagedSmoke().catch((error: unknown) => {
-        console.error('packaged GUI smoke failed', error);
-        void bridge.shutdown(true).catch((shutdownError: unknown) => {
-          console.error('packaged GUI failure shutdown failed', shutdownError);
-        });
-      });
-    }
-    return () => window.removeEventListener('sky-desktop-gui-smoke', onSmokeEvent);
-  }, [bridge, useStore]);
+  usePackagedSmokeTest({ bridge, useStore });
 
   return (
     <BootstrapGate useStore={useStore}>
@@ -223,6 +56,7 @@ export function App({ bridge }: AppProps) {
             bootstrap={bootstrap}
             useStore={useStore}
             settingsTriggerRef={settingsTriggerRef}
+            searchInputRef={searchInputRef}
             windowControls={windowControls}
           />
           <Workbench useStore={useStore} utilityTriggerRef={utilityTriggerRef} />
@@ -232,7 +66,7 @@ export function App({ bridge }: AppProps) {
             useStore={useStore}
             settingsTriggerRef={settingsTriggerRef}
           />
-          <CalibrationDialog useStore={useStore} />
+          <CalibrationDialog useStore={useStore} settingsTriggerRef={settingsTriggerRef} />
           <UpdateDialog useStore={useStore} />
         </div>
       )}

--- a/desktop/src/app/usePackagedSmokeTest.ts
+++ b/desktop/src/app/usePackagedSmokeTest.ts
@@ -1,0 +1,181 @@
+import { useEffect } from 'react';
+import type { DesktopBridge, UiEvent } from '../bridge/DesktopBridge';
+import type { DesktopStoreHook } from '../state/store';
+
+interface PackagedSmokeTestProps {
+  bridge: DesktopBridge;
+  useStore: DesktopStoreHook;
+}
+
+interface SmokeWindow extends Window {
+  __SKY_DESKTOP_GUI_SMOKE__?: boolean;
+}
+
+export function usePackagedSmokeTest({ bridge, useStore }: PackagedSmokeTestProps): void {
+  useEffect(() => {
+    let completed = false;
+    const runPackagedSmoke = async () => {
+      if (completed) return;
+      completed = true;
+      const waitForReady = async () => {
+        for (let attempt = 0; attempt < 300; attempt += 1) {
+          const state = useStore.getState();
+          if (state.bootstrapState === 'ready' && state.settings) return;
+          if (state.bootstrapState === 'fatal') {
+            throw new Error(state.fatal ?? 'packaged GUI bootstrap failed');
+          }
+          await new Promise((resolve) => window.setTimeout(resolve, 100));
+        }
+        throw new Error('packaged GUI bootstrap timed out');
+      };
+      const waitForStore = async (predicate: () => boolean, description: string): Promise<void> => {
+        for (let attempt = 0; attempt < 100; attempt += 1) {
+          if (predicate()) return;
+          await new Promise((resolve) => window.setTimeout(resolve, 50));
+        }
+        throw new Error(`packaged GUI ${description} state timed out`);
+      };
+
+      await waitForReady();
+      const state = useStore.getState();
+      if (!document.querySelector('.app-shell')) {
+        throw new Error('packaged GUI shell did not render');
+      }
+      const generation = state.library.generation;
+      const search = await bridge.searchSongs({
+        query: '',
+        offset: 0,
+        limit: 200,
+        source: { kind: 'smart', id: 'all' },
+        ...(generation > 0 ? { generation } : {}),
+      });
+      if (
+        !Number.isInteger(search.generation) ||
+        search.generation < 0 ||
+        !Number.isInteger(search.total) ||
+        search.total < 0 ||
+        !Array.isArray(search.items) ||
+        search.items.length > search.limit
+      ) {
+        throw new Error('packaged GUI search postcondition failed');
+      }
+      await waitForStore(() => {
+        const current = useStore.getState();
+        return !current.library.loading && current.library.error === null;
+      }, 'library');
+      const afterSearch = useStore.getState();
+      if (
+        afterSearch.bootstrapState !== 'ready' ||
+        afterSearch.library.loading ||
+        afterSearch.library.error !== null ||
+        afterSearch.fatal !== null
+      ) {
+        throw new Error('packaged GUI library store postcondition failed');
+      }
+      const expectedTheme = state.bootstrap?.theme ?? 'aurora';
+      const smokeTheme = expectedTheme === 'aurora' ? 'slate' : 'aurora';
+      const patched = await bridge.patchSettings({ theme: smokeTheme });
+      if (patched.theme !== smokeTheme) {
+        throw new Error('packaged GUI settings mutation postcondition failed');
+      }
+      const reread = await bridge.getSettings();
+      if (reread.theme !== smokeTheme) {
+        throw new Error('packaged GUI settings round-trip postcondition failed');
+      }
+      const restored = await bridge.patchSettings({ theme: expectedTheme });
+      if (restored.theme !== expectedTheme) {
+        throw new Error('packaged GUI settings restore postcondition failed');
+      }
+      const restoredRead = await bridge.getSettings();
+      if (restoredRead.theme !== expectedTheme) {
+        throw new Error('packaged GUI settings restore round-trip failed');
+      }
+      const afterSettings = useStore.getState();
+      if (afterSettings.settingsState !== 'ready' || afterSettings.fatal !== null) {
+        throw new Error('packaged GUI settings store postcondition failed');
+      }
+      const enabled = await bridge.setDiagnosticsEnabled({ enabled: true });
+      if (enabled.enabled !== true) {
+        throw new Error('packaged GUI diagnostics enable postcondition failed');
+      }
+      const disabled = await bridge.setDiagnosticsEnabled({ enabled: false });
+      if (disabled.enabled !== false) {
+        throw new Error('packaged GUI diagnostics disable postcondition failed');
+      }
+
+      let calibrationOperationId: string | null = null;
+      let calibrationFinished: Extract<UiEvent, { name: 'calibration.finished' }>;
+      const earlyCalibrationFinished: Extract<UiEvent, { name: 'calibration.finished' }>[] = [];
+      let resolveCalibration!: (event: Extract<UiEvent, { name: 'calibration.finished' }>) => void;
+      const calibrationDone = new Promise<Extract<UiEvent, { name: 'calibration.finished' }>>(
+        (resolve) => {
+          resolveCalibration = resolve;
+        },
+      );
+      const unsubscribe = await bridge.subscribeUiEvents((event) => {
+        if (
+          event.name === 'calibration.finished' &&
+          calibrationOperationId !== null &&
+          event.payload.operation_id === calibrationOperationId
+        ) {
+          resolveCalibration(event);
+        } else if (event.name === 'calibration.finished') {
+          earlyCalibrationFinished.push(event);
+        }
+      });
+      try {
+        const calibration = await bridge.startCalibration({
+          mode: 'quick',
+          className: null,
+          polyphony: null,
+          samples: null,
+          timeoutSeconds: null,
+        });
+        if (calibration.state !== 'running') {
+          throw new Error('packaged GUI calibration did not start');
+        }
+        calibrationOperationId = calibration.operation_id;
+        const early = earlyCalibrationFinished.find(
+          (event) => event.payload.operation_id === calibrationOperationId,
+        );
+        if (early) resolveCalibration(early);
+        calibrationFinished = await Promise.race([
+          calibrationDone,
+          new Promise<never>((_, reject) =>
+            window.setTimeout(
+              () => reject(new Error('packaged GUI calibration timed out')),
+              10_000,
+            ),
+          ),
+        ]);
+      } finally {
+        unsubscribe();
+      }
+      if (
+        !calibrationFinished ||
+        !['succeeded', 'cancelled'].includes(calibrationFinished.payload.outcome)
+      ) {
+        throw new Error('packaged GUI calibration terminal postcondition failed');
+      }
+      // The controlled-close command destroys this WebView after starting
+      // bounded native cleanup. Do not wait for an invoke response from a
+      // window that is intentionally being destroyed.
+      void bridge.shutdown();
+    };
+
+    const onSmokeFailure = (error: unknown) => {
+      console.error('packaged GUI smoke failed', error);
+      void bridge.shutdown(true).catch((shutdownError: unknown) => {
+        console.error('packaged GUI failure shutdown failed', shutdownError);
+      });
+    };
+    const onSmokeEvent = () => {
+      void runPackagedSmoke().catch(onSmokeFailure);
+    };
+    window.addEventListener('sky-desktop-gui-smoke', onSmokeEvent);
+    if ((window as SmokeWindow).__SKY_DESKTOP_GUI_SMOKE__) {
+      void runPackagedSmoke().catch(onSmokeFailure);
+    }
+    return () => window.removeEventListener('sky-desktop-gui-smoke', onSmokeEvent);
+  }, [bridge, useStore]);
+}

--- a/desktop/src/components/calibration/CalibrationDialog.tsx
+++ b/desktop/src/components/calibration/CalibrationDialog.tsx
@@ -1,22 +1,21 @@
 import { Dialog, Modal, ModalOverlay } from 'react-aria-components';
 import { CheckCircle2, LoaderCircle, XCircle } from 'lucide-react';
-import type { ReactNode } from 'react';
+import type { ReactNode, RefObject } from 'react';
 import type { DesktopStoreHook } from '../../state/store';
 
 interface CalibrationDialogProps {
+  settingsTriggerRef?: RefObject<HTMLButtonElement | null>;
   useStore: DesktopStoreHook;
 }
 
-export function CalibrationDialog({ useStore }: CalibrationDialogProps) {
+export function CalibrationDialog({ settingsTriggerRef, useStore }: CalibrationDialogProps) {
   const calibration = useStore((store) => store.calibration);
   const setOpen = useStore((store) => store.setCalibrationOpen);
   const start = useStore((store) => store.startCalibration);
   const cancel = useStore((store) => store.cancelCalibration);
   const close = () => {
     setOpen(false);
-    queueMicrotask(() =>
-      document.querySelector<HTMLElement>('[aria-label="Open settings"]')?.focus(),
-    );
+    queueMicrotask(() => settingsTriggerRef?.current?.focus());
   };
   const running = ['starting', 'running', 'cancelling'].includes(calibration.state);
   if (!calibration.open) return null;

--- a/desktop/src/components/chrome/AppTitleBar.tsx
+++ b/desktop/src/components/chrome/AppTitleBar.tsx
@@ -13,12 +13,18 @@ import { WindowCaptionControls } from './WindowCaptionControls';
 
 interface AppTitleBarProps {
   bootstrap: Bootstrap;
+  searchInputRef?: RefObject<HTMLInputElement | null>;
   useStore: DesktopStoreHook;
   settingsTriggerRef?: RefObject<HTMLButtonElement | null>;
   windowControls?: WindowControls;
 }
 
-export function AppTitleBar({ useStore, settingsTriggerRef, windowControls }: AppTitleBarProps) {
+export function AppTitleBar({
+  searchInputRef,
+  useStore,
+  settingsTriggerRef,
+  windowControls,
+}: AppTitleBarProps) {
   const controls = useMemo(() => windowControls ?? createWindowControls(), [windowControls]);
   const reload = useStore((store: DesktopStore) => store.reloadLibrary);
   const setSettingsOpen = useStore((store: DesktopStore) => store.setSettingsOpen);
@@ -42,7 +48,7 @@ export function AppTitleBar({ useStore, settingsTriggerRef, windowControls }: Ap
         <span className="visually-hidden">Sky Auto Player</span>
       </div>
       <div className="titlebar-drag-space" aria-hidden="true" />
-      <GlobalSearch useStore={useStore} />
+      <GlobalSearch {...(searchInputRef ? { inputRef: searchInputRef } : {})} useStore={useStore} />
       <div className="app-titlebar-actions" data-tauri-drag-region="false">
         {update.state === 'available' && (
           <span

--- a/desktop/src/components/chrome/GlobalSearch.tsx
+++ b/desktop/src/components/chrome/GlobalSearch.tsx
@@ -1,18 +1,20 @@
 import { Search } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type RefObject } from 'react';
 import type { DesktopStore, DesktopStoreHook } from '../../state/store';
 
 interface GlobalSearchProps {
+  inputRef?: RefObject<HTMLInputElement | null>;
   useStore: DesktopStoreHook;
 }
 
-export function GlobalSearch({ useStore }: GlobalSearchProps) {
+export function GlobalSearch({ inputRef, useStore }: GlobalSearchProps) {
   const query = useStore((store: DesktopStore) => store.library.query);
   const playlistAddMode = useStore((store: DesktopStore) => store.library.playlistAddMode);
   return (
     <SearchInput
       key={`${query}:${playlistAddMode?.playlistId ?? 'library'}`}
       query={query}
+      {...(inputRef ? { inputRef } : {})}
       useStore={useStore}
       playlistAddMode={playlistAddMode !== null}
     />
@@ -24,7 +26,7 @@ interface SearchInputProps extends GlobalSearchProps {
   playlistAddMode: boolean;
 }
 
-function SearchInput({ query, useStore, playlistAddMode }: SearchInputProps) {
+function SearchInput({ inputRef, query, useStore, playlistAddMode }: SearchInputProps) {
   const search = useStore((store) => store.search);
   const [draft, setDraft] = useState(query);
 
@@ -42,6 +44,7 @@ function SearchInput({ query, useStore, playlistAddMode }: SearchInputProps) {
         {playlistAddMode ? 'Search All Songs' : 'Search library'}
       </span>
       <input
+        ref={inputRef}
         value={draft}
         onChange={(event) => setDraft(event.target.value)}
         placeholder={playlistAddMode ? 'Search All Songs…' : 'Search library…'}

--- a/desktop/src/components/settings/SettingsPanel.tsx
+++ b/desktop/src/components/settings/SettingsPanel.tsx
@@ -48,14 +48,7 @@ export function SettingsPanel({ bootstrap, settingsTriggerRef, useStore }: Setti
       dialogRef.current?.focus();
     } else if (wasOpen.current) {
       wasOpen.current = false;
-      window.setTimeout(
-        () =>
-          (
-            settingsTriggerRef?.current ??
-            document.querySelector<HTMLElement>('[aria-label="Open settings"]')
-          )?.focus(),
-        0,
-      );
+      window.setTimeout(() => settingsTriggerRef?.current?.focus(), 0);
     }
   }, [open, settingsTriggerRef]);
 

--- a/desktop/src/components/workbench/Workbench.test.tsx
+++ b/desktop/src/components/workbench/Workbench.test.tsx
@@ -13,7 +13,31 @@ import {
   getUtilityWidthMax,
   solveWorkbenchGeometry,
   WORKBENCH_STORAGE_KEY,
+  useWorkbenchLayout,
 } from './useWorkbenchLayout';
+
+function LayoutUpdateHarness() {
+  const layout = useWorkbenchLayout(1200, true);
+  return (
+    <>
+      <output data-testid="layout-values">
+        {layout.expandedNavigatorWidth}:{layout.utilityWidth}
+      </output>
+      <button
+        type="button"
+        onClick={() => {
+          layout.setNavigatorWidth(300);
+          layout.setUtilityWidth(400);
+        }}
+      >
+        Update layout
+      </button>
+      <button type="button" onClick={() => layout.setUtilityWidth(410, true)}>
+        Commit utility width
+      </button>
+    </>
+  );
+}
 
 describe('ResizableSeparator', () => {
   afterEach(() => window.localStorage.clear());
@@ -188,5 +212,21 @@ describe('workbench layout persistence', () => {
     expect(minimum.fits).toBe(true);
     expect(COMPACT_NAVIGATOR_WIDTH).toBe(56);
     expect(getNavigatorWidthMax(920)).toBeGreaterThanOrEqual(MIN_NAVIGATOR_WIDTH);
+  });
+
+  it('combines rapid functional updates while persisting only explicit commits', () => {
+    render(<LayoutUpdateHarness />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update layout' }));
+
+    expect(screen.getByTestId('layout-values')).toHaveTextContent('300:400');
+    expect(window.localStorage.getItem(WORKBENCH_STORAGE_KEY)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Commit utility width' }));
+
+    expect(JSON.parse(window.localStorage.getItem(WORKBENCH_STORAGE_KEY)!)).toMatchObject({
+      expandedNavigatorWidth: 300,
+      utilityWidth: 410,
+    });
   });
 });

--- a/desktop/src/components/workbench/Workbench.test.tsx
+++ b/desktop/src/components/workbench/Workbench.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ResizableSeparator } from './ResizableSeparator';
@@ -130,7 +131,10 @@ describe('ResizableSeparator', () => {
 });
 
 describe('workbench layout persistence', () => {
-  afterEach(() => window.localStorage.clear());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
 
   it('loads valid v4 values and clamps them to current bounds', () => {
     window.localStorage.setItem(
@@ -215,11 +219,17 @@ describe('workbench layout persistence', () => {
   });
 
   it('combines rapid functional updates while persisting only explicit commits', () => {
-    render(<LayoutUpdateHarness />);
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+    render(
+      <StrictMode>
+        <LayoutUpdateHarness />
+      </StrictMode>,
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Update layout' }));
 
     expect(screen.getByTestId('layout-values')).toHaveTextContent('300:400');
+    expect(setItem).not.toHaveBeenCalled();
     expect(window.localStorage.getItem(WORKBENCH_STORAGE_KEY)).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Commit utility width' }));
@@ -228,5 +238,6 @@ describe('workbench layout persistence', () => {
       expandedNavigatorWidth: 300,
       utilityWidth: 410,
     });
+    expect(setItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/desktop/src/components/workbench/useWorkbenchLayout.ts
+++ b/desktop/src/components/workbench/useWorkbenchLayout.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 export const WORKBENCH_STORAGE_KEY = 'sky.ui.workbench.v4';
 export const LEGACY_WORKBENCH_V3_STORAGE_KEY = 'sky.ui.workbench.v3';
@@ -180,6 +180,8 @@ function persistWorkbenchLayout(layout: WorkbenchLayoutStateV4): void {
 
 export function useWorkbenchLayout(viewportWidth: number, utilityOpen = false) {
   const [layout, setLayout] = useState<WorkbenchLayoutStateV4>(() => loadWorkbenchLayout());
+  // Keep queued event updates composable between renders without side effects in the updater.
+  const pendingLayoutRef = useRef(layout);
 
   const utilityWidthMax = getUtilityWidthMax(viewportWidth);
   const effectiveUtilityWidth = utilityOpen
@@ -199,11 +201,10 @@ export function useWorkbenchLayout(viewportWidth: number, utilityOpen = false) {
   });
 
   const update = (patch: Partial<WorkbenchLayoutStateV4>, persist = false) => {
-    setLayout((current) => {
-      const next = normalizedLayout({ ...current, ...patch });
-      if (persist) persistWorkbenchLayout(next);
-      return next;
-    });
+    const next = normalizedLayout({ ...pendingLayoutRef.current, ...patch });
+    pendingLayoutRef.current = next;
+    setLayout(() => next);
+    if (persist) persistWorkbenchLayout(next);
   };
 
   return {

--- a/desktop/src/components/workbench/useWorkbenchLayout.ts
+++ b/desktop/src/components/workbench/useWorkbenchLayout.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 export const WORKBENCH_STORAGE_KEY = 'sky.ui.workbench.v4';
 export const LEGACY_WORKBENCH_V3_STORAGE_KEY = 'sky.ui.workbench.v3';
@@ -180,11 +180,6 @@ function persistWorkbenchLayout(layout: WorkbenchLayoutStateV4): void {
 
 export function useWorkbenchLayout(viewportWidth: number, utilityOpen = false) {
   const [layout, setLayout] = useState<WorkbenchLayoutStateV4>(() => loadWorkbenchLayout());
-  const layoutRef = useRef(layout);
-
-  useEffect(() => {
-    layoutRef.current = layout;
-  }, [layout]);
 
   const utilityWidthMax = getUtilityWidthMax(viewportWidth);
   const effectiveUtilityWidth = utilityOpen
@@ -204,10 +199,11 @@ export function useWorkbenchLayout(viewportWidth: number, utilityOpen = false) {
   });
 
   const update = (patch: Partial<WorkbenchLayoutStateV4>, persist = false) => {
-    const next = normalizedLayout({ ...layoutRef.current, ...patch });
-    layoutRef.current = next;
-    setLayout(next);
-    if (persist) persistWorkbenchLayout(next);
+    setLayout((current) => {
+      const next = normalizedLayout({ ...current, ...patch });
+      if (persist) persistWorkbenchLayout(next);
+      return next;
+    });
   };
 
   return {


### PR DESCRIPTION
Implements #218; coordinated under #213. Summary: removed mirrored workbench layout ref/effect and retained explicit commit-only persistence; extracted packaged GUI smoke orchestration into usePackagedSmokeTest with the existing calls, timeouts, postconditions, failure logging, and shutdown behavior; wired React refs for search, settings, and calibration focus. Preserved createDesktopStore bridge memo identity, TrackRow/VirtualTrackRow memoization, and the scoped TanStack Virtual compiler suppression. No dependency or lockfile churn. Verification: cargo xtask check desktop PASS; bun run test:e2e:bundle PASS (1/1); desktop typecheck, lint, format:check, test (63/63), and build:web PASS.