### PR TITLE
feat(desktop): harden process and dependency boundaries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,26 @@ updates:
           - major
 
   - package-ecosystem: bun
+    directory: /desktop
+    schedule:
+      interval: weekly
+    groups:
+      desktop-major-technologies:
+        patterns:
+          - react
+          - react-dom
+          - typescript
+          - vite
+        update-types:
+          - major
+      desktop-regular:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: bun
     directory: /site
     schedule:
       interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,12 @@ jobs:
           path: ${{ runner.temp }}/cargo-audit
           key: cargo-audit-${{ runner.os }}-${{ runner.arch }}-0.22.2-rust-1.98
 
+      - name: JavaScript dependency advisory scan
+        uses: google/osv-scanner-action/osv-scanner-action@06b2ab4348248b456ee06c9e953637f55e03504f # v2.5.0
+        with:
+          scan-args: |-
+            --lockfile=./desktop/bun.lock
+
       - name: Cargo-vet dependency policy
         env:
           CARGO_VET_VERSION: 0.10.2

--- a/desktop/bun.lock
+++ b/desktop/bun.lock
@@ -38,7 +38,7 @@
         "prettier": "3.9.6",
         "typescript": "7.0.2",
         "vite": "8.2.2",
-        "vitest": "4.1.10",
+        "vitest": "4.1.11",
       },
     },
   },
@@ -323,19 +323,19 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.1.1", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "oxc-transform-react": "^0.145.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler", "oxc-transform-react"] }, "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+    "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.11", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+    "@vitest/runner": ["@vitest/runner@4.1.11", "", { "dependencies": { "@vitest/utils": "4.1.11", "pathe": "^2.0.3" } }, "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+    "@vitest/spy": ["@vitest/spy@4.1.11", "", {}, "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+    "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
 
     "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
@@ -663,7 +663,7 @@
 
     "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
 
-    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+    "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 

--- a/desktop/eslint.config.js
+++ b/desktop/eslint.config.js
@@ -50,6 +50,23 @@ export default [
     ...reactHooks.configs.flat.recommended,
   },
   {
+    files: ['src/**/*.{ts,tsx}'],
+    ignores: ['src/bridge/**', 'src/platform/**'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@tauri-apps/*'],
+              message: 'Import Tauri APIs only from src/bridge or src/platform adapters.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['**/*.{js,mjs,cjs}', 'vite.config.ts', 'vitest.config.ts', 'playwright.config.ts'],
     languageOptions: {
       globals: globals.node,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -53,6 +53,6 @@
     "prettier": "3.9.6",
     "typescript": "7.0.2",
     "vite": "8.2.2",
-    "vitest": "4.1.10"
+    "vitest": "4.1.11"
   }
 }

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -56,7 +56,9 @@ url = "2.5.8"
 raw-window-handle = "0.6"
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
     "Win32_UI_HiDpi",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,8 @@ mod native_runtime;
 mod native_update;
 mod ui_events;
 #[cfg(windows)]
+mod single_instance;
+#[cfg(windows)]
 mod windows_caption;
 #[cfg(windows)]
 mod windows_icon;
@@ -141,6 +143,20 @@ pub fn selftest_update_install_rejection_during_playback() -> i32 {
 }
 
 fn run_inner(gui_smoke: bool, update_smoke: bool) {
+    #[cfg(windows)]
+    let _single_instance_guard = match single_instance::SingleInstanceGuard::acquire() {
+        Ok(guard) => guard,
+        Err(single_instance::AcquireError::AlreadyRunning) => {
+            single_instance::focus_existing_instance();
+            eprintln!("Sky Auto Player is already running");
+            return;
+        }
+        Err(error) => {
+            eprintln!("Sky Auto Player startup refused: {error}");
+            return;
+        }
+    };
+
     let update_marker = update_smoke_marker("--selftest-update-marker");
     let update_safety_marker = update_smoke_marker("--selftest-update-safety-marker");
     let expected_version_file = update_smoke_marker("--selftest-update-expected-version-file");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,9 +6,9 @@ mod ipc_contract;
 mod lifecycle;
 mod native_runtime;
 mod native_update;
-mod ui_events;
 #[cfg(windows)]
 mod single_instance;
+mod ui_events;
 #[cfg(windows)]
 mod windows_caption;
 #[cfg(windows)]

--- a/desktop/src-tauri/src/single_instance.rs
+++ b/desktop/src-tauri/src/single_instance.rs
@@ -1,0 +1,118 @@
+//! Windows process-level singleton guard for the desktop shell.
+//!
+//! The playback activity coordinator is intentionally process-local. Without a
+//! process-level guard, two independently launched desktop shells could each
+//! own a valid coordinator and emit physical SendInput concurrently.
+
+use std::fmt;
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_ALREADY_EXISTS, GetLastError, HANDLE, SetLastError, WIN32_ERROR,
+};
+use windows_sys::Win32::System::Threading::CreateMutexW;
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    FindWindowW, SW_RESTORE, SetForegroundWindow, ShowWindow,
+};
+
+const INSTANCE_MUTEX_NAME: &str = r"Local\io.github.pumni.skyautoplayer.single-instance";
+const MAIN_WINDOW_TITLE: &str = "Sky Auto Player";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AcquireError {
+    AlreadyRunning,
+    Win32(u32),
+}
+
+impl fmt::Display for AcquireError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AlreadyRunning => {
+                formatter.write_str("another desktop instance is already running")
+            }
+            Self::Win32(code) => write!(
+                formatter,
+                "single-instance mutex creation failed with Win32 error {code}"
+            ),
+        }
+    }
+}
+
+pub(crate) struct SingleInstanceGuard {
+    handle: HANDLE,
+}
+
+impl SingleInstanceGuard {
+    pub(crate) fn acquire() -> Result<Self, AcquireError> {
+        Self::acquire_named(INSTANCE_MUTEX_NAME)
+    }
+
+    fn acquire_named(name: &str) -> Result<Self, AcquireError> {
+        let name = wide_null(name);
+        unsafe {
+            // CreateMutexW documents ERROR_ALREADY_EXISTS on success when the
+            // named mutex already existed. Clear the thread-local last-error
+            // slot first so a successful new mutex cannot inherit a stale 183.
+            SetLastError(WIN32_ERROR(0));
+            let handle = CreateMutexW(std::ptr::null(), 0, name.as_ptr());
+            if handle.is_null() {
+                return Err(AcquireError::Win32(GetLastError().0));
+            }
+            if GetLastError() == ERROR_ALREADY_EXISTS {
+                let _ = CloseHandle(handle);
+                return Err(AcquireError::AlreadyRunning);
+            }
+            Ok(Self { handle })
+        }
+    }
+}
+
+impl Drop for SingleInstanceGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+pub(crate) fn focus_existing_instance() {
+    let title = wide_null(MAIN_WINDOW_TITLE);
+    unsafe {
+        let window = FindWindowW(std::ptr::null(), title.as_ptr());
+        if window.is_null() {
+            return;
+        }
+        let _ = ShowWindow(window, SW_RESTORE);
+        let _ = SetForegroundWindow(window);
+    }
+}
+
+fn wide_null(value: &str) -> Vec<u16> {
+    value.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_mutex_rejects_a_second_live_guard_and_releases_on_drop() {
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let name = format!(
+            r"Local\io.github.pumni.skyautoplayer.test.{}.{}",
+            std::process::id(),
+            suffix
+        );
+
+        let first = SingleInstanceGuard::acquire_named(&name).expect("first guard");
+        assert_eq!(
+            SingleInstanceGuard::acquire_named(&name).err(),
+            Some(AcquireError::AlreadyRunning)
+        );
+
+        drop(first);
+        let _reacquired =
+            SingleInstanceGuard::acquire_named(&name).expect("reacquired guard");
+    }
+}

--- a/desktop/src-tauri/src/single_instance.rs
+++ b/desktop/src-tauri/src/single_instance.rs
@@ -112,7 +112,6 @@ mod tests {
         );
 
         drop(first);
-        let _reacquired =
-            SingleInstanceGuard::acquire_named(&name).expect("reacquired guard");
+        let _reacquired = SingleInstanceGuard::acquire_named(&name).expect("reacquired guard");
     }
 }

--- a/desktop/src-tauri/src/single_instance.rs
+++ b/desktop/src-tauri/src/single_instance.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 use windows_sys::Win32::Foundation::{
-    CloseHandle, ERROR_ALREADY_EXISTS, GetLastError, HANDLE, SetLastError, WIN32_ERROR,
+    CloseHandle, ERROR_ALREADY_EXISTS, GetLastError, HANDLE, SetLastError,
 };
 use windows_sys::Win32::System::Threading::CreateMutexW;
 use windows_sys::Win32::UI::WindowsAndMessaging::{
@@ -51,10 +51,10 @@ impl SingleInstanceGuard {
             // CreateMutexW documents ERROR_ALREADY_EXISTS on success when the
             // named mutex already existed. Clear the thread-local last-error
             // slot first so a successful new mutex cannot inherit a stale 183.
-            SetLastError(WIN32_ERROR(0));
+            SetLastError(0);
             let handle = CreateMutexW(std::ptr::null(), 0, name.as_ptr());
             if handle.is_null() {
-                return Err(AcquireError::Win32(GetLastError().0));
+                return Err(AcquireError::Win32(GetLastError()));
             }
             if GetLastError() == ERROR_ALREADY_EXISTS {
                 let _ = CloseHandle(handle);

--- a/rust/crates/sky_dispatch_win32/src/input/physical.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/physical.rs
@@ -4,6 +4,7 @@ use super::scan_code::PHYSICAL_INSTRUMENT_SCAN_CODES;
 use super::scan_code::{FULL_INSTRUMENT_MASK, key_mask};
 use crate::focus::foreground_window_matches;
 use sky_dispatch_core::model::MAX_KEYS;
+#[cfg(any(test, feature = "test-support"))]
 use smallvec::SmallVec;
 
 #[cfg(windows)]
@@ -67,6 +68,7 @@ pub(crate) fn map_instrument_virtual_keys(
     Some(virtual_keys)
 }
 
+#[cfg(any(test, feature = "test-support"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstrumentPhysicalState {
     AllUp,

--- a/rust/crates/sky_dispatch_win32/src/input/profile.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/profile.rs
@@ -166,6 +166,7 @@ impl MaterializedInstrumentKeyProfile {
         self.keys[slot]
     }
 
+    #[cfg(any(test, feature = "test-support"))]
     pub(crate) fn logical_mask_for_scan_codes(&self, scan_codes: &[u16]) -> Option<u16> {
         scan_codes.iter().try_fold(0u16, |mask, scan_code| {
             self.keys

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/packet_send.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/packet_send.rs
@@ -876,6 +876,7 @@ impl TrackedKeyState {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 fn logical_prefix_mask(mask: u16, count: u8) -> u16 {
     let mut remaining = mask;
     let mut prefix = 0u16;

--- a/rust/crates/sky_dispatch_win32/src/input/tracked/preflight.rs
+++ b/rust/crates/sky_dispatch_win32/src/input/tracked/preflight.rs
@@ -1,7 +1,8 @@
 use super::super::outcome::PhysicalKeyPreflightError;
+#[cfg(any(test, feature = "test-support"))]
+use super::super::physical::InstrumentPhysicalState;
 use super::super::physical::{
-    InstrumentPhysicalState, LogicalInstrumentPhysicalState,
-    instrument_logical_physical_state_for_mask,
+    LogicalInstrumentPhysicalState, instrument_logical_physical_state_for_mask,
 };
 use super::super::scan_code::FULL_INSTRUMENT_MASK;
 use super::TrackedKeyState;

--- a/rust/xtask/src/checks.rs
+++ b/rust/xtask/src/checks.rs
@@ -2607,6 +2607,16 @@ fn v4_trust_material_contract(root: &Path) -> Result<()> {
     if ci.matches("cargo install cargo-vet").count() != 1 {
         return Err("CI must install cargo-vet exactly once in the supply-chain job".into());
     }
+    if ci
+        .matches("google/osv-scanner-action/osv-scanner-action@")
+        .count()
+        != 1
+    {
+        return Err("CI must run exactly one pinned OSV-Scanner action".into());
+    }
+    if !ci.contains("--lockfile=./desktop/bun.lock") {
+        return Err("CI OSV-Scanner must audit the desktop Bun lockfile".into());
+    }
 
     let verifier = fs::read_to_string(root.join("scripts/verify_v4_authenticode.ps1"))?;
     for marker in [


### PR DESCRIPTION
## Summary

- add a Windows process-level single-instance guard so two desktop shells cannot independently own playback and emit physical `SendInput` concurrently
- restore/focus the existing Sky Auto Player window on a second launch when possible
- add weekly Dependabot coverage for the `/desktop` Bun workspace
- scan `desktop/bun.lock` with pinned OSV-Scanner in the existing supply-chain CI lane
- lock the OSV requirement into the existing xtask CI contract
- enforce the frontend host boundary so `@tauri-apps/*` imports remain confined to `src/bridge/**` and `src/platform/**`
- update Vitest 4.1.10 → 4.1.11 after the new OSV gate identified GHSA-82fw-gwwq-j7x9 in the existing lockfile

## Scope decisions

- no Authenticode changes
- no React/Vite/TypeScript/Zustand/React Aria stack migration
- no `store.ts` slice refactor in this PR; that remains a separate maintainability change because it has a much larger review and regression surface
- no new Tauri plugin dependency: the singleton uses the already-owned `windows-sys` boundary, avoiding unrelated Cargo.lock/transitive dependency churn
- no vulnerability suppression/baseline was added; the detected Vitest advisory is fixed instead

## Verification

- source/API review against the pinned Windows API surface
- first CI pass proved the OSV gate is active and detected the pre-existing Vitest advisory
- Vitest family and lockfile integrity were then updated to 4.1.11, the fixed release
- canonical repository CI on the current head remains the authoritative build/test verification

This execution environment does not provide the repository's pinned Rust/Bun toolchains, so no local result is being substituted for the repository gates.