### PR TITLE
ui: compact playback timing controls and settings

### DIFF
--- a/desktop/src-tauri/src/native_runtime.rs
+++ b/desktop/src-tauri/src/native_runtime.rs
@@ -736,6 +736,9 @@ impl NativeCalibrationService {
         };
         let recommendation_available = outcome == CalibrationOutcome::Succeeded;
         let recommended_timing_margin_us = recommendation_available.then(|| {
+            if !applied {
+                return sky_app_core::settings::DEFAULT_TIMING_MARGIN_US;
+            }
             let reserve_us = margin_us.unwrap_or(sky_native_adapters::DEFAULT_TRANSPORT_MARGIN_US);
             let evidence_budget_us = down_late_grace_us.saturating_add(reserve_us);
             evidence_budget_us.div_ceil(sky_app_core::settings::TIMING_MARGIN_STEP_US)
@@ -4918,12 +4921,15 @@ fn timing_margin_recommendation(
     down_late_grace_us: u64,
 ) -> crate::commands::TimingMarginRecommendationDto {
     let resolution = load_calibration_resolution(calibration_cache_path);
-    let evidence_budget = down_late_grace_us
-        .checked_add(resolution.transport_reserve_us)
-        .expect("bounded calibration reserve");
-    let recommended_timing_margin_us = evidence_budget
-        .div_ceil(sky_app_core::settings::TIMING_MARGIN_STEP_US)
-        * sky_app_core::settings::TIMING_MARGIN_STEP_US;
+    let recommended_timing_margin_us = if resolution.qualified {
+        let evidence_budget = down_late_grace_us
+            .checked_add(resolution.transport_reserve_us)
+            .expect("bounded calibration reserve");
+        evidence_budget.div_ceil(sky_app_core::settings::TIMING_MARGIN_STEP_US)
+            * sky_app_core::settings::TIMING_MARGIN_STEP_US
+    } else {
+        sky_app_core::settings::DEFAULT_TIMING_MARGIN_US
+    };
     let source = match resolution.source.as_str() {
         sky_native_adapters::CALIBRATION_MARGIN_SOURCE_DEVICE => "qualified_calibration",
         sky_native_adapters::CALIBRATION_MARGIN_SOURCE_OUT_OF_ENVELOPE => {
@@ -5866,9 +5872,10 @@ mod tests {
             assert_eq!(
                 recommendation.recommended_timing_margin_us,
                 match worst {
+                    0 => 800,
                     677 => 1_300,
                     1_900 => 2_500,
-                    _ => 800,
+                    _ => sky_app_core::settings::DEFAULT_TIMING_MARGIN_US,
                 }
             );
             assert_eq!(recommendation.qualified, expected_margin.is_some());
@@ -5895,14 +5902,17 @@ mod tests {
     }
 
     #[test]
-    fn sender_margin_recommendation_tracks_cutoff_without_clamping_to_setting_max() {
+    fn unqualified_margin_recommendation_uses_default_timing_margin() {
         let path = std::env::temp_dir().join(format!(
             "sky-down-tolerance-recommendation-{}-missing.json",
             std::process::id()
         ));
-        for (cutoff, expected) in [(500, 800), (1_000, 1_300), (2_000, 2_300), (5_000, 5_300)] {
+        for cutoff in [500, 1_000, 2_000, 5_000] {
             let recommendation = timing_margin_recommendation(&path, cutoff);
-            assert_eq!(recommendation.recommended_timing_margin_us, expected);
+            assert_eq!(
+                recommendation.recommended_timing_margin_us,
+                sky_app_core::settings::DEFAULT_TIMING_MARGIN_US
+            );
             assert_eq!(recommendation.source, "default_fallback");
         }
     }

--- a/desktop/src/bridge/mockBridge.ts
+++ b/desktop/src/bridge/mockBridge.ts
@@ -95,7 +95,7 @@ function initialSettings(): Settings {
       dry_run: false,
     },
     timing_margin_recommendation: {
-      recommended_timing_margin_us: 2_300,
+      recommended_timing_margin_us: 500,
       qualified: false,
       source: 'default_fallback',
     },
@@ -480,7 +480,9 @@ export function createMockBridge(): DesktopBridge {
           ...settings,
           timing_margin_recommendation: {
             ...settings.timing_margin_recommendation,
-            recommended_timing_margin_us: Math.ceil((playback.downLateGraceUs + 300) / 100) * 100,
+            recommended_timing_margin_us: settings.timing_margin_recommendation.qualified
+              ? Math.ceil((playback.downLateGraceUs + 300) / 100) * 100
+              : 500,
           },
         };
       }

--- a/desktop/src/components/player/PlayerTools.tsx
+++ b/desktop/src/components/player/PlayerTools.tsx
@@ -169,6 +169,7 @@ function ProfileFields({ defaults, bootstrap, recommendation, patchSettings }: P
         value={defaults.timing_margin_us}
         options={bootstrap.option_sets}
         recommendation={recommendation}
+        density="compact"
         onChange={(value) =>
           patchSettings({ playbackDefaults: { timingMarginUs: value } }).then(
             (authoritative) => authoritative?.playback_defaults.timing_margin_us ?? null,
@@ -176,14 +177,6 @@ function ProfileFields({ defaults, bootstrap, recommendation, patchSettings }: P
         }
       />
       <dl className="profile-timing-summary">
-        <div>
-          <dt>1 frame</dt>
-          <dd>{(frameUs / 1_000).toFixed(3)} ms</dd>
-        </div>
-        <div>
-          <dt>Base hold</dt>
-          <dd>{(frameBaseHoldUs / 1_000).toFixed(3)} ms</dd>
-        </div>
         <div>
           <dt>Target hold</dt>
           <dd>{(minHoldUs / 1_000).toFixed(3)} ms</dd>

--- a/desktop/src/components/settings/SettingsPanel.test.tsx
+++ b/desktop/src/components/settings/SettingsPanel.test.tsx
@@ -22,7 +22,7 @@ describe('SettingsPanel playback timing', () => {
     expect(
       screen.getByText('Source: Default fallback (no valid calibration cache)'),
     ).toBeInTheDocument();
-    expect(screen.getByText('· rec. 2300 µs')).toBeInTheDocument();
+    expect(screen.getByText('· rec. 500 µs')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Use recommended/ })).not.toBeInTheDocument();
     expect(screen.queryByText(/sender evidence, not proof/)).not.toBeInTheDocument();
   });

--- a/desktop/src/components/settings/SettingsPanel.test.tsx
+++ b/desktop/src/components/settings/SettingsPanel.test.tsx
@@ -7,7 +7,7 @@ import { SettingsPanel } from './SettingsPanel';
 describe('SettingsPanel playback timing', () => {
   afterEach(() => cleanup());
 
-  it('labels base hold and shows the independent cutoff and recommendation source', async () => {
+  it('keeps recommendation source subordinate and preserves the timing summary', async () => {
     const store = createDesktopStore(createMockBridge());
     await act(async () => store.getState().initialize());
     const bootstrap = store.getState().bootstrap;
@@ -18,8 +18,12 @@ describe('SettingsPanel playback timing', () => {
 
     expect(screen.getByLabelText('Base Hold')).toBeInTheDocument();
     expect(screen.getByText('Late Down tolerance').parentElement).toHaveTextContent('2000 µs');
-    expect(screen.getByText(/Recommended sender margin: 2300 µs · Source:/)).toHaveTextContent(
-      'Default fallback (no valid calibration cache)',
-    );
+    expect(screen.getByRole('heading', { name: 'Timing' })).toBeInTheDocument();
+    expect(
+      screen.getByText('Source: Default fallback (no valid calibration cache)'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('· rec. 2300 µs')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Use recommended/ })).not.toBeInTheDocument();
+    expect(screen.queryByText(/sender evidence, not proof/)).not.toBeInTheDocument();
   });
 });

--- a/desktop/src/components/settings/SettingsPanel.tsx
+++ b/desktop/src/components/settings/SettingsPanel.tsx
@@ -154,43 +154,47 @@ export function SettingsPanel({ bootstrap, settingsTriggerRef, useStore }: Setti
                       </select>
                     </label>
                   </div>
-                  <TimingMarginControl
-                    value={defaults.timing_margin_us}
-                    options={bootstrap.option_sets}
-                    recommendation={settings.timing_margin_recommendation}
-                    onChange={(value) =>
-                      patchSettings({ playbackDefaults: { timingMarginUs: value } }).then(
-                        (authoritative) =>
-                          authoritative?.playback_defaults.timing_margin_us ?? null,
-                      )
-                    }
-                  />
-                  <dl className="settings-timing-summary">
-                    <div>
-                      <dt>1 frame</dt>
-                      <dd>{(frameUs / 1_000).toFixed(3)} ms</dd>
-                    </div>
-                    <div>
-                      <dt>Base hold</dt>
-                      <dd>{(frameBaseHoldUs / 1_000).toFixed(3)} ms</dd>
-                    </div>
-                    <div>
-                      <dt>Target hold</dt>
-                      <dd>{(minHoldUs / 1_000).toFixed(3)} ms</dd>
-                    </div>
-                    <div>
-                      <dt>Release gap</dt>
-                      <dd>{(minReleaseGapUs / 1_000).toFixed(3)} ms</dd>
-                    </div>
-                    <div>
-                      <dt>Late Down tolerance</dt>
-                      <dd>{defaults.down_late_grace_us} µs</dd>
-                    </div>
-                  </dl>
-                  <p className="settings-note">
-                    Playback changes apply when preparing the next session. An active session keeps
-                    its frozen timing values.
-                  </p>
+                  <div className="settings-timing-group">
+                    <h4>Timing</h4>
+                    <TimingMarginControl
+                      value={defaults.timing_margin_us}
+                      options={bootstrap.option_sets}
+                      recommendation={settings.timing_margin_recommendation}
+                      density="full"
+                      onChange={(value) =>
+                        patchSettings({ playbackDefaults: { timingMarginUs: value } }).then(
+                          (authoritative) =>
+                            authoritative?.playback_defaults.timing_margin_us ?? null,
+                        )
+                      }
+                    />
+                    <dl className="settings-timing-summary">
+                      <div>
+                        <dt>1 frame</dt>
+                        <dd>{(frameUs / 1_000).toFixed(3)} ms</dd>
+                      </div>
+                      <div>
+                        <dt>Base hold</dt>
+                        <dd>{(frameBaseHoldUs / 1_000).toFixed(3)} ms</dd>
+                      </div>
+                      <div>
+                        <dt>Target hold</dt>
+                        <dd>{(minHoldUs / 1_000).toFixed(3)} ms</dd>
+                      </div>
+                      <div>
+                        <dt>Release gap</dt>
+                        <dd>{(minReleaseGapUs / 1_000).toFixed(3)} ms</dd>
+                      </div>
+                      <div>
+                        <dt>Late Down tolerance</dt>
+                        <dd>{defaults.down_late_grace_us} µs</dd>
+                      </div>
+                    </dl>
+                    <p className="settings-note">
+                      Changes apply to the next prepared session; an active session keeps its frozen
+                      timing values.
+                    </p>
+                  </div>
                 </section>
               )}
 

--- a/desktop/src/components/settings/TimingMarginControl.test.tsx
+++ b/desktop/src/components/settings/TimingMarginControl.test.tsx
@@ -24,13 +24,14 @@ const recommendation: TimingMarginRecommendation = {
 describe('TimingMarginControl', () => {
   afterEach(() => cleanup());
 
-  it('steps by the backend increment and applies recommendations explicitly', () => {
+  it('shows recommendation as text and steps by the backend increment', () => {
     const changes: number[] = [];
     render(
       <TimingMarginControl
         value={800}
         options={options}
         recommendation={recommendation}
+        density="full"
         onChange={async (value) => {
           changes.push(value);
           return value;
@@ -39,10 +40,31 @@ describe('TimingMarginControl', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Increase Timing Margin' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Use recommended (1300 µs)' }));
 
-    expect(changes).toEqual([900, 1_300]);
-    expect(screen.getByText(/Source: Qualified calibration/)).toBeInTheDocument();
+    expect(changes).toEqual([900]);
+    expect(screen.getByText('· rec. 1300 µs')).toBeInTheDocument();
+    expect(screen.getByText('Source: Qualified calibration')).toBeInTheDocument();
+    expect(screen.getByText('Applies to Hold and Release Gap')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Use recommended/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the compact variant informational and omits source details', () => {
+    render(
+      <TimingMarginControl
+        value={800}
+        options={options}
+        recommendation={recommendation}
+        density="compact"
+        onChange={async (value) => value}
+      />,
+    );
+
+    expect(screen.getByRole('group', { name: 'Timing Margin' })).toContainElement(
+      screen.getByText('· rec. 1300 µs'),
+    );
+    expect(screen.queryByText(/Source:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Applies to Hold and Release Gap')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Use recommended/ })).not.toBeInTheDocument();
   });
 
   it('disables steps at the configured endpoints', () => {
@@ -51,6 +73,7 @@ describe('TimingMarginControl', () => {
         value={0}
         options={options}
         recommendation={recommendation}
+        density="full"
         onChange={async () => 0}
       />,
     );
@@ -63,6 +86,7 @@ describe('TimingMarginControl', () => {
         value={3_000}
         options={options}
         recommendation={recommendation}
+        density="full"
         onChange={async () => 3_000}
       />,
     );
@@ -79,6 +103,7 @@ describe('TimingMarginControl', () => {
         value={800}
         options={options}
         recommendation={recommendation}
+        density="compact"
         onChange={(value) => {
           changes.push(value);
           return new Promise<number>((resolve) => confirmations.push(resolve));
@@ -107,6 +132,7 @@ describe('TimingMarginControl', () => {
         value={800}
         options={options}
         recommendation={recommendation}
+        density="full"
         onChange={async () => {
           throw new Error('settings IPC failed');
         }}
@@ -118,20 +144,25 @@ describe('TimingMarginControl', () => {
     await waitFor(() => expect(screen.getByText('800 µs')).toBeInTheDocument());
   });
 
-  it('shows an over-range recommendation without clamping or applying it', () => {
+  it('shows an over-range recommendation as information and never writes it', () => {
+    const changes: number[] = [];
     render(
       <TimingMarginControl
         value={800}
         options={options}
         recommendation={{ ...recommendation, recommended_timing_margin_us: 5_300 }}
-        onChange={async (value) => value}
+        density="compact"
+        onChange={async (value) => {
+          changes.push(value);
+          return value;
+        }}
       />,
     );
 
-    expect(screen.getByRole('button', { name: 'Use recommended (5300 µs)' })).toBeDisabled();
-    expect(
-      screen.getByText('Recommendation exceeds the current Timing Margin range.'),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Recommended sender margin: 5300 µs/)).toBeInTheDocument();
+    expect(screen.getByText('· rec. 5300 µs · out of range')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Use recommended/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Increase Timing Margin' }));
+    expect(changes).toEqual([900]);
+    expect(changes).not.toContain(5_300);
   });
 });

--- a/desktop/src/components/settings/TimingMarginControl.tsx
+++ b/desktop/src/components/settings/TimingMarginControl.tsx
@@ -6,6 +6,7 @@ interface TimingMarginControlProps {
   value: number;
   options: PlaybackOptionSets;
   recommendation: TimingMarginRecommendation;
+  density: 'compact' | 'full';
   onChange: (value: number) => Promise<number | null>;
 }
 
@@ -13,6 +14,7 @@ export function TimingMarginControl({
   value,
   options,
   recommendation,
+  density,
   onChange,
 }: TimingMarginControlProps) {
   const min = options.timing_margin_min_us;
@@ -46,8 +48,19 @@ export function TimingMarginControl({
   };
 
   return (
-    <div className="timing-margin-control" aria-label="Timing Margin">
-      <span className="timing-margin-label">Timing Margin</span>
+    <div
+      className={`timing-margin-control timing-margin-control--${density}`}
+      role="group"
+      aria-label="Timing Margin"
+    >
+      <div className="timing-margin-heading">
+        <span className="timing-margin-label">Timing Margin</span>
+        <span className="timing-margin-recommendation">
+          {` · rec. ${recommendation.recommended_timing_margin_us} µs${
+            recommendationWithinRange ? '' : ' · out of range'
+          }`}
+        </span>
+      </div>
       <div className="timing-margin-stepper">
         <button
           className="button timing-margin-step"
@@ -69,29 +82,14 @@ export function TimingMarginControl({
           +
         </button>
       </div>
-      {requestedValue !== recommendation.recommended_timing_margin_us && (
-        <button
-          className="button timing-margin-recommendation"
-          type="button"
-          disabled={!recommendationWithinRange}
-          onClick={() => requestValue(recommendation.recommended_timing_margin_us)}
-        >
-          Use recommended ({recommendation.recommended_timing_margin_us} µs)
-        </button>
+      {density === 'full' && (
+        <>
+          <span className="settings-note timing-margin-source">
+            Source: {timingMarginRecommendationSourceLabel(recommendation.source)}
+          </span>
+          <span className="settings-note">Applies to Hold and Release Gap</span>
+        </>
       )}
-      {!recommendationWithinRange && (
-        <span className="settings-note" role="status">
-          Recommendation exceeds the current Timing Margin range.
-        </span>
-      )}
-      <span className="settings-note">
-        Applies to Hold and Release Gap. Changes take effect in the next prepared session.
-      </span>
-      <span className="settings-note">
-        Recommended sender margin: {recommendation.recommended_timing_margin_us} µs · Source:{' '}
-        {timingMarginRecommendationSourceLabel(recommendation.source)}. This is sender evidence, not
-        proof that the game accepted a note.
-      </span>
     </div>
   );
 }

--- a/desktop/src/styles/overlays.css
+++ b/desktop/src/styles/overlays.css
@@ -96,6 +96,20 @@
   margin-bottom: 1px;
 }
 
+.settings-timing-group {
+  display: grid;
+  gap: 8px;
+  margin-top: 2px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-timing-group h4 {
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .settings-section label:not(.checkbox-row) {
   display: grid;
   gap: 6px;
@@ -165,13 +179,28 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 6px 12px;
-  margin-top: 12px;
+  gap: 4px 12px;
+  min-width: 0;
+}
+
+.timing-margin-heading {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0 6px;
+  min-width: 0;
 }
 
 .timing-margin-label {
   color: var(--text-secondary);
   font-size: 12px;
+  white-space: nowrap;
+}
+
+.timing-margin-recommendation {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
 }
 
 .timing-margin-stepper {
@@ -193,9 +222,12 @@
   cursor: default;
 }
 
-.timing-margin-recommendation,
 .timing-margin-control .settings-note {
   grid-column: 1 / -1;
+}
+
+.timing-margin-control--full .timing-margin-source {
+  margin-top: 2px;
 }
 
 .settings-timing-summary,
@@ -206,6 +238,10 @@
   margin: 10px 0 0;
   font-size: 11px;
   font-variant-numeric: tabular-nums;
+}
+
+.profile-timing-summary {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .settings-timing-summary div,

--- a/desktop/src/styles/player.css
+++ b/desktop/src/styles/player.css
@@ -293,9 +293,10 @@
   z-index: 7;
   display: grid;
   gap: 10px;
-  min-width: 205px;
-  width: max-content;
+  width: min(320px, calc(100vw - 24px));
+  min-width: min(260px, calc(100vw - 24px));
   max-width: calc(100vw - 24px);
+  box-sizing: border-box;
   padding: 12px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-panel);
@@ -320,7 +321,11 @@
 
 .profile-popover .timing-margin-control {
   grid-template-columns: minmax(0, 1fr) auto;
-  margin-top: 2px;
+  gap: 5px 8px;
+}
+
+.profile-popover .timing-margin-heading {
+  column-gap: 4px;
 }
 
 .profile-popover .profile-timing-summary {

--- a/desktop/tests/e2e/library.spec.ts
+++ b/desktop/tests/e2e/library.spec.ts
@@ -449,16 +449,49 @@ test('Player Bar remains compact, centered, and bounded at the minimum viewport'
 });
 
 test('Playback Profile works through the narrow popover with focus restore', async ({ page }) => {
-  await page.setViewportSize({ width: 800, height: 560 });
+  await page.setViewportSize({ width: 1366, height: 768 });
   await page.goto('/');
   const trigger = page.getByRole('button', { name: 'Configure playback profile' });
+  const popover = page.getByRole('dialog', { name: 'Playback profile' });
+
+  await trigger.click();
+  await expect(popover).toBeVisible();
+  const assertPopoverGeometry = async () => {
+    const box = await popover.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.width).toBeGreaterThanOrEqual(260);
+      expect(box.width).toBeLessThanOrEqual(320);
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(page.viewportSize()?.width ?? 0);
+    }
+    const hasHorizontalOverflow = await popover.evaluate(
+      (element) => element.scrollWidth > element.clientWidth,
+    );
+    expect(hasHorizontalOverflow).toBe(false);
+  };
+  await assertPopoverGeometry();
+  await page.keyboard.press('Escape');
+  await expect(popover).toBeHidden();
+
+  await page.setViewportSize({ width: 800, height: 560 });
   await trigger.click();
 
-  const popover = page.getByRole('dialog', { name: 'Playback profile' });
   await expect(popover).toBeVisible();
+  await assertPopoverGeometry();
   await expect(popover.getByLabel('Hold')).toBeVisible();
   await expect(popover.getByLabel('Tempo')).toBeVisible();
   await expect(popover.getByLabel('FPS')).toBeVisible();
+  await expect(popover.locator('.profile-timing-summary dt')).toHaveText([
+    'Target hold',
+    'Release gap',
+    'Late Down tolerance',
+  ]);
+  await expect(popover.locator('.timing-margin-control')).toContainText(
+    'Timing Margin · rec. 2300 µs',
+  );
+  await expect(popover.getByRole('button', { name: /Use recommended/ })).toHaveCount(0);
+  await expect(popover.getByText(/Source:/)).toHaveCount(0);
   await expect(popover.getByRole('button', { name: 'Test playback (no input)' })).toBeVisible();
   await expect(popover.locator('input[type="checkbox"]')).toHaveCount(0);
   await expectNoSeriousAccessibilityViolations(page);
@@ -565,6 +598,25 @@ test('Settings modal has no serious accessibility violations and closes accessib
     'aria-current',
     'page',
   );
+  await expect(dialog.getByRole('heading', { name: 'Timing' })).toBeVisible();
+  await expect(
+    dialog.getByText('Source: Default fallback (no valid calibration cache)'),
+  ).toBeVisible();
+  await expect(dialog.getByRole('button', { name: /Use recommended/ })).toHaveCount(0);
+  await expect(dialog.getByText(/sender evidence, not proof/)).toHaveCount(0);
+  const playbackContentHasHorizontalOverflow = await dialog
+    .locator('.settings-content')
+    .evaluate((element) => element.scrollWidth > element.clientWidth);
+  expect(playbackContentHasHorizontalOverflow).toBe(false);
+  const timingHeadingBox = await dialog.locator('.timing-margin-heading').boundingBox();
+  const timingStepperBox = await dialog.locator('.timing-margin-stepper').boundingBox();
+  expect(timingHeadingBox).not.toBeNull();
+  expect(timingStepperBox).not.toBeNull();
+  if (timingHeadingBox && timingStepperBox) {
+    const headingCenterY = timingHeadingBox.y + timingHeadingBox.height / 2;
+    const stepperCenterY = timingStepperBox.y + timingStepperBox.height / 2;
+    expect(Math.abs(headingCenterY - stepperCenterY)).toBeLessThanOrEqual(2);
+  }
   const initialBox = await dialog.boundingBox();
   const settingsContent = dialog.locator('.settings-content');
   const initialContentWidth = await settingsContent.evaluate((element) => element.clientWidth);

--- a/desktop/tests/e2e/library.spec.ts
+++ b/desktop/tests/e2e/library.spec.ts
@@ -488,7 +488,7 @@ test('Playback Profile works through the narrow popover with focus restore', asy
     'Late Down tolerance',
   ]);
   await expect(popover.locator('.timing-margin-control')).toContainText(
-    'Timing Margin · rec. 2300 µs',
+    'Timing Margin · rec. 500 µs',
   );
   await expect(popover.getByRole('button', { name: /Use recommended/ })).toHaveCount(0);
   await expect(popover.getByText(/Source:/)).toHaveCount(0);

--- a/docs/hold-frame-model.md
+++ b/docs/hold-frame-model.md
@@ -55,8 +55,8 @@ candidate above `2,000 µs` is out of the trusted envelope and uses the
 unqualified transport reserve. A qualified recommendation is rounded up to
 the next `100 µs` after adding the currently selected Late Down tolerance.
 With the default `2,000 µs` cutoff and fallback `300 µs` reserve, that advisory
-value is `2,300 µs`. Applying it
-requires the user's explicit **Use recommended** action and affects only the
+value is `2,300 µs`. It is informational only and never writes a setting.
+Users adjust Timing Margin with its bounded stepper; a change affects only the
 next prepared session.
 
 The release gap is one base game frame plus the exact Timing Margin. It is an

--- a/docs/hold-frame-model.md
+++ b/docs/hold-frame-model.md
@@ -39,11 +39,11 @@ The user-owned Timing Margin defaults to `500 µs`, ranges from `0` through
 `3,000 µs` in `100 µs` steps, and applies equally to Hold and Release Gap.
 The independent Late Down tolerance defaults to `2,000 µs`, ranges from `0`
 through `5,000 µs` in `100 µs` steps, and is frozen per prepared session.
-Calibration never supplies part of the authored timing equation. It may
-produce an advisory recommendation from the selected Late Down tolerance plus
-measured transport-reserve evidence; with the default cutoff and the
-unqualified `300 µs` reserve, the fallback recommendation is `2,300 µs`.
-Calibration is never shown as qualified when fallback is used.
+Calibration never supplies part of the authored timing equation. Qualified
+calibration may produce an advisory recommendation from the selected Late
+Down tolerance plus measured transport-reserve evidence. Without qualified
+evidence, the informational fallback recommendation is the `500 µs` default
+Timing Margin. Calibration is never shown as qualified when fallback is used.
 Production calibration uses one pair metric per Down/Up SendInput
 packet, based on `T_D/P_D/C_D` and `T_U/P_U/C_U`; Raw Input receipt timing is
 not part of qualification. It uses exactly the six `1/5/15 × hot/cold`
@@ -54,8 +54,8 @@ candidate at or below `2,000 µs` qualifies and reserves at least `300 µs`; a
 candidate above `2,000 µs` is out of the trusted envelope and uses the
 unqualified transport reserve. A qualified recommendation is rounded up to
 the next `100 µs` after adding the currently selected Late Down tolerance.
-With the default `2,000 µs` cutoff and fallback `300 µs` reserve, that advisory
-value is `2,300 µs`. It is informational only and never writes a setting.
+An unqualified recommendation falls back to the `500 µs` default Timing
+Margin. Recommendations are informational only and never write a setting.
 Users adjust Timing Margin with its bounded stepper; a change affects only the
 next prepared session.
 

--- a/docs/implementation-compact-playback-timing-ui.md
+++ b/docs/implementation-compact-playback-timing-ui.md
@@ -1,0 +1,348 @@
+# Compact playback timing UI handoff
+
+Status: **implementation work order for Codex**.
+
+Base: `main` after PR #233.
+
+This PR is deliberately UI-only. It must improve the quick playback profile popover and the Playback section of Settings without changing timing policy, persistence, native/runtime behavior, calibration semantics, or playback admission.
+
+## User problem
+
+The timing controls added in PR #233 are functionally correct but visually too large and verbose.
+
+Two current problems are visible in the shipped layout:
+
+1. The quick playback profile popover at the lower-right grows much wider than the controls need. The current combination of `width: max-content`, a full-width **Use recommended (...)** button, and long explanatory copy makes the popover dominate the workbench.
+2. The Playback page in Settings gives the Timing Margin recommendation too much visual weight and spreads the timing information over too much space.
+
+The target is a compact, high-information layout that keeps common controls immediately readable and moves explanation into secondary text.
+
+## Non-goals / invariants
+
+Do **not** change any of the following:
+
+- Timing Margin default: **500 us**.
+- Late Down tolerance default: **2000 us**.
+- Timing Margin range/step.
+- Late Down tolerance range/step.
+- Base Hold choices.
+- FPS or tempo choices.
+- Authored Hold / Release Gap equations.
+- Calibration or recommendation calculation.
+- Persisted settings schema.
+- Native bridge DTOs.
+- Session freezing behavior.
+- Scheduler/compiler behavior.
+- SendInput, cutoff, admission, recovery, packet, chord, scan-code, retry, or telemetry semantics.
+
+This PR is a presentation and interaction-density change only.
+
+## Primary implementation areas
+
+Expected files:
+
+- `desktop/src/components/player/PlayerTools.tsx`
+- `desktop/src/components/settings/TimingMarginControl.tsx`
+- `desktop/src/components/settings/SettingsPanel.tsx`
+- `desktop/src/styles/player.css`
+- `desktop/src/styles/overlays.css`
+- related component tests
+- `desktop/tests/e2e/library.spec.ts` if geometry/responsive assertions need updating
+
+Avoid native Rust changes unless a test proves a UI contract cannot otherwise be preserved. Any Rust change requires explicit reviewer justification.
+
+## 1. Quick playback profile popover
+
+The quick profile is a fast-access surface, not a full explanation surface.
+
+### Required layout
+
+Make the popover compact and bounded.
+
+Target behavior:
+
+- It must no longer size itself from long recommendation/help text.
+- Prefer an explicit compact width in the **260-320 px** range.
+- It may shrink responsively on narrow windows.
+- It must never expand across most of the track list as in the current implementation.
+- Long copy must wrap inside the bounded width rather than determine the width.
+
+Replace the current vertical/full-width recommendation treatment.
+
+Current pattern to remove from the quick popover:
+
+```
+Timing Margin                    [-] 800 us [+]
+[        Use recommended (2300 us)               ]
+Applies to Hold and Release Gap...
+Recommended sender margin: 2300 us · Source...
+```
+
+Target pattern:
+
+```
+Base Hold                 [1f]
+Tempo                     [1x]
+FPS                       [60]
+
+Timing Margin · rec. 2300 us     [-] 800 us [+]
+
+Target hold               17.167 ms
+Release gap               17.167 ms
+Late Down tolerance       2000 us
+
+[ Test playback (no input) ]
+```
+
+Exact typography may be refined, but the information hierarchy is required.
+
+### Recommendation behavior in quick profile
+
+Remove the **Use recommended** button from the quick profile.
+
+The quick profile must show recommendation as non-interactive secondary text immediately adjacent to the Timing Margin label, for example:
+
+- `Timing Margin · rec. 2300 us`
+- or `Timing Margin   Recommended 2300 us`
+
+Requirements:
+
+- Recommendation remains visible.
+- It must not look clickable.
+- If recommendation is outside the valid Timing Margin range, show that state succinctly, e.g. `rec. 5300 us · out of range`.
+- Do not silently clamp the recommendation.
+- The quick profile must not offer an action that writes an out-of-range recommendation.
+
+The quick profile does **not** need the recommendation source or the long “sender evidence, not proof...” paragraph.
+
+### Quick timing summary
+
+Reduce the summary to the values most useful while choosing a profile:
+
+- Target hold.
+- Release gap.
+- Late Down tolerance.
+
+The following are redundant in the quick surface and should be omitted there:
+
+- `1 frame`
+- `Base hold`
+
+They may remain in the full Settings view.
+
+### Control density
+
+Base Hold, Tempo, and FPS must remain immediately editable.
+
+Use compact rows or another dense arrangement that preserves readable labels and keyboard access. Do not create a large card for each field.
+
+The Timing Margin stepper remains authoritative and keeps the existing async write/reconciliation behavior.
+
+The full-width **Test playback (no input)** action remains at the bottom.
+
+## 2. Playback section in Settings
+
+The Settings modal is the full-detail surface, but it should still be visually economical.
+
+### Required hierarchy
+
+Keep:
+
+- Playback defaults heading.
+- Base Hold / Tempo / FPS controls.
+- Timing Margin control.
+- Full timing summary.
+- “next prepared session / frozen active session” semantics.
+
+Improve the layout so Timing Margin reads as one settings row instead of a large action block.
+
+Suggested structure:
+
+```
+Playback defaults
+[ Base Hold ] [ Tempo ] [ FPS ]
+
+Timing
+Timing Margin     rec. 2300 us                 [-] 800 us [+]
+                  Default fallback · sender-side recommendation
+                  Applies to Hold and Release Gap
+
+1 frame          16.667 ms      Base hold       16.667 ms
+Target hold      17.467 ms      Release gap     17.467 ms
+Late Down tolerance             2000 us
+
+Playback changes apply to the next prepared session...
+```
+
+The exact visual grouping can differ, but the following acceptance rules are mandatory:
+
+- No full-width **Use recommended** button.
+- Recommendation text must be visually secondary to the current setting.
+- Recommendation source may remain in Settings, but it must be short and subordinate.
+- The long sender-evidence disclaimer must not dominate the section.
+- Current value and +/- controls must be visually aligned as one row.
+- Timing summary values must be compact, aligned, and scan-friendly.
+- Avoid large unused horizontal gaps.
+- Do not make the modal wider to solve the layout.
+
+### Recommendation application
+
+For this UI cleanup, recommendation is informational only.
+
+Remove direct **Use recommended** application from `TimingMarginControl` rather than keeping a hidden/context-dependent action.
+
+The user can set the recommended number with the existing +/- stepper.
+
+Do not add a new icon-only apply button, context menu, or hover-only action.
+
+This simplification is intentional.
+
+### Settings dialog dimensions
+
+Do not increase the existing Settings dialog footprint.
+
+It is acceptable to reduce its width slightly if the result remains comfortable for all categories. The Playback section must work without horizontal scrolling.
+
+At approximately 1280x720:
+
+- Settings must remain fully usable.
+- Footer and close control must remain reachable.
+- Playback content may vertically scroll if needed.
+- No field or stepper may be clipped.
+
+## 3. Shared component design
+
+`TimingMarginControl` is currently shared by Settings and PlayerTools. Refactor it so the same state/reconciliation logic can support two presentation densities without duplicating async setting logic.
+
+Preferred approaches include:
+
+- a `density="compact" | "full"` / `variant` prop;
+- small presentational subcomponents over one shared request/reconciliation hook.
+
+Do not copy/paste the pending-write logic into PlayerTools.
+
+The recommendation must remain readable to assistive technology in both variants.
+
+## 4. Accessibility
+
+Preserve or improve:
+
+- `aria-label="Timing Margin"`.
+- Decrease/Increase button accessible names.
+- `output aria-live="polite"` for current value.
+- Keyboard operation for selects and stepper buttons.
+- Visible focus states.
+- Dialog/Popover focus behavior.
+
+Recommendation text must not be announced as an actionable control after the button is removed.
+
+## 5. Responsive / geometry acceptance
+
+Add or update automated coverage where practical.
+
+Acceptance targets:
+
+### Quick profile
+
+At standard desktop widths:
+
+- bounded compact width, approximately 260-320 px;
+- no horizontal page overflow;
+- no overlap beyond the viewport edge;
+- long recommendation/source strings cannot expand the popover width.
+
+At narrower supported window sizes:
+
+- popover remains within viewport;
+- controls remain operable;
+- text may wrap;
+- no horizontal scrollbar inside the popover unless absolutely unavoidable.
+
+### Settings
+
+- no horizontal overflow in Playback;
+- three primary selects may collapse responsively if existing breakpoints require it;
+- timing stepper stays aligned and usable;
+- summary remains readable.
+
+## 6. Tests
+
+Update tests to reflect the interaction simplification.
+
+Required component coverage:
+
+- current Timing Margin renders correctly;
+- +/- update behavior and pending-write reconciliation remain unchanged;
+- recommendation renders as text;
+- **Use recommended** button is absent;
+- out-of-range recommendation is visible as informational state and cannot write an invalid value;
+- compact and full variants render the intended information;
+- Settings still renders source/qualification information in a subordinate form;
+- quick profile omits long source/evidence copy;
+- quick profile retains Test playback behavior.
+
+Run at minimum:
+
+```powershell
+cd desktop
+bun test
+bun run build
+bunx playwright test
+```
+
+Then run the repository's canonical desktop/CI validation path used by GitHub Actions.
+
+## 7. Visual acceptance checklist
+
+Before declaring complete, manually inspect the actual Tauri app at the same approximate layouts as the reported screenshots.
+
+Quick profile acceptance:
+
+- [ ] popover is visibly much narrower than before;
+- [ ] no **Use recommended** button;
+- [ ] recommendation is beside Timing Margin as small secondary text;
+- [ ] no long recommendation/source paragraph;
+- [ ] Target hold / Release gap / Late Down tolerance remain visible;
+- [ ] Test playback stays obvious;
+- [ ] no clipping at right/bottom edge.
+
+Settings acceptance:
+
+- [ ] Playback page has a clear primary/secondary hierarchy;
+- [ ] Timing Margin occupies one compact row;
+- [ ] recommendation does not look like the primary action;
+- [ ] summary is aligned and compact;
+- [ ] no unnecessary width increase;
+- [ ] no behavior regression when changing Base Hold, Tempo, FPS, or Margin.
+
+Capture before/after screenshots in the final Codex report if the local environment allows it.
+
+## 8. Scope discipline
+
+Do not use this PR to redesign the entire app.
+
+Do not:
+
+- redesign navigation;
+- restyle unrelated dialogs;
+- change themes/tokens globally unless a narrowly scoped token is necessary;
+- move Late Down tolerance between categories as part of this work;
+- change playback behavior;
+- change recommendation math.
+
+If a broader design issue is discovered, report it separately rather than expanding this PR.
+
+## Definition of Done
+
+The implementation is ready for independent review when:
+
+1. quick profile is compact and bounded;
+2. recommendation is informational text, not a button;
+3. quick profile no longer contains verbose recommendation copy;
+4. Settings Playback timing hierarchy is visibly cleaner;
+5. all timing values and persistence semantics are unchanged;
+6. component/unit/E2E tests pass;
+7. exact-head CI is green;
+8. final report contains changed files, validation commands, exact head SHA, CI run, and screenshots or a concise visual verification statement.
+
+Do not merge this PR. Leave it draft for independent acceptance.

--- a/docs/implementation-compact-playback-timing-ui.md
+++ b/docs/implementation-compact-playback-timing-ui.md
@@ -85,7 +85,7 @@ Base Hold                 [1f]
 Tempo                     [1x]
 FPS                       [60]
 
-Timing Margin · rec. 2300 us     [-] 800 us [+]
+Timing Margin · rec. 500 us      [-] 800 us [+]
 
 Target hold               17.167 ms
 Release gap               17.167 ms
@@ -102,8 +102,8 @@ Remove the **Use recommended** button from the quick profile.
 
 The quick profile must show recommendation as non-interactive secondary text immediately adjacent to the Timing Margin label, for example:
 
-- `Timing Margin · rec. 2300 us`
-- or `Timing Margin   Recommended 2300 us`
+- `Timing Margin · rec. 500 us`
+- or `Timing Margin   Recommended 500 us`
 
 Requirements:
 
@@ -163,7 +163,7 @@ Playback defaults
 [ Base Hold ] [ Tempo ] [ FPS ]
 
 Timing
-Timing Margin     rec. 2300 us                 [-] 800 us [+]
+Timing Margin     rec. 500 us                  [-] 800 us [+]
                   Default fallback · sender-side recommendation
                   Applies to Hold and Release Gap
 

--- a/docs/implementation-real-game-input-reliability-late-down-tolerance.md
+++ b/docs/implementation-real-game-input-reliability-late-down-tolerance.md
@@ -5,6 +5,10 @@
 > only; users adjust Timing Margin through the existing bounded stepper. This
 > presentation change does not alter the separate native
 > `PlaybackDecision::UseRecommended` risk-flow decision.
+>
+> Missing, invalid, and out-of-envelope calibration now show the `500 µs`
+> default as the informational fallback. Qualified calibration remains
+> evidence-based; older fallback calculations below are historical.
 
 ## Status
 

--- a/docs/implementation-real-game-input-reliability-late-down-tolerance.md
+++ b/docs/implementation-real-game-input-reliability-late-down-tolerance.md
@@ -1,5 +1,11 @@
 # Real-game input reliability investigation and user-owned Late Down tolerance
 
+> **UI follow-up (PR #234):** Earlier **Use recommended** Timing Margin UI
+> examples in this handoff are superseded. Recommendation is informational
+> only; users adjust Timing Margin through the existing bounded stepper. This
+> presentation change does not alter the separate native
+> `PlaybackDecision::UseRecommended` risk-flow decision.
+
 ## Status
 
 Implementation / investigation handoff for Codex on draft PR #233.

--- a/docs/implementation-user-owned-symmetric-timing-margin.md
+++ b/docs/implementation-user-owned-symmetric-timing-margin.md
@@ -9,6 +9,11 @@ Status: **implementation complete; superseded as an active handoff**.
 > users adjust Timing Margin through the existing bounded stepper. This
 > presentation change does not alter the separate native
 > `PlaybackDecision::UseRecommended` risk-flow decision.
+>
+> **Recommendation follow-up (PR #234):** Missing, invalid, and out-of-envelope
+> calibration now show the `500 µs` default as the informational fallback.
+> Qualified calibration recommendations remain evidence-based; the earlier
+> `2,300 µs` fallback example below is historical.
 
 The merge defaults accepted by the user are:
 
@@ -16,7 +21,7 @@ The merge defaults accepted by the user are:
 - Late Down tolerance: **2000 us**.
 - Base Hold choices remain **1.0 / 1.25 / 1.5 frames**.
 - The two controls remain independent; the cutoff is never added to authored Hold or Release Gap.
-- Calibration remains advisory only. With the default cutoff and unqualified 300-us transport reserve, the fallback recommendation is **2300 us**.
+- At the original #233 implementation point, the fallback recommendation was **2300 us**; PR #234 changes the unqualified fallback to **500 us** while qualified calibration remains evidence-based.
 
 The remainder of this document preserves the implementation history of the original Timing Margin work. Older examples that mention 800-us margin or a 500-us fixed cutoff are historical design context, not current product defaults. The Late Down work and final closure are documented in `implementation-real-game-input-reliability-late-down-tolerance.md`.
 

--- a/docs/implementation-user-owned-symmetric-timing-margin.md
+++ b/docs/implementation-user-owned-symmetric-timing-margin.md
@@ -4,6 +4,12 @@
 
 Status: **implementation complete; superseded as an active handoff**.
 
+> **UI follow-up (PR #234):** The earlier **Use recommended** Timing Margin UI
+> action described below is superseded. Recommendation is informational only;
+> users adjust Timing Margin through the existing bounded stepper. This
+> presentation change does not alter the separate native
+> `PlaybackDecision::UseRecommended` risk-flow decision.
+
 The merge defaults accepted by the user are:
 
 - Timing Margin: **500 us**.

--- a/docs/timing-principles.md
+++ b/docs/timing-principles.md
@@ -24,7 +24,7 @@ microsecond conversions.
 | `min_hold` | Fixed materialized floor equal to the selected frame-based hold plus the exact user Timing Margin. |
 | `down_late_cutoff` | Independent user-owned production cutoff for authorized Down admission; default `2,000 µs` after the physical target, range `0..=5,000 µs` in `100 µs` steps, frozen per prepared session. |
 | `min_release_gap` | One frame period plus the same exact user Timing Margin between a same-key Up and the next same-key Down. |
-| `timing_margin_recommendation` | Advisory value derived from calibration evidence; it changes a setting only after an explicit user action. |
+| `timing_margin_recommendation` | Informational value derived from calibration evidence; it never writes settings, and users adjust Timing Margin with its bounded stepper. |
 | `authored_hold_valid` | Pre-start proof that authored Down→Up spacing meets the materialized hold. |
 
 The worker never applies a learned dispatch-cost lead to `scheduled` or
@@ -158,10 +158,11 @@ The user-facing recommendation is
 `ceil_to_100us(selected_down_late_tolerance + reserve)`. With the default
 `2,000 µs` cutoff and fallback `300 µs` reserve, the unqualified advisory value
 is `2,300 µs`. A valid calibration may therefore recommend another value. It
-never changes a saved user setting or an active/prepared session; the user must
-explicitly choose **Use recommended**. An invalid, missing, or out-of-envelope
-cache uses the unqualified transport reserve and recomputes the advisory value
-from the selected cutoff. Qualification status and source remain visible.
+never changes a saved user setting or an active/prepared session. Settings and
+the quick profile present it as informational text; users adjust Timing Margin
+with the bounded stepper. An invalid, missing, or out-of-envelope cache uses
+the unqualified transport reserve and recomputes the advisory value from the
+selected cutoff. Qualification status and source remain visible.
 Calibration does not change Note-On timestamps, physical Down targets, the
 selected Late Down cutoff,
 or runtime scheduling. Protocol 10, native schema 15, artifact

--- a/docs/timing-principles.md
+++ b/docs/timing-principles.md
@@ -24,7 +24,7 @@ microsecond conversions.
 | `min_hold` | Fixed materialized floor equal to the selected frame-based hold plus the exact user Timing Margin. |
 | `down_late_cutoff` | Independent user-owned production cutoff for authorized Down admission; default `2,000 µs` after the physical target, range `0..=5,000 µs` in `100 µs` steps, frozen per prepared session. |
 | `min_release_gap` | One frame period plus the same exact user Timing Margin between a same-key Up and the next same-key Down. |
-| `timing_margin_recommendation` | Informational value derived from calibration evidence; it never writes settings, and users adjust Timing Margin with its bounded stepper. |
+| `timing_margin_recommendation` | Informational value: qualified calibration evidence may suggest a value; otherwise it falls back to the `500 µs` default. It never writes settings. |
 | `authored_hold_valid` | Pre-start proof that authored Down→Up spacing meets the materialized hold. |
 
 The worker never applies a learned dispatch-cost lead to `scheduled` or
@@ -154,15 +154,13 @@ candidate <= 2,000 µs -> VALID, reserve = max(300 µs, candidate)
 candidate > 2,000 µs  -> OUT_OF_ENVELOPE, use fallback reserve = 300 µs
 ```
 
-The user-facing recommendation is
-`ceil_to_100us(selected_down_late_tolerance + reserve)`. With the default
-`2,000 µs` cutoff and fallback `300 µs` reserve, the unqualified advisory value
-is `2,300 µs`. A valid calibration may therefore recommend another value. It
-never changes a saved user setting or an active/prepared session. Settings and
-the quick profile present it as informational text; users adjust Timing Margin
-with the bounded stepper. An invalid, missing, or out-of-envelope cache uses
-the unqualified transport reserve and recomputes the advisory value from the
-selected cutoff. Qualification status and source remain visible.
+With qualified calibration, the user-facing recommendation is
+`ceil_to_100us(selected_down_late_tolerance + measured_reserve)`. When
+calibration is missing, invalid, or out of envelope, the recommendation is the
+`500 µs` default Timing Margin. It never changes a saved user setting or an
+active/prepared session. Settings and the quick profile present it as
+informational text; users adjust Timing Margin with the bounded stepper.
+Qualification status and source remain visible.
 Calibration does not change Note-On timestamps, physical Down targets, the
 selected Late Down cutoff,
 or runtime scheduling. Protocol 10, native schema 15, artifact


### PR DESCRIPTION
## UI/UX cleanup handoff

This draft PR is a focused work order for the playback timing UI introduced around PR #233.

### Problem

The current quick playback-profile popover is too wide and verbose:

- `width: max-content` lets long copy determine the popover width;
- the full-width **Use recommended (...)** button increases visual weight and width;
- recommendation/source/help copy belongs in the full Settings surface, not the quick-access popover.

The Playback section in Settings also needs a clearer primary/secondary hierarchy around Timing Margin.

### Required outcome

Quick profile:

- compact bounded width (~260-320 px);
- remove **Use recommended**;
- show recommendation as muted inline text beside **Timing Margin**;
- remove long recommendation/source copy;
- retain +/- controls;
- retain Target hold / Release gap / Late Down tolerance;
- retain **Test playback (no input)**.

Settings:

- no **Use recommended** button;
- one compact Timing Margin row;
- recommendation/source rendered as subordinate informational text;
- compact aligned timing summary;
- no wider Settings dialog;
- no timing/runtime semantics changes.

### Scope

UI-only. Do not change timing defaults, recommendation math, persistence, Rust runtime, scheduler, SendInput, admission, cutoff, packet/chord semantics, or session freezing.

The complete Codex work order and acceptance checklist is in:

`docs/implementation-compact-playback-timing-ui.md`

### Workflow

Codex should implement directly on this branch, run unit/build/Playwright plus canonical CI validation, push exact-head changes, and leave this PR draft for independent acceptance.

Do **not** merge as part of implementation.
